### PR TITLE
fix(vectors-core): correct GGUF inference kernels

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1065,6 +1065,96 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
   }
 
+  /** SIMD 4-row-unrolled GEMV over little-endian mapped GGUF F32 weights. */
+  @Override
+  public void ggufF32MatVecDot(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    int rowGroup = rows & ~3;
+    int limit = FLOAT_SPECIES.loopBound(cols);
+    long rowBytes = (long) cols * Float.BYTES;
+
+    for (int row = 0; row < rowGroup; row += 4) {
+      long base0 = row * rowBytes;
+      long base1 = base0 + rowBytes;
+      long base2 = base1 + rowBytes;
+      long base3 = base2 + rowBytes;
+      FloatVector acc0 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc1 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc2 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc3 = FloatVector.zero(FLOAT_SPECIES);
+
+      for (int col = 0; col < limit; col += FLOAT_SPECIES.length()) {
+        FloatVector queryVector = FloatVector.fromArray(FLOAT_SPECIES, query, col);
+        long byteOffset = (long) col * Float.BYTES;
+        acc0 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base0 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc0);
+        acc1 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base1 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc1);
+        acc2 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base2 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc2);
+        acc3 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base3 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc3);
+      }
+
+      float sum0 = acc0.reduceLanes(VectorOperators.ADD);
+      float sum1 = acc1.reduceLanes(VectorOperators.ADD);
+      float sum2 = acc2.reduceLanes(VectorOperators.ADD);
+      float sum3 = acc3.reduceLanes(VectorOperators.ADD);
+      for (int col = limit; col < cols; col++) {
+        float queryValue = query[col];
+        long byteOffset = (long) col * Float.BYTES;
+        sum0 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base0 + byteOffset), sum0);
+        sum1 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base1 + byteOffset), sum1);
+        sum2 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base2 + byteOffset), sum2);
+        sum3 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base3 + byteOffset), sum3);
+      }
+
+      out[row] = sum0;
+      out[row + 1] = sum1;
+      out[row + 2] = sum2;
+      out[row + 3] = sum3;
+    }
+
+    for (int row = rowGroup; row < rows; row++) {
+      long base = row * rowBytes;
+      FloatVector accumulator = FloatVector.zero(FLOAT_SPECIES);
+      for (int col = 0; col < limit; col += FLOAT_SPECIES.length()) {
+        accumulator =
+            fma(
+                FloatVector.fromArray(FLOAT_SPECIES, query, col),
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES,
+                    weight,
+                    base + (long) col * Float.BYTES,
+                    ByteOrder.LITTLE_ENDIAN),
+                accumulator);
+      }
+      float sum = accumulator.reduceLanes(VectorOperators.ADD);
+      for (int col = limit; col < cols; col++) {
+        sum =
+            MathUtil.fma(
+                query[col], weight.get(GGUF_LE_FLOAT, base + (long) col * Float.BYTES), sum);
+      }
+      out[row] = sum;
+    }
+  }
+
   /**
    * SIMD 4-row-unrolled fused GEMV for squared L2 distance.
    *

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -190,6 +190,17 @@ public final class VectorUtil {
   }
 
   /**
+   * Fused GEMV over a little-endian GGUF F32 matrix stored in mapped or off-heap memory.
+   *
+   * <p>This avoids copying the full matrix to a temporary heap array before each projection.
+   */
+  public static void ggufF32BatchDotProduct(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    checkGgufF32BatchArguments(query, weight, rows, cols, out);
+    IMPL.ggufF32MatVecDot(query, weight, rows, cols, out);
+  }
+
+  /**
    * Dot product of a full-precision query with one GGUF Q4_0 quantized row.
    *
    * <p>The operation fuses Q4_0 dequantization and dot-product accumulation without allocating a
@@ -457,6 +468,32 @@ public final class VectorUtil {
               + rowMajorMatrix.length
               + " < "
               + required);
+    }
+    if (out.length < rows) {
+      throw new IllegalArgumentException(
+          "out.length must be >= rows: " + out.length + " < " + rows);
+    }
+  }
+
+  private static void checkGgufF32BatchArguments(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    Objects.requireNonNull(query, "query");
+    Objects.requireNonNull(weight, "weight");
+    Objects.requireNonNull(out, "out");
+    if (rows < 0) {
+      throw new IllegalArgumentException("rows must be >= 0: " + rows);
+    }
+    if (cols < 0) {
+      throw new IllegalArgumentException("cols must be >= 0: " + cols);
+    }
+    checkDimensions(query.length, cols);
+    long requiredBytes = (long) rows * cols * Float.BYTES;
+    if (requiredBytes > weight.byteSize()) {
+      throw new IllegalArgumentException(
+          "weight byteSize must be >= rows * cols * 4: "
+              + weight.byteSize()
+              + " < "
+              + requiredBytes);
     }
     if (out.length < rows) {
       throw new IllegalArgumentException(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -30,6 +30,8 @@ public interface VectorUtilSupport {
 
   ValueLayout.OfShort GGUF_LE_SHORT =
       ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+  ValueLayout.OfFloat GGUF_LE_FLOAT =
+      ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
   int GGUF_Q_BLOCK_SIZE = 32;
   int GGUF_Q4_0_BLOCK_BYTES = 18;
   int GGUF_Q8_0_BLOCK_BYTES = 34;
@@ -161,6 +163,21 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Batched row-major GEMV over little-endian GGUF F32 rows without copying mapped weights. */
+  default void ggufF32MatVecDot(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    long rowBytes = (long) cols * Float.BYTES;
+    for (int row = 0; row < rows; row++) {
+      long rowOffset = row * rowBytes;
+      float sum = 0.0f;
+      for (int col = 0; col < cols; col++) {
+        float value = weight.get(GGUF_LE_FLOAT, rowOffset + (long) col * Float.BYTES);
+        sum = MathUtil.fma(query[col], value, sum);
+      }
+      out[row] = sum;
+    }
+  }
+
   /**
    * Dot product of a full-precision query with one GGUF Q4_0 quantized row.
    *
@@ -182,8 +199,8 @@ public interface VectorUtilSupport {
         int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + i) & 0xFF;
         int lo = (packed & 0x0F) - 8;
         int hi = ((packed >>> 4) & 0x0F) - 8;
-        sum = MathUtil.fma(query[queryOffset + i * 2], lo * scale, sum);
-        sum = MathUtil.fma(query[queryOffset + i * 2 + 1], hi * scale, sum);
+        sum = MathUtil.fma(query[queryOffset + i], lo * scale, sum);
+        sum = MathUtil.fma(query[queryOffset + i + 16], hi * scale, sum);
       }
     }
     return sum;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -32,6 +32,39 @@ import org.junit.jupiter.api.Test;
 class GgufQuantizedDotTest {
 
   @Test
+  void f32BatchDotProduct_readsLittleEndianMappedRows() {
+    float[] query = {1.5f, -2.0f, 0.25f, 4.0f, -0.5f};
+    float[] matrix = {
+      0.5f, 1.0f, -3.0f, 0.25f, 2.0f,
+      -1.0f, 0.5f, 2.0f, -0.75f, 4.0f
+    };
+    float[] out = new float[2];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, f32Bytes(matrix));
+
+      VectorUtil.ggufF32BatchDotProduct(query, segment, 2, 5, out);
+
+      assertThat(out[0]).isCloseTo(-2.0f, within(1e-5f));
+      assertThat(out[1]).isCloseTo(-7.0f, within(1e-5f));
+    }
+  }
+
+  @Test
+  void f32BatchDotProduct_rejectsTruncatedMatrix() {
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = arena.allocate(7 * Float.BYTES);
+
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufF32BatchDotProduct(
+                      new float[] {1, 2, 3, 4}, segment, 2, 4, new float[2]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("byteSize");
+    }
+  }
+
+  @Test
   void q4_0DotProduct_matchesDecodedReference() {
     float[] query = new float[32];
     byte[] block = q4Block(0.5f, query, null);
@@ -39,8 +72,8 @@ class GgufQuantizedDotTest {
     float expected = 0f;
     for (int i = 0; i < query.length; i++) {
       query[i] = (i % 7) - 3.0f;
-      int packed = block[2 + (i >>> 1)] & 0xFF;
-      int nibble = (i & 1) == 0 ? packed & 0x0F : (packed >>> 4) & 0x0F;
+      int packed = block[2 + (i & 0x0F)] & 0xFF;
+      int nibble = i < 16 ? packed & 0x0F : (packed >>> 4) & 0x0F;
       expected = Math.fma(query[i], (nibble - 8) * 0.5f, expected);
     }
 
@@ -50,6 +83,20 @@ class GgufQuantizedDotTest {
       float actual = VectorUtil.ggufQ4_0DotProduct(query, segment, 0, query.length);
 
       assertThat(actual).isCloseTo(expected, within(1e-5f));
+    }
+  }
+
+  @Test
+  void q4_0DotProduct_usesGgmlSplitNibbleLayout() {
+    float[] query = new float[32];
+    query[16] = 1.0f;
+    byte[] block = q4Block(0.5f, query, (lo, hi) -> lo == 0 ? 0x98 : 0x88);
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      assertThat(VectorUtil.ggufQ4_0DotProduct(query, segment, 0, query.length))
+          .isCloseTo(0.5f, within(1e-5f));
     }
   }
 
@@ -178,7 +225,7 @@ class GgufQuantizedDotTest {
     ByteBuffer.wrap(block).order(ByteOrder.LITTLE_ENDIAN).putShort(0, Float.floatToFloat16(scale));
     for (int i = 0; i < 16; i++) {
       if (factory != null) {
-        block[2 + i] = (byte) factory.packed(i * 2, i * 2 + 1);
+        block[2 + i] = (byte) factory.packed(i, i + 16);
       } else {
         int lo = i & 0x0F;
         int hi = 15 - i;
@@ -195,6 +242,15 @@ class GgufQuantizedDotTest {
       block[2 + i] = (byte) (i - 16);
     }
     return block;
+  }
+
+  private static byte[] f32Bytes(float[] values) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(values.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    for (float value : values) {
+      buffer.putFloat(value);
+    }
+    return buffer.array();
   }
 
   private static byte[] q6KBlock(

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
 class ScalarVectorUtilSupportTest {
@@ -111,6 +113,20 @@ class ScalarVectorUtilSupportTest {
     float[] adc = new float[5];
     scalar.batchAssembleAndSum(table, packed, 0, adc, 5, 2);
     assertThat(adc).containsExactly(13f, 11f, 12f, 12f, 12f);
+  }
+
+  @Test
+  void mappedF32GgufKernelReadsLittleEndianRows() {
+    float[] query = {1f, 2f, 3f};
+    ByteBuffer matrix = ByteBuffer.allocate(6 * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    for (float value : new float[] {1f, 0f, -1f, 0.5f, 1f, 2f}) {
+      matrix.putFloat(value);
+    }
+    float[] out = new float[2];
+
+    scalar.ggufF32MatVecDot(query, MemorySegment.ofArray(matrix.array()), 2, 3, out);
+
+    assertThat(out).containsExactly(-2f, 8.5f);
   }
 
   private static float referenceDot(float[] a, int ao, float[] b, int bo, int length) {


### PR DESCRIPTION
## Summary
- correct GGML Q4_0 split-nibble decoding
- add zero-copy little-endian F32 GGUF GEMV kernels for scalar and Panama providers
- cover mapped rows, truncation validation, and scalar fallback

## Verification
- `./gradlew :vectors-core:test :vectors-core:spotlessCheck`