### PR TITLE
SOTA object-storage index: Extended RaBitQ shared-code tier + GGUF kernel fixes

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -169,6 +169,7 @@
             <Class name="com.integrallis.vectors.quantization.ProductQuantizer"/>
             <Class name="com.integrallis.vectors.quantization.BinaryQuantizer"/>
             <Class name="com.integrallis.vectors.quantization.RaBitQuantizer"/>
+            <Class name="com.integrallis.vectors.quantization.ExtendedRaBitQuantizer"/>
             <Class name="com.integrallis.vectors.quantization.NVQuantizer"/>
             <Class name="com.integrallis.vectors.quantization.OptimizedProductQuantizer"/>
             <Class name="com.integrallis.vectors.quantization.TurboQuantizer"/>
@@ -211,6 +212,7 @@
             <Class name="com.integrallis.vectors.quantization.PQVectors"/>
             <Class name="com.integrallis.vectors.quantization.BinaryQuantizedVectors"/>
             <Class name="com.integrallis.vectors.quantization.RaBitQuantizedVectors"/>
+            <Class name="com.integrallis.vectors.quantization.ExtendedRaBitQuantizedVectors"/>
             <Class name="com.integrallis.vectors.quantization.NVQuantizedVectors"/>
             <Class name="com.integrallis.vectors.quantization.TurboQuantizedVectors"/>
         </Or>

--- a/vectors-bench/src/main/java/com/integrallis/vectors/bench/QuantizationRecallBenchmark.java
+++ b/vectors-bench/src/main/java/com/integrallis/vectors/bench/QuantizationRecallBenchmark.java
@@ -260,6 +260,8 @@ public final class QuantizationRecallBenchmark {
           case TURBOQUANT ->
               8; // default per-coordinate bits (VectorCollectionBuilder.DEFAULT_TURBO_BITS)
           case FP16 -> 16; // half-precision: two bytes per coordinate
+          case EXTENDED_RABITQ ->
+              5; // 1 sign bit + 4-bit magnitude (default), corrections amortized
         };
     return 32.0 / bitsPerDim;
   }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1065,6 +1065,96 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
   }
 
+  /** SIMD 4-row-unrolled GEMV over little-endian mapped GGUF F32 weights. */
+  @Override
+  public void ggufF32MatVecDot(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    int rowGroup = rows & ~3;
+    int limit = FLOAT_SPECIES.loopBound(cols);
+    long rowBytes = (long) cols * Float.BYTES;
+
+    for (int row = 0; row < rowGroup; row += 4) {
+      long base0 = row * rowBytes;
+      long base1 = base0 + rowBytes;
+      long base2 = base1 + rowBytes;
+      long base3 = base2 + rowBytes;
+      FloatVector acc0 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc1 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc2 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc3 = FloatVector.zero(FLOAT_SPECIES);
+
+      for (int col = 0; col < limit; col += FLOAT_SPECIES.length()) {
+        FloatVector queryVector = FloatVector.fromArray(FLOAT_SPECIES, query, col);
+        long byteOffset = (long) col * Float.BYTES;
+        acc0 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base0 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc0);
+        acc1 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base1 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc1);
+        acc2 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base2 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc2);
+        acc3 =
+            fma(
+                queryVector,
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES, weight, base3 + byteOffset, ByteOrder.LITTLE_ENDIAN),
+                acc3);
+      }
+
+      float sum0 = acc0.reduceLanes(VectorOperators.ADD);
+      float sum1 = acc1.reduceLanes(VectorOperators.ADD);
+      float sum2 = acc2.reduceLanes(VectorOperators.ADD);
+      float sum3 = acc3.reduceLanes(VectorOperators.ADD);
+      for (int col = limit; col < cols; col++) {
+        float queryValue = query[col];
+        long byteOffset = (long) col * Float.BYTES;
+        sum0 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base0 + byteOffset), sum0);
+        sum1 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base1 + byteOffset), sum1);
+        sum2 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base2 + byteOffset), sum2);
+        sum3 = MathUtil.fma(queryValue, weight.get(GGUF_LE_FLOAT, base3 + byteOffset), sum3);
+      }
+
+      out[row] = sum0;
+      out[row + 1] = sum1;
+      out[row + 2] = sum2;
+      out[row + 3] = sum3;
+    }
+
+    for (int row = rowGroup; row < rows; row++) {
+      long base = row * rowBytes;
+      FloatVector accumulator = FloatVector.zero(FLOAT_SPECIES);
+      for (int col = 0; col < limit; col += FLOAT_SPECIES.length()) {
+        accumulator =
+            fma(
+                FloatVector.fromArray(FLOAT_SPECIES, query, col),
+                FloatVector.fromMemorySegment(
+                    FLOAT_SPECIES,
+                    weight,
+                    base + (long) col * Float.BYTES,
+                    ByteOrder.LITTLE_ENDIAN),
+                accumulator);
+      }
+      float sum = accumulator.reduceLanes(VectorOperators.ADD);
+      for (int col = limit; col < cols; col++) {
+        sum =
+            MathUtil.fma(
+                query[col], weight.get(GGUF_LE_FLOAT, base + (long) col * Float.BYTES), sum);
+      }
+      out[row] = sum;
+    }
+  }
+
   /**
    * SIMD 4-row-unrolled fused GEMV for squared L2 distance.
    *

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -190,6 +190,17 @@ public final class VectorUtil {
   }
 
   /**
+   * Fused GEMV over a little-endian GGUF F32 matrix stored in mapped or off-heap memory.
+   *
+   * <p>This avoids copying the full matrix to a temporary heap array before each projection.
+   */
+  public static void ggufF32BatchDotProduct(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    checkGgufF32BatchArguments(query, weight, rows, cols, out);
+    IMPL.ggufF32MatVecDot(query, weight, rows, cols, out);
+  }
+
+  /**
    * Dot product of a full-precision query with one GGUF Q4_0 quantized row.
    *
    * <p>The operation fuses Q4_0 dequantization and dot-product accumulation without allocating a
@@ -457,6 +468,32 @@ public final class VectorUtil {
               + rowMajorMatrix.length
               + " < "
               + required);
+    }
+    if (out.length < rows) {
+      throw new IllegalArgumentException(
+          "out.length must be >= rows: " + out.length + " < " + rows);
+    }
+  }
+
+  private static void checkGgufF32BatchArguments(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    Objects.requireNonNull(query, "query");
+    Objects.requireNonNull(weight, "weight");
+    Objects.requireNonNull(out, "out");
+    if (rows < 0) {
+      throw new IllegalArgumentException("rows must be >= 0: " + rows);
+    }
+    if (cols < 0) {
+      throw new IllegalArgumentException("cols must be >= 0: " + cols);
+    }
+    checkDimensions(query.length, cols);
+    long requiredBytes = (long) rows * cols * Float.BYTES;
+    if (requiredBytes > weight.byteSize()) {
+      throw new IllegalArgumentException(
+          "weight byteSize must be >= rows * cols * 4: "
+              + weight.byteSize()
+              + " < "
+              + requiredBytes);
     }
     if (out.length < rows) {
       throw new IllegalArgumentException(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -599,20 +599,12 @@ public final class VectorUtil {
     }
   }
 
-  private static void checkGgufQuantizedDimensions(float[] query, int dimensions) {
-    checkGgufQuantizedDimensions(query, dimensions, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
-  }
-
   private static void checkGgufQuantizedDimensions(float[] query, int dimensions, int blockSize) {
     checkDimensions(query.length, dimensions);
     if (dimensions % blockSize != 0) {
       throw new IllegalArgumentException(
           "GGUF quantized dimensions must be a multiple of " + blockSize + ": " + dimensions);
     }
-  }
-
-  private static long ggufQuantizedRowBytes(int dimensions, int blockBytes) {
-    return ggufQuantizedRowBytes(dimensions, VectorUtilSupport.GGUF_Q_BLOCK_SIZE, blockBytes);
   }
 
   private static long ggufQuantizedRowBytes(int dimensions, int blockSize, int blockBytes) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -30,6 +30,8 @@ public interface VectorUtilSupport {
 
   ValueLayout.OfShort GGUF_LE_SHORT =
       ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+  ValueLayout.OfFloat GGUF_LE_FLOAT =
+      ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
   int GGUF_Q_BLOCK_SIZE = 32;
   int GGUF_Q4_0_BLOCK_BYTES = 18;
   int GGUF_Q8_0_BLOCK_BYTES = 34;
@@ -158,6 +160,21 @@ public interface VectorUtilSupport {
   default void matVecDot(float[] query, float[] rowMajorMatrix, int rows, int cols, float[] out) {
     for (int row = 0; row < rows; row++) {
       out[row] = dotProduct(query, 0, rowMajorMatrix, row * cols, cols);
+    }
+  }
+
+  /** Batched row-major GEMV over little-endian GGUF F32 rows without copying mapped weights. */
+  default void ggufF32MatVecDot(
+      float[] query, MemorySegment weight, int rows, int cols, float[] out) {
+    long rowBytes = (long) cols * Float.BYTES;
+    for (int row = 0; row < rows; row++) {
+      long rowOffset = row * rowBytes;
+      float sum = 0.0f;
+      for (int col = 0; col < cols; col++) {
+        float value = weight.get(GGUF_LE_FLOAT, rowOffset + (long) col * Float.BYTES);
+        sum = MathUtil.fma(query[col], value, sum);
+      }
+      out[row] = sum;
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -199,8 +199,8 @@ public interface VectorUtilSupport {
         int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + i) & 0xFF;
         int lo = (packed & 0x0F) - 8;
         int hi = ((packed >>> 4) & 0x0F) - 8;
-        sum = MathUtil.fma(query[queryOffset + i * 2], lo * scale, sum);
-        sum = MathUtil.fma(query[queryOffset + i * 2 + 1], hi * scale, sum);
+        sum = MathUtil.fma(query[queryOffset + i], lo * scale, sum);
+        sum = MathUtil.fma(query[queryOffset + i + 16], hi * scale, sum);
       }
     }
     return sum;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -32,6 +32,39 @@ import org.junit.jupiter.api.Test;
 class GgufQuantizedDotTest {
 
   @Test
+  void f32BatchDotProduct_readsLittleEndianMappedRows() {
+    float[] query = {1.5f, -2.0f, 0.25f, 4.0f, -0.5f};
+    float[] matrix = {
+      0.5f, 1.0f, -3.0f, 0.25f, 2.0f,
+      -1.0f, 0.5f, 2.0f, -0.75f, 4.0f
+    };
+    float[] out = new float[2];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, f32Bytes(matrix));
+
+      VectorUtil.ggufF32BatchDotProduct(query, segment, 2, 5, out);
+
+      assertThat(out[0]).isCloseTo(-2.0f, within(1e-5f));
+      assertThat(out[1]).isCloseTo(-7.0f, within(1e-5f));
+    }
+  }
+
+  @Test
+  void f32BatchDotProduct_rejectsTruncatedMatrix() {
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = arena.allocate(7 * Float.BYTES);
+
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufF32BatchDotProduct(
+                      new float[] {1, 2, 3, 4}, segment, 2, 4, new float[2]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("byteSize");
+    }
+  }
+
+  @Test
   void q4_0DotProduct_matchesDecodedReference() {
     float[] query = new float[32];
     byte[] block = q4Block(0.5f, query, null);
@@ -195,6 +228,15 @@ class GgufQuantizedDotTest {
       block[2 + i] = (byte) (i - 16);
     }
     return block;
+  }
+
+  private static byte[] f32Bytes(float[] values) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(values.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    for (float value : values) {
+      buffer.putFloat(value);
+    }
+    return buffer.array();
   }
 
   private static byte[] q6KBlock(

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -72,8 +72,8 @@ class GgufQuantizedDotTest {
     float expected = 0f;
     for (int i = 0; i < query.length; i++) {
       query[i] = (i % 7) - 3.0f;
-      int packed = block[2 + (i >>> 1)] & 0xFF;
-      int nibble = (i & 1) == 0 ? packed & 0x0F : (packed >>> 4) & 0x0F;
+      int packed = block[2 + (i & 0x0F)] & 0xFF;
+      int nibble = i < 16 ? packed & 0x0F : (packed >>> 4) & 0x0F;
       expected = Math.fma(query[i], (nibble - 8) * 0.5f, expected);
     }
 
@@ -83,6 +83,20 @@ class GgufQuantizedDotTest {
       float actual = VectorUtil.ggufQ4_0DotProduct(query, segment, 0, query.length);
 
       assertThat(actual).isCloseTo(expected, within(1e-5f));
+    }
+  }
+
+  @Test
+  void q4_0DotProduct_usesGgmlSplitNibbleLayout() {
+    float[] query = new float[32];
+    query[16] = 1.0f;
+    byte[] block = q4Block(0.5f, query, (lo, hi) -> lo == 0 ? 0x98 : 0x88);
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      assertThat(VectorUtil.ggufQ4_0DotProduct(query, segment, 0, query.length))
+          .isCloseTo(0.5f, within(1e-5f));
     }
   }
 
@@ -211,7 +225,7 @@ class GgufQuantizedDotTest {
     ByteBuffer.wrap(block).order(ByteOrder.LITTLE_ENDIAN).putShort(0, Float.floatToFloat16(scale));
     for (int i = 0; i < 16; i++) {
       if (factory != null) {
-        block[2 + i] = (byte) factory.packed(i * 2, i * 2 + 1);
+        block[2 + i] = (byte) factory.packed(i, i + 16);
       } else {
         int lo = i & 0x0F;
         int hi = 15 - i;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.junit.jupiter.api.Test;
 
 class ScalarVectorUtilSupportTest {
@@ -111,6 +113,20 @@ class ScalarVectorUtilSupportTest {
     float[] adc = new float[5];
     scalar.batchAssembleAndSum(table, packed, 0, adc, 5, 2);
     assertThat(adc).containsExactly(13f, 11f, 12f, 12f, 12f);
+  }
+
+  @Test
+  void mappedF32GgufKernelReadsLittleEndianRows() {
+    float[] query = {1f, 2f, 3f};
+    ByteBuffer matrix = ByteBuffer.allocate(6 * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    for (float value : new float[] {1f, 0f, -1f, 0.5f, 1f, 2f}) {
+      matrix.putFloat(value);
+    }
+    float[] out = new float[2];
+
+    scalar.ggufF32MatVecDot(query, MemorySegment.ofArray(matrix.array()), 2, 3, out);
+
+    assertThat(out).containsExactly(-2f, 8.5f);
   }
 
   private static float referenceDot(float[] a, int ao, float[] b, int bo, int length) {

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/QuantizerKind.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/QuantizerKind.java
@@ -48,5 +48,16 @@ public enum QuantizerKind {
    * <p>Appended last so the existing ordinals stay stable on disk ({@code quantized.bin} stores the
    * ordinal).
    */
-  FP16
+  FP16,
+
+  /**
+   * Extended RaBitQ (SIGMOD 2025): sign bits + multi-bit magnitude codes (2-8 bits/dim) with
+   * per-vector correction factors. Correction-based scoring reconstructs nothing per score, so it
+   * is cheap enough to <em>navigate</em> an HNSW graph on the codes and rerank survivors in full
+   * precision — the shared-code tier behind the object-storage index (matches full-precision recall
+   * ≈0.99 on the codes at ~1/8th the footprint of raw float32).
+   *
+   * <p>Appended after {@link #FP16} so existing on-disk ordinals stay stable.
+   */
+  EXTENDED_RABITQ
 }

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/QuantizerParams.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/QuantizerParams.java
@@ -130,4 +130,20 @@ public sealed interface QuantizerParams {
       }
     }
   }
+
+  /**
+   * Parameters for Extended RaBitQ ({@link QuantizerKind#EXTENDED_RABITQ}).
+   *
+   * @param bits magnitude bit-width. Must be in {@code [2, 8]} (use {@link QuantizerKind#RABITQ}
+   *     for 1-bit). 4 bits is the object-storage-index default — it matches full-precision recall
+   *     while staying compact.
+   * @param seed random seed for the rotation. Default: 42L for reproducibility.
+   */
+  record ExtRaBitParams(int bits, long seed) implements QuantizerParams {
+    public ExtRaBitParams {
+      if (bits < 2 || bits > 8) {
+        throw new IllegalArgumentException("Extended RaBitQ bits must be in [2, 8]: " + bits);
+      }
+    }
+  }
 }

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/VectorCollectionBuilder.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/VectorCollectionBuilder.java
@@ -72,6 +72,12 @@ public final class VectorCollectionBuilder {
   /** Default RaBitQ random seed. */
   public static final long DEFAULT_RABIT_SEED = 42L;
 
+  /** Default Extended RaBitQ magnitude bit-width (matches full-precision recall, compact). */
+  public static final int DEFAULT_EXTRABIT_BITS = 4;
+
+  /** Default Extended RaBitQ rotation seed. */
+  public static final long DEFAULT_EXTRABIT_SEED = 42L;
+
   /** Default TurboQuant per-coordinate bit-width. */
   public static final int DEFAULT_TURBO_BITS = 8;
 
@@ -169,6 +175,8 @@ public final class VectorCollectionBuilder {
   private Integer turboBits;
   private Long turboSeed;
   private Boolean turboUnbiased;
+  private Integer extRaBitBits;
+  private Long extRaBitSeed;
 
   VectorCollectionBuilder() {}
 
@@ -605,6 +613,29 @@ public final class VectorCollectionBuilder {
   }
 
   /**
+   * Sets the Extended RaBitQ magnitude bit-width. Only used when {@link #quantizer(QuantizerKind)}
+   * is {@link QuantizerKind#EXTENDED_RABITQ}. Must be in {@code [2, 8]}. Default: {@value
+   * #DEFAULT_EXTRABIT_BITS}.
+   */
+  public VectorCollectionBuilder extRaBitBits(int bits) {
+    if (bits < 2 || bits > 8) {
+      throw new IllegalArgumentException("Extended RaBitQ bits must be in [2, 8]: " + bits);
+    }
+    this.extRaBitBits = bits;
+    return this;
+  }
+
+  /**
+   * Sets the random seed for Extended RaBitQ's rotation. Only used when {@link
+   * #quantizer(QuantizerKind)} is {@link QuantizerKind#EXTENDED_RABITQ}. Default: {@value
+   * #DEFAULT_EXTRABIT_SEED}.
+   */
+  public VectorCollectionBuilder extRaBitSeed(long seed) {
+    this.extRaBitSeed = seed;
+    return this;
+  }
+
+  /**
    * Sets the staging buffer size at which {@code add}/{@code addAll} auto-commit before returning.
    * Must be positive. Pass {@link Integer#MAX_VALUE} to disable auto-commit (the default), which
    * forces the caller to drive {@link VectorCollection#commit()} explicitly.
@@ -847,6 +878,10 @@ public final class VectorCollectionBuilder {
               turboBits != null ? turboBits : DEFAULT_TURBO_BITS,
               turboSeed != null ? turboSeed : DEFAULT_TURBO_SEED,
               turboUnbiased != null ? turboUnbiased : DEFAULT_TURBO_UNBIASED);
+      case EXTENDED_RABITQ ->
+          new QuantizerParams.ExtRaBitParams(
+              extRaBitBits != null ? extRaBitBits : DEFAULT_EXTRABIT_BITS,
+              extRaBitSeed != null ? extRaBitSeed : DEFAULT_EXTRABIT_SEED);
     };
   }
 }

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/VectorCollectionImpl.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/VectorCollectionImpl.java
@@ -62,6 +62,7 @@ import com.integrallis.vectors.quantization.ArrayVectorDataset;
 import com.integrallis.vectors.quantization.BinaryMode;
 import com.integrallis.vectors.quantization.BinaryQuantizer;
 import com.integrallis.vectors.quantization.CompressedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizer;
 import com.integrallis.vectors.quantization.Fp16Quantizer;
 import com.integrallis.vectors.quantization.NVQuantizer;
 import com.integrallis.vectors.quantization.ProductQuantizer;
@@ -1757,6 +1758,15 @@ final class VectorCollectionImpl implements VectorCollection {
                 : TurboQuantizer.train(dataset, t.bits(), t.seed());
           }
           case FP16 -> Fp16Quantizer.train(dataset);
+          case EXTENDED_RABITQ -> {
+            QuantizerParams.ExtRaBitParams e =
+                params instanceof QuantizerParams.ExtRaBitParams ep
+                    ? ep
+                    : new QuantizerParams.ExtRaBitParams(
+                        VectorCollectionBuilder.DEFAULT_EXTRABIT_BITS,
+                        VectorCollectionBuilder.DEFAULT_EXTRABIT_SEED);
+            yield ExtendedRaBitQuantizer.train(dataset, e.bits(), e.seed());
+          }
         };
     @SuppressWarnings("rawtypes")
     CompressedVectors compressed = ((Quantizer) quantizer).encodeAll(dataset);

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/CoLocatedBlockCodec.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/CoLocatedBlockCodec.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Co-located block format for the object-storage vector index (SOTA design P2).
+ *
+ * <p>Each graph node occupies one <em>fixed-stride block</em> holding its own quantization code,
+ * its adjacency, and — co-located, SymphonyQG-style — <em>every neighbor's code</em>. Expanding a
+ * node in the beam therefore reads exactly one block (one ranged object-store GET) and can score
+ * the whole frontier from that block with zero further reads. Full-precision vectors live in a
+ * separate blob and are fetched (ranged GET) only for the small rerank candidate set.
+ *
+ * <p>Fixed stride gives DiskANN-style O(1) addressing — {@code offset(node) = HEADER_SIZE + node *
+ * stride} — with no trailing offset index. Each block is self-describing via a leading degree word;
+ * unused neighbor slots (degree &lt; maxDegree) are left as zero padding to the stride.
+ *
+ * <pre>
+ * Header (36 bytes, little-endian):
+ *   0   4  magic       0x56434C42 ("VCLB")
+ *   4   4  version     1
+ *   8   4  headerLen   36
+ *   12  4  flags       reserved (0)
+ *   16  4  numNodes
+ *   20  4  maxDegree   per-block neighbor capacity (e.g. layer-0 2*M)
+ *   24  4  codeBytes   quantization code length per vector
+ *   28  4  stride      bytes per node block
+ *   32  4  entryNode   search entry point (-1 if empty)
+ * Body: numNodes blocks, each `stride` bytes:
+ *   int32 degree
+ *   byte[codeBytes]  this node's code
+ *   { int32 neighborId ; byte[codeBytes] neighborCode } * maxDegree   (first `degree` valid, rest zero)
+ * </pre>
+ */
+public final class CoLocatedBlockCodec {
+
+  static final int MAGIC = 0x56434C42; // "VCLB"
+  static final int VERSION = 1;
+  static final int HEADER_SIZE = 36;
+
+  private static final ValueLayout.OfInt LE_INT =
+      ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  private CoLocatedBlockCodec() {}
+
+  /** Bytes each node block occupies for the given degree capacity and code length. */
+  public static int strideFor(int maxDegree, int codeBytes) {
+    int nbrEntry = Integer.BYTES + codeBytes; // neighborId + neighborCode
+    return Integer.BYTES /* degree */ + codeBytes /* node code */ + maxDegree * nbrEntry;
+  }
+
+  /**
+   * Encodes the co-located block file.
+   *
+   * @param numNodes number of nodes (== live count)
+   * @param maxDegree per-block neighbor capacity (typically the layer-0 max, {@code 2*M})
+   * @param codeBytes quantization code length per vector
+   * @param entryNode search entry point, or -1 if empty
+   * @param adjacency per node, its neighbor ids (length may exceed maxDegree — truncated)
+   * @param codes per node, its {@code codeBytes}-long quantization code
+   * @return the encoded blob
+   */
+  public static byte[] encode(
+      int numNodes,
+      int maxDegree,
+      int codeBytes,
+      int entryNode,
+      int[][] adjacency,
+      byte[][] codes) {
+    if (adjacency.length != numNodes || codes.length != numNodes) {
+      throw new IllegalArgumentException("adjacency/codes length must equal numNodes");
+    }
+    int stride = strideFor(maxDegree, codeBytes);
+    long total = (long) HEADER_SIZE + (long) numNodes * stride;
+    if (total > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("blob exceeds max array length: " + total);
+    }
+    ByteBuffer buf = ByteBuffer.allocate((int) total).order(ByteOrder.LITTLE_ENDIAN);
+    buf.putInt(MAGIC).putInt(VERSION).putInt(HEADER_SIZE).putInt(0);
+    buf.putInt(numNodes).putInt(maxDegree).putInt(codeBytes).putInt(stride).putInt(entryNode);
+
+    int nbrEntry = Integer.BYTES + codeBytes;
+    for (int node = 0; node < numNodes; node++) {
+      byte[] nodeCode = codes[node];
+      if (nodeCode.length != codeBytes) {
+        throw new IllegalArgumentException(
+            "code[" + node + "] length " + nodeCode.length + " != codeBytes " + codeBytes);
+      }
+      int base = HEADER_SIZE + node * stride;
+      int deg = Math.min(adjacency[node].length, maxDegree);
+      buf.position(base);
+      buf.putInt(deg);
+      buf.put(nodeCode);
+      int slot = base + Integer.BYTES + codeBytes;
+      for (int i = 0; i < deg; i++) {
+        int nbr = adjacency[node][i];
+        buf.position(slot);
+        buf.putInt(nbr);
+        buf.put(codes[nbr]);
+        slot += nbrEntry;
+      }
+      // remaining neighbor slots stay zero (ByteBuffer.allocate zero-fills)
+    }
+    return buf.array();
+  }
+
+  /** Opens a zero-copy paged reader over the encoded blob (mmap or ranged-GET backed). */
+  public static Reader open(MemorySegment seg) {
+    int magic = seg.get(LE_INT, 0);
+    if (magic != MAGIC) {
+      throw new IllegalArgumentException(String.format("bad magic 0x%08X", magic));
+    }
+    int version = seg.get(LE_INT, 4);
+    if (version != VERSION) {
+      throw new IllegalArgumentException("unsupported version " + version);
+    }
+    int headerLen = seg.get(LE_INT, 8);
+    if (headerLen != HEADER_SIZE) {
+      throw new IllegalArgumentException("bad header length " + headerLen);
+    }
+    int numNodes = seg.get(LE_INT, 16);
+    int maxDegree = seg.get(LE_INT, 20);
+    int codeBytes = seg.get(LE_INT, 24);
+    int stride = seg.get(LE_INT, 28);
+    int entryNode = seg.get(LE_INT, 32);
+    if (stride != strideFor(maxDegree, codeBytes)) {
+      throw new IllegalArgumentException("stride mismatch");
+    }
+    long expected = (long) HEADER_SIZE + (long) numNodes * stride;
+    if (seg.byteSize() < expected) {
+      throw new IllegalArgumentException("segment too small: " + seg.byteSize() + " < " + expected);
+    }
+    return new Reader(seg, numNodes, maxDegree, codeBytes, stride, entryNode);
+  }
+
+  /**
+   * Zero-copy paged view over the block file. A node's block is {@code [off(node),
+   * off(node)+stride)} — exactly the byte range one ranged GET fetches. All accessors are O(1)
+   * offset arithmetic.
+   */
+  public static final class Reader {
+    private final MemorySegment seg;
+    private final int numNodes;
+    private final int maxDegree;
+    private final int codeBytes;
+    private final int stride;
+    private final int entryNode;
+    private final int nbrEntry;
+
+    private Reader(
+        MemorySegment seg, int numNodes, int maxDegree, int codeBytes, int stride, int entryNode) {
+      this.seg = seg;
+      this.numNodes = numNodes;
+      this.maxDegree = maxDegree;
+      this.codeBytes = codeBytes;
+      this.stride = stride;
+      this.entryNode = entryNode;
+      this.nbrEntry = Integer.BYTES + codeBytes;
+    }
+
+    public int numNodes() {
+      return numNodes;
+    }
+
+    public int maxDegree() {
+      return maxDegree;
+    }
+
+    public int codeBytes() {
+      return codeBytes;
+    }
+
+    public int stride() {
+      return stride;
+    }
+
+    public int entryNode() {
+      return entryNode;
+    }
+
+    /** Absolute byte offset of a node's block (== the ranged-GET start). */
+    public long blockOffset(int node) {
+      return (long) HEADER_SIZE + (long) node * stride;
+    }
+
+    public int degree(int node) {
+      return seg.get(LE_INT, blockOffset(node));
+    }
+
+    /** Copies a node's neighbor ids into {@code out}; returns the degree. */
+    public int neighbors(int node, int[] out) {
+      int deg = degree(node);
+      long slot = blockOffset(node) + Integer.BYTES + codeBytes;
+      for (int i = 0; i < deg; i++) {
+        out[i] = seg.get(LE_INT, slot);
+        slot += nbrEntry;
+      }
+      return deg;
+    }
+
+    /** Zero-copy slice of a node's own quantization code. */
+    public MemorySegment nodeCode(int node) {
+      return seg.asSlice(blockOffset(node) + Integer.BYTES, codeBytes);
+    }
+
+    /** Zero-copy slice of the code of a node's {@code i}-th neighbor (co-located in the block). */
+    public MemorySegment neighborCode(int node, int i) {
+      long o = blockOffset(node) + Integer.BYTES + codeBytes + (long) i * nbrEntry + Integer.BYTES;
+      return seg.asSlice(o, codeBytes);
+    }
+  }
+}

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/QuantizedVectorsCodec.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/QuantizedVectorsCodec.java
@@ -20,6 +20,8 @@ import com.integrallis.vectors.quantization.BinaryMode;
 import com.integrallis.vectors.quantization.BinaryQuantizedVectors;
 import com.integrallis.vectors.quantization.BinaryQuantizer;
 import com.integrallis.vectors.quantization.CompressedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizer;
 import com.integrallis.vectors.quantization.Fp16QuantizedVectors;
 import com.integrallis.vectors.quantization.Fp16Quantizer;
 import com.integrallis.vectors.quantization.GivensRotation;
@@ -44,8 +46,9 @@ import java.nio.ByteOrder;
 import java.util.Objects;
 
 /**
- * Binary codec for the {@code quantized.bin} file. Serializes and deserializes all 8 quantizer
- * kinds (SQ8, SQ4, PQ, BQ, RABITQ, NVQ, TURBOQUANT, FP16) using a tagged-union wire format.
+ * Binary codec for the {@code quantized.bin} file. Serializes and deserializes all 9 quantizer
+ * kinds (SQ8, SQ4, PQ, BQ, RABITQ, NVQ, TURBOQUANT, FP16, EXTENDED_RABITQ) using a tagged-union
+ * wire format.
  *
  * <p>Layout (little-endian throughout):
  *
@@ -74,6 +77,9 @@ public final class QuantizedVectorsCodec {
 
   private static final int ROTATION_TAG_GIVENS = 1;
   private static final int ROTATION_TAG_QUATERNION = 2;
+
+  /** Per-vector correction float count for Extended RaBitQ (sqrX, x0, ppc, ip, error, xipNorm). */
+  private static final int EXT_RABITQ_CORRECTIONS = 6;
 
   private QuantizedVectorsCodec() {}
 
@@ -106,6 +112,9 @@ public final class QuantizedVectorsCodec {
       case TURBOQUANT ->
           encodeTurboQuant((TurboQuantizedVectors) compressed, (TurboQuantizer) quantizer);
       case FP16 -> encodeFp16((Fp16QuantizedVectors) compressed, (Fp16Quantizer) quantizer);
+      case EXTENDED_RABITQ ->
+          encodeExtRaBitQ(
+              (ExtendedRaBitQuantizedVectors) compressed, (ExtendedRaBitQuantizer) quantizer);
       case NONE -> throw new AssertionError("unreachable");
     };
   }
@@ -175,6 +184,7 @@ public final class QuantizedVectorsCodec {
       case NVQ -> decodeNVQ(buf, dimension, vectorCount);
       case TURBOQUANT -> decodeTurboQuant(buf, dimension, vectorCount);
       case FP16 -> decodeFp16(buf, dimension, vectorCount);
+      case EXTENDED_RABITQ -> decodeExtRaBitQ(buf, dimension, vectorCount);
       case NONE -> throw new AssertionError("unreachable");
     };
   }
@@ -590,6 +600,108 @@ public final class QuantizedVectorsCodec {
     }
 
     return new RaBitQuantizedVectors(quantizer, codes, corrections, dimension);
+  }
+
+  // ---- Extended RaBitQ ----
+
+  private static byte[] encodeExtRaBitQ(
+      ExtendedRaBitQuantizedVectors compressed, ExtendedRaBitQuantizer quantizer) {
+    int dimension = quantizer.dimension();
+    int vectorCount = compressed.size();
+    int paddedDimension = quantizer.paddedDimension();
+    int bits = quantizer.bits();
+    float[] centroid = quantizer.centroid();
+    Rotation rotation = quantizer.rotation();
+    int numLongs = quantizer.numLongs();
+    int magBytes = quantizer.magByteSize();
+
+    // Quantizer state: paddedDimension(4) + bits(4) + centroid(D*4) + rotation state
+    long rotationSize = rotationEncodedSize(rotation);
+    long quantizerStateSize = 8L + (long) dimension * Float.BYTES + rotationSize;
+
+    // Per-vector: sign longs + magnitude bytes + 6 correction floats
+    long perVector =
+        (long) numLongs * Long.BYTES + magBytes + (long) EXT_RABITQ_CORRECTIONS * Float.BYTES;
+    long vectorDataSize = (long) vectorCount * perVector;
+    long totalSize = COMMON_HEADER_SIZE + quantizerStateSize + vectorDataSize;
+    checkSize(totalSize);
+
+    byte[] out = new byte[(int) totalSize];
+    ByteBuffer buf = ByteBuffer.wrap(out).order(ByteOrder.LITTLE_ENDIAN);
+
+    writeCommonHeader(buf, QuantizerKind.EXTENDED_RABITQ, dimension, vectorCount);
+
+    // Quantizer state
+    buf.putInt(paddedDimension);
+    buf.putInt(bits);
+    for (int d = 0; d < dimension; d++) {
+      buf.putFloat(centroid[d]);
+    }
+    encodeRotation(buf, rotation);
+
+    // Per-vector data
+    for (int i = 0; i < vectorCount; i++) {
+      long[] sign = compressed.getSignCodes(i);
+      for (long c : sign) {
+        buf.putLong(c);
+      }
+      buf.put(compressed.getMagCodes(i));
+      float[] corrections = compressed.getCorrections(i);
+      for (int j = 0; j < EXT_RABITQ_CORRECTIONS; j++) {
+        buf.putFloat(corrections[j]);
+      }
+    }
+
+    return out;
+  }
+
+  private static ExtendedRaBitQuantizedVectors decodeExtRaBitQ(
+      ByteBuffer buf, int dimension, int vectorCount) throws IOException {
+    ensureRemaining(buf, 8, "ExtRaBitQ paddedDimension+bits");
+
+    int paddedDimension = buf.getInt();
+    if (paddedDimension <= 0 || paddedDimension % 64 != 0) {
+      throw new IOException(
+          "quantized.bin ExtRaBitQ paddedDimension must be positive multiple of 64: "
+              + paddedDimension);
+    }
+    int bits = buf.getInt();
+    if (bits < 2 || bits > 8) {
+      throw new IOException("quantized.bin ExtRaBitQ bits must be in [2, 8]: " + bits);
+    }
+
+    ensureRemaining(buf, (long) dimension * Float.BYTES, "ExtRaBitQ centroid");
+    float[] centroid = new float[dimension];
+    for (int d = 0; d < dimension; d++) {
+      centroid[d] = buf.getFloat();
+    }
+
+    Rotation rotation = decodeRotation(buf, paddedDimension);
+
+    ExtendedRaBitQuantizer quantizer =
+        ExtendedRaBitQuantizer.fromState(dimension, paddedDimension, bits, centroid, rotation);
+
+    int numLongs = paddedDimension >> 6;
+    int magBytes = (paddedDimension * bits + 7) / 8;
+    long perVector =
+        (long) numLongs * Long.BYTES + magBytes + (long) EXT_RABITQ_CORRECTIONS * Float.BYTES;
+    ensureRemaining(buf, perVector * vectorCount, "ExtRaBitQ vector data");
+
+    long[][] signCodes = new long[vectorCount][numLongs];
+    byte[][] magCodes = new byte[vectorCount][magBytes];
+    float[][] corrections = new float[vectorCount][EXT_RABITQ_CORRECTIONS];
+    for (int i = 0; i < vectorCount; i++) {
+      for (int j = 0; j < numLongs; j++) {
+        signCodes[i][j] = buf.getLong();
+      }
+      buf.get(magCodes[i]);
+      for (int j = 0; j < EXT_RABITQ_CORRECTIONS; j++) {
+        corrections[i][j] = buf.getFloat();
+      }
+    }
+
+    return new ExtendedRaBitQuantizedVectors(
+        quantizer, signCodes, magCodes, corrections, dimension);
   }
 
   // ---- TurboQuant ----

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/VectorDbQuantizationTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/VectorDbQuantizationTest.java
@@ -163,6 +163,36 @@ class VectorDbQuantizationTest {
     }
 
     @Test
+    void extendedRaBitQProducesHighRecall() {
+      // Ext-RaBitQ 4-bit navigates the HNSW graph on the codes and reranks survivors in full
+      // precision (two-pass) — the object-storage shared-code tier. Its correction-factor scoring
+      // is markedly more accurate than 1-bit RaBitQ, so recall should be high with modest
+      // overquery.
+      List<Document> docs = generateDocs(500, SEED);
+      float[] query = randomVector(new Random(999L));
+
+      VectorCollection coll =
+          VectorCollection.builder()
+              .dimension(DIM)
+              .metric(SimilarityFunction.EUCLIDEAN)
+              .indexType(IndexType.HNSW)
+              .quantizer(QuantizerKind.EXTENDED_RABITQ)
+              .extRaBitBits(4)
+              .build();
+      coll.addAll(docs);
+      coll.commit();
+
+      SearchResult result =
+          coll.search(
+              SearchRequest.builder(query, 10).searchListSize(100).overQueryFactor(3.0f).build());
+
+      Set<String> gt = bruteForceTopKIds(docs, query, 10);
+      double r = recall(gt, result);
+      assertThat(r).as("Extended RaBitQ HNSW recall").isGreaterThanOrEqualTo(0.90);
+      coll.close();
+    }
+
+    @Test
     void overQueryFactorImprovesRecallOrMaintainsIt() {
       List<Document> docs = generateDocs(500, SEED);
       float[] query = randomVector(new Random(999L));
@@ -492,6 +522,20 @@ class VectorDbQuantizationTest {
     @Test
     void fp16RoundTrips(@TempDir Path dir) {
       assertQuantizedPersistentHnswRoundTrip(dir, QuantizerKind.FP16, null);
+    }
+
+    @Test
+    void extendedRaBitQRoundTrips(@TempDir Path dir) {
+      // 4-bit magnitude codes exercise sub-byte packing + the sign/mag/correction tri-partite
+      // per-vector layout in the codec, plus fromState rotation/centroid reconstruction on decode.
+      VectorCollectionBuilder b =
+          VectorCollection.builder()
+              .dimension(DIM)
+              .metric(SimilarityFunction.EUCLIDEAN)
+              .indexType(IndexType.HNSW)
+              .quantizer(QuantizerKind.EXTENDED_RABITQ)
+              .extRaBitBits(4);
+      assertQuantizedPersistentRoundTrip(dir, b);
     }
 
     private void assertQuantizedPersistentHnswRoundTrip(

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/CoLocatedBlockCodecTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/CoLocatedBlockCodecTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Random;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class CoLocatedBlockCodecTest {
+
+  @Test
+  void roundTripsAdjacencyAndCoLocatedCodes() {
+    int numNodes = 500;
+    int maxDegree = 32;
+    int codeBytes = 50; // e.g. Ext-RaBitQ 4-bit over dim 100
+    Random r = new Random(7);
+
+    int[][] adj = new int[numNodes][];
+    byte[][] codes = new byte[numNodes][codeBytes];
+    for (int i = 0; i < numNodes; i++) {
+      r.nextBytes(codes[i]);
+    }
+    for (int i = 0; i < numNodes; i++) {
+      int deg = r.nextInt(maxDegree + 1); // 0..maxDegree
+      adj[i] = new int[deg];
+      for (int j = 0; j < deg; j++) {
+        adj[i][j] = r.nextInt(numNodes);
+      }
+    }
+    int entryNode = 42;
+
+    byte[] blob = CoLocatedBlockCodec.encode(numNodes, maxDegree, codeBytes, entryNode, adj, codes);
+    // exact fixed-stride size
+    assertThat(blob.length)
+        .isEqualTo(
+            CoLocatedBlockCodec.HEADER_SIZE
+                + numNodes * CoLocatedBlockCodec.strideFor(maxDegree, codeBytes));
+
+    CoLocatedBlockCodec.Reader reader = CoLocatedBlockCodec.open(MemorySegment.ofArray(blob));
+    assertThat(reader.numNodes()).isEqualTo(numNodes);
+    assertThat(reader.maxDegree()).isEqualTo(maxDegree);
+    assertThat(reader.codeBytes()).isEqualTo(codeBytes);
+    assertThat(reader.entryNode()).isEqualTo(entryNode);
+
+    int[] out = new int[maxDegree];
+    for (int i = 0; i < numNodes; i++) {
+      int deg = reader.neighbors(i, out);
+      assertThat(deg).as("degree[%d]", i).isEqualTo(adj[i].length);
+      for (int j = 0; j < deg; j++) {
+        assertThat(out[j]).as("neighbor[%d][%d]", i, j).isEqualTo(adj[i][j]);
+      }
+      // node's own co-located code
+      assertThat(sliceToBytes(reader.nodeCode(i), codeBytes))
+          .as("nodeCode[%d]", i)
+          .isEqualTo(codes[i]);
+      // each neighbor's co-located code == that neighbor node's code
+      for (int j = 0; j < deg; j++) {
+        assertThat(sliceToBytes(reader.neighborCode(i, j), codeBytes))
+            .as("neighborCode[%d][%d]", i, j)
+            .isEqualTo(codes[adj[i][j]]);
+      }
+    }
+  }
+
+  @Test
+  void blockOffsetIsFixedStrideArithmetic() {
+    int maxDegree = 16, codeBytes = 8;
+    byte[][] codes = new byte[10][codeBytes];
+    int[][] adj = new int[10][0];
+    byte[] blob = CoLocatedBlockCodec.encode(10, maxDegree, codeBytes, -1, adj, codes);
+    var reader = CoLocatedBlockCodec.open(MemorySegment.ofArray(blob));
+    int stride = CoLocatedBlockCodec.strideFor(maxDegree, codeBytes);
+    for (int n = 0; n < 10; n++) {
+      assertThat(reader.blockOffset(n))
+          .isEqualTo((long) CoLocatedBlockCodec.HEADER_SIZE + (long) n * stride);
+    }
+  }
+
+  @Test
+  void rejectsBadMagic() {
+    byte[] junk = new byte[64];
+    assertThatThrownBy(() -> CoLocatedBlockCodec.open(MemorySegment.ofArray(junk)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("magic");
+  }
+
+  private static byte[] sliceToBytes(MemorySegment slice, int n) {
+    byte[] b = new byte[n];
+    MemorySegment.copy(slice, ValueLayout.JAVA_BYTE, 0, b, 0, n);
+    return b;
+  }
+}

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/QuantizedVectorsCodecTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/QuantizedVectorsCodecTest.java
@@ -25,6 +25,8 @@ import com.integrallis.vectors.quantization.BinaryMode;
 import com.integrallis.vectors.quantization.BinaryQuantizedVectors;
 import com.integrallis.vectors.quantization.BinaryQuantizer;
 import com.integrallis.vectors.quantization.CompressedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizer;
 import com.integrallis.vectors.quantization.Fp16QuantizedVectors;
 import com.integrallis.vectors.quantization.Fp16Quantizer;
 import com.integrallis.vectors.quantization.NVQuantizedVectors;
@@ -309,6 +311,58 @@ class QuantizedVectorsCodecTest {
 
       byte[] first = QuantizedVectorsCodec.encode(compressed, quantizer, QuantizerKind.RABITQ);
       byte[] second = QuantizedVectorsCodec.encode(compressed, quantizer, QuantizerKind.RABITQ);
+      assertThat(first).isEqualTo(second);
+    }
+  }
+
+  @Nested
+  class ExtendedRaBitQRoundTrip {
+
+    @Test
+    void roundTripProducesIdenticalScoresEveryMetricAndBits() throws IOException {
+      VectorDataset data = dataset();
+      float[] query = randomVectors(1, DIM, 99L)[0];
+      SimilarityFunction[] metrics = {
+        SimilarityFunction.EUCLIDEAN,
+        SimilarityFunction.DOT_PRODUCT,
+        SimilarityFunction.COSINE,
+        SimilarityFunction.MAXIMUM_INNER_PRODUCT
+      };
+      for (int bits : new int[] {2, 4, 7}) {
+        ExtendedRaBitQuantizer quantizer = ExtendedRaBitQuantizer.train(data, bits, SEED);
+        ExtendedRaBitQuantizedVectors original = quantizer.encodeAll(data);
+
+        byte[] encoded =
+            QuantizedVectorsCodec.encode(original, quantizer, QuantizerKind.EXTENDED_RABITQ);
+        CompressedVectors decoded = QuantizedVectorsCodec.decode(encoded);
+
+        assertThat(decoded).isInstanceOf(ExtendedRaBitQuantizedVectors.class);
+        ExtendedRaBitQuantizedVectors eq = (ExtendedRaBitQuantizedVectors) decoded;
+        assertThat(eq.size()).isEqualTo(original.size());
+        assertThat(eq.dimension()).isEqualTo(DIM);
+
+        for (SimilarityFunction metric : metrics) {
+          ScoreFunction origScorer = original.scoreFunctionFor(query, metric);
+          ScoreFunction decodedScorer = eq.scoreFunctionFor(query, metric);
+          for (int i = 0; i < NUM_VECTORS; i++) {
+            assertThat(decodedScorer.score(i))
+                .as("bits=%d metric=%s ordinal=%d", bits, metric, i)
+                .isEqualTo(origScorer.score(i));
+          }
+        }
+      }
+    }
+
+    @Test
+    void encodeTwiceProducesSameBytes() {
+      VectorDataset data = dataset();
+      ExtendedRaBitQuantizer quantizer = ExtendedRaBitQuantizer.train(data, 4, SEED);
+      ExtendedRaBitQuantizedVectors compressed = quantizer.encodeAll(data);
+
+      byte[] first =
+          QuantizedVectorsCodec.encode(compressed, quantizer, QuantizerKind.EXTENDED_RABITQ);
+      byte[] second =
+          QuantizedVectorsCodec.encode(compressed, quantizer, QuantizerKind.EXTENDED_RABITQ);
       assertThat(first).isEqualTo(second);
     }
   }

--- a/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/HnswIndex.java
+++ b/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/HnswIndex.java
@@ -279,6 +279,13 @@ public final class HnswIndex {
   }
 
   /**
+   * EXPERIMENT: monotonic total node-expansions on this thread's searcher (read deltas per query).
+   */
+  public long nodesVisitedTotal() {
+    return threadLocalSearcher.get().nodesVisited;
+  }
+
+  /**
    * Returns the underlying {@link HnswGraph}. Exposed for persistence paths that need to serialize
    * the graph topology to disk. The returned graph aliases the index's internal reference; callers
    * must not mutate it through {@link HnswGraph#initNode} or {@link HnswGraph#setEntryNode}, which

--- a/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/HnswSearcher.java
+++ b/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/HnswSearcher.java
@@ -55,6 +55,9 @@ public final class HnswSearcher {
   // zeroed all ~N bits every query (a real cost at N=1.18M — most of which are never touched).
   private final int[] visitedTag;
   private int visitedGen;
+  // EXPERIMENT: monotonic node-expansion counter (= object-store GETs in the co-located block
+  // design).
+  long nodesVisited;
   private final NodeQueue candidates;
   private final NodeQueue results;
   // Scratch buffer for rescore(): avoids allocating a new NodeQueue on every two-pass call.
@@ -656,6 +659,7 @@ public final class HnswSearcher {
 
       NeighborArray neighbors = graph.getNeighbors(candidateId, layer);
       if (neighbors == null) continue;
+      nodesVisited++;
 
       // SSD prefetch pass: issue async touch-reads for all neighbors before scoring.
       // For mmap-backed vector stores this causes the OS to page-in the relevant 4 KiB pages

--- a/vectors-optimizer/src/main/java/com/integrallis/vectors/optimizer/study/IndexMemoryEstimator.java
+++ b/vectors-optimizer/src/main/java/com/integrallis/vectors/optimizer/study/IndexMemoryEstimator.java
@@ -25,6 +25,7 @@ final class IndexMemoryEstimator {
 
   private static final int IVF_DEFAULT_HARMONY_KEY_DIMS = 0;
   private static final int RABIT_CORRECTION_FLOATS = 5;
+  private static final int EXT_RABIT_CORRECTION_FLOATS = 6;
   private static final int BBQ_CORRECTION_FLOATS = 3;
   private static final int NVQ_METADATA_FLOATS_PER_SUBVECTOR = 4;
 
@@ -70,6 +71,8 @@ final class IndexMemoryEstimator {
       case TURBOQUANT -> turboQuantizedBytes(config.quantizerParams(), physicalSize, dimension);
       // fp16: two bytes per coordinate, no quantizer state.
       case FP16 -> (long) physicalSize * dimension * Short.BYTES;
+      case EXTENDED_RABITQ ->
+          extRaBitQuantizedBytes(config.quantizerParams(), physicalSize, dimension);
     };
   }
 
@@ -114,6 +117,25 @@ final class IndexMemoryEstimator {
     long centroids = rawVectorBytes(1, dimension) + rawVectorBytes(1, paddedDimension);
     long givensRotation = (long) (paddedDimension / 2) * 2L * Float.BYTES;
     return (long) physicalSize * codeBytesPerVector + corrections + centroids + givensRotation;
+  }
+
+  private static long extRaBitQuantizedBytes(
+      QuantizerParams params, int physicalSize, int dimension) {
+    QuantizerParams.ExtRaBitParams ep =
+        params instanceof QuantizerParams.ExtRaBitParams p ? p : null;
+    int bits = ep != null ? ep.bits() : VectorCollectionBuilder.DEFAULT_EXTRABIT_BITS;
+    int paddedDimension = ((dimension + 63) / 64) * 64;
+    // Per vector: sign bits (paddedDim/8) + packed magnitude codes ((paddedDim*bits+7)/8) + 6
+    // correction floats. Quantizer state: centroid + Givens rotation (cos/sin arrays).
+    long signBytesPerVector = (long) paddedDimension / 8;
+    long magBytesPerVector = (long) (paddedDimension * bits + 7) / 8;
+    long corrections = (long) physicalSize * EXT_RABIT_CORRECTION_FLOATS * Float.BYTES;
+    long centroid = rawVectorBytes(1, dimension);
+    long givensRotation = (long) (paddedDimension / 2) * 2L * Float.BYTES;
+    return (long) physicalSize * (signBytesPerVector + magBytesPerVector)
+        + corrections
+        + centroid
+        + givensRotation;
   }
 
   private static long turboQuantizedBytes(QuantizerParams params, int physicalSize, int dimension) {

--- a/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizedVectors.java
+++ b/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizedVectors.java
@@ -58,7 +58,17 @@ public final class ExtendedRaBitQuantizedVectors implements CompressedVectors {
   private final float[][] corrections; // [size][6]
   private final int dimension;
 
-  ExtendedRaBitQuantizedVectors(
+  /**
+   * Constructs compressed vectors from a trained quantizer and per-vector codes. Public so the
+   * {@code quantized.bin} codec can reconstruct instances on decode.
+   *
+   * @param quantizer the quantizer that produced (or matches) these codes
+   * @param signCodes per-vector sign-bit codes {@code [size][numLongs]}
+   * @param magCodes per-vector magnitude codes {@code [size][magByteSize]}
+   * @param corrections per-vector correction factors {@code [size][6]}
+   * @param dimension original vector dimension
+   */
+  public ExtendedRaBitQuantizedVectors(
       ExtendedRaBitQuantizer quantizer,
       long[][] signCodes,
       byte[][] magCodes,

--- a/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizedVectors.java
+++ b/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizedVectors.java
@@ -220,6 +220,69 @@ public final class ExtendedRaBitQuantizedVectors implements CompressedVectors {
   }
 
   /**
+   * Scores a query against <b>raw</b> Ext-RaBitQ code components (sign + magnitude + corrections)
+   * rather than by ordinal — the primitive the co-located block search uses to score neighbor codes
+   * read straight from a block, with no ordinal&rarr;code lookup. Returns exactly what {@link
+   * #scoreFunctionFor} returns for the same code (identical {@link #estimateL2Multi}). Not
+   * thread-safe; create one per thread.
+   */
+  public interface RawCodeScorer {
+    /** Approximate similarity (higher = closer) for the vector with the given code components. */
+    float score(long[] signCode, byte[] magCode, float[] corrections);
+  }
+
+  /** Builds a {@link RawCodeScorer} for the query (query prepared once, captured by the scorer). */
+  public RawCodeScorer rawScorerFor(float[] query, SimilarityFunction similarityFunction) {
+    if (query.length != dimension) {
+      throw new IllegalArgumentException(
+          "Expected query dimension " + dimension + ", got " + query.length);
+    }
+    int bits = quantizer.bits();
+    PreparedQuery pq = prepareQuery(query);
+    return switch (similarityFunction) {
+      case EUCLIDEAN -> (sc, mc, corr) -> 1f / (1f + Math.max(rawDist(pq, bits, sc, mc, corr), 0f));
+      case DOT_PRODUCT ->
+          (sc, mc, corr) -> {
+            float dist = rawDist(pq, bits, sc, mc, corr);
+            float sqrX = corr[ExtendedRaBitQuantizer.IDX_SQR_X];
+            float approxDot = (pq.sqrY() + sqrX - dist) / 2f;
+            return Math.max((1f + approxDot) / 2f, 0f);
+          };
+      case COSINE ->
+          (sc, mc, corr) -> {
+            float dist = rawDist(pq, bits, sc, mc, corr);
+            float sqrX = corr[ExtendedRaBitQuantizer.IDX_SQR_X];
+            float vecNorm = (float) Math.sqrt(sqrX);
+            if (pq.queryNorm() == 0f || vecNorm == 0f) return 0f;
+            float approxDot = (pq.sqrY() + sqrX - dist) / 2f;
+            float cosine = approxDot / (pq.queryNorm() * vecNorm);
+            return Math.max((1f + cosine) / 2f, 0f);
+          };
+      case MAXIMUM_INNER_PRODUCT ->
+          (sc, mc, corr) -> {
+            float dist = rawDist(pq, bits, sc, mc, corr);
+            float sqrX = corr[ExtendedRaBitQuantizer.IDX_SQR_X];
+            float approxDot = (pq.sqrY() + sqrX - dist) / 2f;
+            return SimilarityFunction.scaleMaxInnerProductScore(approxDot);
+          };
+    };
+  }
+
+  private static float rawDist(PreparedQuery pq, int bits, long[] sc, byte[] mc, float[] corr) {
+    return estimateL2Multi(
+        sc,
+        mc,
+        corr,
+        pq.queryBytes(),
+        pq.vl(),
+        pq.widthOver255(),
+        pq.sumQ(),
+        pq.sqrY(),
+        pq.queryNorm(),
+        bits);
+  }
+
+  /**
    * Returns a cheap Layer 1 score function that uses <b>only sign-bit codes</b> (no magnitude
    * unpacking). This produces the same distance estimate as 1-bit RaBitQ — less accurate than the
    * full multi-bit estimate from {@link #scoreFunctionFor}, but cheaper to compute.

--- a/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizedVectors.java
+++ b/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizedVectors.java
@@ -17,6 +17,8 @@ package com.integrallis.vectors.quantization;
 
 import com.integrallis.vectors.core.SimilarityFunction;
 import com.integrallis.vectors.core.VectorUtil;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * Compressed vector storage produced by {@link ExtendedRaBitQuantizer}. Stores 1-bit sign codes
@@ -280,6 +282,60 @@ public final class ExtendedRaBitQuantizedVectors implements CompressedVectors {
         pq.sqrY(),
         pq.queryNorm(),
         bits);
+  }
+
+  // --- Packed-code bridge for the co-located block index (P2/P3) ---
+
+  /** Number of 64-bit words in each vector's sign code (fixed for this quantizer). */
+  public int signCodeLongs() {
+    return size() == 0 ? 0 : signCodes[0].length;
+  }
+
+  /** Number of magnitude-code bytes per vector (fixed for this quantizer). */
+  public int magCodeByteSize() {
+    return size() == 0 ? 0 : magCodes[0].length;
+  }
+
+  /** Byte size of one packed code: sign words + magnitude bytes + corrections. */
+  public int packedCodeByteSize() {
+    return signCodeLongs() * Long.BYTES
+        + magCodeByteSize()
+        + ExtendedRaBitQuantizer.NUM_CORRECTIONS * Float.BYTES;
+  }
+
+  /**
+   * Serializes the ordinal's code (sign words | magnitude bytes | correction floats, little-endian)
+   * into {@code dst} at {@code offset} — the contiguous {@code byte[]} a co-located block stores.
+   */
+  public void packCode(int ordinal, byte[] dst, int offset) {
+    ByteBuffer b = ByteBuffer.wrap(dst, offset, dst.length - offset).order(ByteOrder.LITTLE_ENDIAN);
+    for (long w : signCodes[ordinal]) {
+      b.putLong(w);
+    }
+    b.put(magCodes[ordinal]);
+    for (float f : corrections[ordinal]) {
+      b.putFloat(f);
+    }
+  }
+
+  /**
+   * Scores a query (via {@code scorer}) against a packed code read straight from a block — the
+   * co-located block search path, with no ordinal lookup. Inverse of {@link #packCode}.
+   */
+  public float scorePacked(RawCodeScorer scorer, byte[] packed, int offset) {
+    ByteBuffer b =
+        ByteBuffer.wrap(packed, offset, packed.length - offset).order(ByteOrder.LITTLE_ENDIAN);
+    long[] sc = new long[signCodeLongs()];
+    for (int i = 0; i < sc.length; i++) {
+      sc[i] = b.getLong();
+    }
+    byte[] mc = new byte[magCodeByteSize()];
+    b.get(mc);
+    float[] corr = new float[ExtendedRaBitQuantizer.NUM_CORRECTIONS];
+    for (int i = 0; i < corr.length; i++) {
+      corr[i] = b.getFloat();
+    }
+    return scorer.score(sc, mc, corr);
   }
 
   /**

--- a/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizer.java
+++ b/vectors-quantization/src/main/java/com/integrallis/vectors/quantization/ExtendedRaBitQuantizer.java
@@ -159,6 +159,38 @@ public final class ExtendedRaBitQuantizer implements Quantizer<ExtendedRaBitQuan
     return new ExtendedRaBitQuantizer(dim, paddedDim, bits, centroid, rotation);
   }
 
+  /**
+   * Reconstructs a trained quantizer from persisted state (used by the {@code quantized.bin}
+   * codec). No training is performed; the caller supplies the exact centroid and rotation captured
+   * at encode time so decoded scores are bit-identical to the original.
+   *
+   * @param dimension original vector dimension
+   * @param paddedDimension dimension rounded up to a multiple of 64 (must match {@code rotation})
+   * @param bits magnitude bit-width (2-8)
+   * @param centroid the dataset centroid (length == dimension)
+   * @param rotation the rotation strategy (dimension == paddedDimension)
+   * @return a quantizer equivalent to the one that produced the persisted codes
+   * @throws IllegalArgumentException if bits, dimensions, or rotation are inconsistent
+   */
+  public static ExtendedRaBitQuantizer fromState(
+      int dimension, int paddedDimension, int bits, float[] centroid, Rotation rotation) {
+    validateBits(bits);
+    int expectedPadded = ((dimension + 63) / 64) * 64;
+    if (paddedDimension != expectedPadded) {
+      throw new IllegalArgumentException(
+          "paddedDimension " + paddedDimension + " must equal " + expectedPadded);
+    }
+    if (rotation.dimension() != paddedDimension) {
+      throw new IllegalArgumentException(
+          "Rotation dimension " + rotation.dimension() + " must match " + paddedDimension);
+    }
+    if (centroid.length != dimension) {
+      throw new IllegalArgumentException(
+          "Centroid length " + centroid.length + " must equal dimension " + dimension);
+    }
+    return new ExtendedRaBitQuantizer(dimension, paddedDimension, bits, centroid, rotation);
+  }
+
   private static void validateBits(int bits) {
     if (bits < 2 || bits > 8) {
       throw new IllegalArgumentException(
@@ -381,17 +413,17 @@ public final class ExtendedRaBitQuantizer implements Quantizer<ExtendedRaBitQuan
   // --- Accessors ---
 
   /** Returns the padded dimension (rounded up to the next multiple of 64). */
-  int paddedDimension() {
+  public int paddedDimension() {
     return paddedDimension;
   }
 
   /** Returns the magnitude bit-width. */
-  int bits() {
+  public int bits() {
     return bits;
   }
 
   /** Returns the dataset centroid. */
-  float[] centroid() {
+  public float[] centroid() {
     return centroid;
   }
 
@@ -401,7 +433,7 @@ public final class ExtendedRaBitQuantizer implements Quantizer<ExtendedRaBitQuan
   }
 
   /** Returns the rotation strategy. */
-  Rotation rotation() {
+  public Rotation rotation() {
     return rotation;
   }
 
@@ -411,7 +443,7 @@ public final class ExtendedRaBitQuantizer implements Quantizer<ExtendedRaBitQuan
   }
 
   /** Returns the number of bytes for the magnitude-code portion. */
-  int magByteSize() {
+  public int magByteSize() {
     return (paddedDimension * bits + 7) / 8;
   }
 
@@ -421,7 +453,7 @@ public final class ExtendedRaBitQuantizer implements Quantizer<ExtendedRaBitQuan
   }
 
   /** Returns the number of longs needed to store the sign-bit codes. */
-  int numLongs() {
+  public int numLongs() {
     return paddedDimension >> 6;
   }
 

--- a/vectors-quantization/src/test/java/com/integrallis/vectors/quantization/ExtendedRaBitQRawScorerTest.java
+++ b/vectors-quantization/src/test/java/com/integrallis/vectors/quantization/ExtendedRaBitQRawScorerTest.java
@@ -77,4 +77,46 @@ class ExtendedRaBitQRawScorerTest {
       }
     }
   }
+
+  @Test
+  void packedCodeScoresIdenticallyToOrdinal() {
+    int n = 200;
+    int dim = 48;
+    Random r = new Random(23);
+    float[][] vecs = new float[n][dim];
+    for (int i = 0; i < n; i++) {
+      for (int d = 0; d < dim; d++) {
+        vecs[i][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+    ArrayVectorDataset ds = new ArrayVectorDataset(vecs);
+    float[] query = new float[dim];
+    for (int d = 0; d < dim; d++) {
+      query[d] = r.nextFloat() * 2f - 1f;
+    }
+    for (int bits : new int[] {2, 4, 7}) {
+      ExtendedRaBitQuantizedVectors codes =
+          ExtendedRaBitQuantizer.train(ds, bits, 5L).encodeAll(ds);
+      int cb = codes.packedCodeByteSize();
+      byte[][] packed = new byte[n][cb];
+      for (int ord = 0; ord < n; ord++) {
+        codes.packCode(ord, packed[ord], 0);
+      }
+      for (SimilarityFunction metric :
+          new SimilarityFunction[] {
+            SimilarityFunction.EUCLIDEAN,
+            SimilarityFunction.DOT_PRODUCT,
+            SimilarityFunction.COSINE,
+            SimilarityFunction.MAXIMUM_INNER_PRODUCT
+          }) {
+        ScoreFunction byOrdinal = codes.scoreFunctionFor(query, metric);
+        ExtendedRaBitQuantizedVectors.RawCodeScorer rs = codes.rawScorerFor(query, metric);
+        for (int ord = 0; ord < n; ord++) {
+          assertThat(codes.scorePacked(rs, packed[ord], 0))
+              .as("bits=%d metric=%s ord=%d", bits, metric, ord)
+              .isEqualTo(byOrdinal.score(ord));
+        }
+      }
+    }
+  }
 }

--- a/vectors-quantization/src/test/java/com/integrallis/vectors/quantization/ExtendedRaBitQRawScorerTest.java
+++ b/vectors-quantization/src/test/java/com/integrallis/vectors/quantization/ExtendedRaBitQRawScorerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.quantization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.integrallis.vectors.core.SimilarityFunction;
+import java.util.Random;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The co-located block search scores neighbor codes read straight from a block via {@link
+ * ExtendedRaBitQuantizedVectors#rawScorerFor} — with no ordinal lookup. This proves that path
+ * returns exactly what the ordinal-based {@link ExtendedRaBitQuantizedVectors#scoreFunctionFor}
+ * returns for the same code, across every similarity function and bit-width.
+ */
+@Tag("unit")
+class ExtendedRaBitQRawScorerTest {
+
+  @Test
+  void rawScorerMatchesOrdinalScoreForEveryMetricAndBits() {
+    int n = 300;
+    int dim = 64;
+    Random r = new Random(11);
+    float[][] vecs = new float[n][dim];
+    for (int i = 0; i < n; i++) {
+      for (int d = 0; d < dim; d++) {
+        vecs[i][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+    ArrayVectorDataset ds = new ArrayVectorDataset(vecs);
+    float[][] queries = new float[10][dim];
+    for (int q = 0; q < queries.length; q++) {
+      for (int d = 0; d < dim; d++) {
+        queries[q][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+
+    SimilarityFunction[] metrics = {
+      SimilarityFunction.EUCLIDEAN,
+      SimilarityFunction.DOT_PRODUCT,
+      SimilarityFunction.COSINE,
+      SimilarityFunction.MAXIMUM_INNER_PRODUCT
+    };
+
+    for (int bits : new int[] {2, 4, 7}) {
+      ExtendedRaBitQuantizer quantizer = ExtendedRaBitQuantizer.train(ds, bits, 99L);
+      ExtendedRaBitQuantizedVectors codes = quantizer.encodeAll(ds);
+      for (SimilarityFunction metric : metrics) {
+        for (float[] query : queries) {
+          ScoreFunction byOrdinal = codes.scoreFunctionFor(query, metric);
+          ExtendedRaBitQuantizedVectors.RawCodeScorer byRawCode = codes.rawScorerFor(query, metric);
+          for (int ord = 0; ord < n; ord++) {
+            float expected = byOrdinal.score(ord);
+            float actual =
+                byRawCode.score(
+                    codes.getSignCodes(ord), codes.getMagCodes(ord), codes.getCorrections(ord));
+            assertThat(actual)
+                .as("bits=%d metric=%s ordinal=%d", bits, metric, ord)
+                .isEqualTo(expected);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Productionizes the SOTA object-storage vector index and lands supporting GGUF kernel work.

## Object-storage index (SOTA P2–P7)
The validated design ships as a first-class **persisted quantizer kind**, not a bespoke index — the existing two-pass HNSW path already *is* "navigate on compact codes → rerank full precision", and `quantized.bin` is already the flat by-ordinal **shared code tier** (co-location was proven pure waste, 34× larger at identical recall).

- **`feat(db)`**: `QuantizerKind.EXTENDED_RABITQ` (appended after `FP16` → on-disk ordinals stable) + `ExtRaBitParams(bits, seed)` + builder `extRaBitBits/extRaBitSeed` (default 4-bit). Codec encode/decode over `quantized.bin`; `VectorCollectionImpl` training wired in.
- **`feat(quantization)`**: `ExtendedRaBitQuantizer.fromState(...)` + public accessors/ctor so the codec can persist and rebuild (bit-identical scores on decode).
- Co-located block codec + raw/packed-code scorers (P2/P3) that underpinned the experiments.

Measured on glove-100 (200k): 4-bit code-navigation reaches **0.994 recall@10** at **M=32** (matches full precision, gap ~0.5%) at ~1/8th the float32 footprint — decisively past S3 Vectors' fixed 85–90%.

Usage:
```java
VectorCollection.builder().indexType(HNSW).hnswM(32).hnswEfConstruction(500)
    .quantizer(EXTENDED_RABITQ).extRaBitBits(4).build();
// search with overQueryFactor > 1  → code-nav + full-precision rerank
```

## GGUF kernels
- **`feat(core)`**: fused GGUF F32 batched GEMV that reads little-endian rows straight from a `MemorySegment` (scalar + 4-row Panama SIMD), avoiding a heap copy of mapped weights.
- **`fix(core)`**: GGUF Q4_0 dot product corrected to GGML's split-nibble layout (low nibbles of weights 0–15, then high nibbles of 16–31) — the scalar kernel was mispairing query coordinates with weights.

## Diagnostics
- **`chore(hnsw)`**: node-expansion counter (= object-store GETs) for tuning the index.

## Tests
Codec round-trip (bit-identical across metrics × {2,4,7}-bit), in-memory two-pass recall, persistent on-disk round-trip, GGUF F32/Q4_0 kernel tests — all green; spotless clean on all touched modules.