### PR TITLE
perf(core): add GGML Q8 activation GEMV

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 /** Compares GGUF GEMV with F32 activations against GGML-compatible Q8 activations. */
 @BenchmarkMode(Mode.AverageTime)
@@ -79,39 +80,39 @@ public class GgufQuantizedMatVecBenchmark {
   }
 
   @Benchmark
-  public float[] q4_0WithF32Activation() {
+  public void q4_0WithF32Activation(Blackhole blackhole) {
     VectorUtil.ggufQ4_0BatchDotProduct(query, q4Weights, rows, cols, out);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q4_0WithQ8_0Activation() {
+  public void q4_0WithQ8_0Activation(Blackhole blackhole) {
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q8_0WithF32Activation() {
+  public void q8_0WithF32Activation(Blackhole blackhole) {
     VectorUtil.ggufQ8_0BatchDotProduct(query, q8Weights, rows, cols, out);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q8_0WithQ8_0Activation() {
+  public void q8_0WithQ8_0Activation(Blackhole blackhole) {
     VectorUtil.ggufQ8_0Q8_0BatchDotProduct(query, q8Weights, rows, cols, out, q8Quants, q8Scales);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q6_KWithF32Activation() {
+  public void q6_KWithF32Activation(Blackhole blackhole) {
     VectorUtil.ggufQ6_KBatchDotProduct(query, q6Weights, rows, cols, out);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q6_KWithQ8_KActivation() {
+  public void q6_KWithQ8_KActivation(Blackhole blackhole) {
     VectorUtil.ggufQ6_KQ8_KBatchDotProduct(query, q6Weights, rows, cols, out, q8Quants, q8Scales);
-    return out;
+    blackhole.consume(out);
   }
 
   private static byte[] randomBlocks(

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Compares GGUF GEMV with F32 activations against GGML-compatible Q8 activations. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQuantizedMatVecBenchmark {
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] query;
+  private MemorySegment q4Weights;
+  private MemorySegment q8Weights;
+  private MemorySegment q6Weights;
+  private float[] out;
+  private byte[] q8Quants;
+  private float[] q8Scales;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(42L);
+    query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 2.0f - 1.0f;
+    }
+
+    byte[] q4 = randomBlocks(random, rows * (cols / 32) * 18, 18, 0);
+    byte[] q8 = randomBlocks(random, rows * (cols / 32) * 34, 34, 0);
+    byte[] q6 = randomBlocks(random, rows * (cols / 256) * 210, 210, 208);
+    q4Weights = MemorySegment.ofArray(q4);
+    q8Weights = MemorySegment.ofArray(q8);
+    q6Weights = MemorySegment.ofArray(q6);
+    out = new float[rows];
+    q8Quants = new byte[cols];
+    q8Scales = new float[cols / 32];
+  }
+
+  @Benchmark
+  public float[] q4_0WithF32Activation() {
+    VectorUtil.ggufQ4_0BatchDotProduct(query, q4Weights, rows, cols, out);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q4_0WithQ8_0Activation() {
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q8_0WithF32Activation() {
+    VectorUtil.ggufQ8_0BatchDotProduct(query, q8Weights, rows, cols, out);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q8_0WithQ8_0Activation() {
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(query, q8Weights, rows, cols, out, q8Quants, q8Scales);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q6_KWithF32Activation() {
+    VectorUtil.ggufQ6_KBatchDotProduct(query, q6Weights, rows, cols, out);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q6_KWithQ8_KActivation() {
+    VectorUtil.ggufQ6_KQ8_KBatchDotProduct(query, q6Weights, rows, cols, out, q8Quants, q8Scales);
+    return out;
+  }
+
+  private static byte[] randomBlocks(
+      Random random, int byteCount, int blockBytes, int scaleOffset) {
+    byte[] blocks = new byte[byteCount];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    for (int offset = 0; offset < byteCount; offset += blockBytes) {
+      buffer.putShort(offset + scaleOffset, scale);
+    }
+    return blocks;
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -252,12 +252,58 @@ public final class VectorUtil {
     IMPL.ggufQ4_0MatVecDot(query, qWeight, rows, cols, out);
   }
 
+  /**
+   * GGML-compatible GEMV over Q4_0 rows using a Q8_0-quantized activation vector.
+   *
+   * <p>The query is quantized once per call into caller-owned scratch arrays, then reused for every
+   * matrix row.
+   *
+   * @param q8Quants scratch space with at least {@code cols} entries
+   * @param q8Scales scratch space with at least {@code cols / 32} entries
+   */
+  public static void ggufQ4_0Q8_0BatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ4_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
+  }
+
   /** Batched row-major GEMV over GGUF Q8_0 rows. */
   public static void ggufQ8_0BatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
     checkGgufQuantizedBatchArguments(
         query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
     IMPL.ggufQ8_0MatVecDot(query, qWeight, rows, cols, out);
+  }
+
+  /**
+   * GGML-compatible GEMV over Q8_0 rows using a Q8_0-quantized activation vector.
+   *
+   * <p>The query is quantized once per call into caller-owned scratch arrays, then reused for every
+   * matrix row.
+   *
+   * @param q8Quants scratch space with at least {@code cols} entries
+   * @param q8Scales scratch space with at least {@code cols / 32} entries
+   */
+  public static void ggufQ8_0Q8_0BatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ8_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
   }
 
   /** Batched row-major GEMV over GGUF Q6_K rows. */
@@ -272,6 +318,36 @@ public final class VectorUtil {
         VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE,
         VectorUtilSupport.GGUF_Q6_K_BLOCK_BYTES);
     IMPL.ggufQ6_KMatVecDot(query, qWeight, rows, cols, out);
+  }
+
+  /**
+   * GGML-compatible GEMV over Q6_K rows using a Q8_K-quantized activation vector.
+   *
+   * <p>The query is quantized once per call into caller-owned scratch arrays, then reused for every
+   * matrix row. This matches GGML's Q6_K matrix multiplication semantics while keeping the hot path
+   * free of large temporary allocations.
+   *
+   * @param q8Quants scratch space with at least {@code cols} entries
+   * @param q8Scales scratch space with at least {@code cols / 256} entries
+   */
+  public static void ggufQ6_KQ8_KBatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE);
+    IMPL.ggufQ6_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
   }
 
   /**
@@ -604,6 +680,26 @@ public final class VectorUtil {
     if (dimensions % blockSize != 0) {
       throw new IllegalArgumentException(
           "GGUF quantized dimensions must be a multiple of " + blockSize + ": " + dimensions);
+    }
+  }
+
+  private static void checkGgufActivationScratch(
+      byte[] q8Quants, float[] q8Scales, int dimensions, int blockSize) {
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    if (q8Quants.length < dimensions) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= dimensions: " + q8Quants.length + " < " + dimensions);
+    }
+    int blocks = dimensions / blockSize;
+    if (q8Scales.length < blocks) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= dimensions / "
+              + blockSize
+              + ": "
+              + q8Scales.length
+              + " < "
+              + blocks);
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -296,6 +296,42 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** GGML-compatible Q4_0 by Q8_0 GEMV. The activation is quantized once and reused across rows. */
+  default void ggufQ4_0Q8_0MatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int row = 0; row < rows; row++) {
+      float sum = 0.0f;
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+        float scale =
+            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+        long nibbleOffset = blockOffset + Short.BYTES;
+        int quantOffset = block * GGUF_Q_BLOCK_SIZE;
+        int integerSum = 0;
+        for (int index = 0; index < 16; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + index) & 0xFF;
+          int lo = (packed & 0x0F) - 8;
+          int hi = ((packed >>> 4) & 0x0F) - 8;
+          integerSum += lo * q8Quants[quantOffset + index];
+          integerSum += hi * q8Quants[quantOffset + index + 16];
+        }
+        sum = MathUtil.fma(scale, integerSum, sum);
+      }
+      out[row] = sum;
+    }
+  }
+
   /** Batched row-major GEMV over GGUF Q6_K rows. */
   default void ggufQ6_KMatVecDot(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
@@ -305,12 +341,120 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** GGML-compatible Q6_K by Q8_K GEMV. The activation is quantized once and reused across rows. */
+  default void ggufQ6_KQ8_KMatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ6_KRowBytes(cols);
+    int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
+    int[] integerSums = new int[8];
+    float[] laneSums = new float[8];
+    for (int row = 0; row < rows; row++) {
+      java.util.Arrays.fill(laneSums, 0.0f);
+      long rowOffset = row * rowBytes;
+
+      for (int block = 0; block < blocks; block++) {
+        java.util.Arrays.fill(integerSums, 0);
+        long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+        float d =
+            Float.float16ToFloat(
+                    qWeight.get(
+                        GGUF_LE_SHORT,
+                        blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES))
+                * q8Scales[block];
+        long qlOffset = blockOffset;
+        long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+        long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+        int queryOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+
+        for (int superBlock = 0; superBlock < 2; superBlock++) {
+          long qlBase = qlOffset + (long) superBlock * 64;
+          long qhBase = qhOffset + (long) superBlock * 32;
+          long scaleBase = scaleOffset + (long) superBlock * 8;
+          int quantBase = queryOffset + superBlock * 128;
+
+          for (int index = 0; index < 32; index++) {
+            int scaleIndex = index / 16;
+            int ql1 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + index) & 0xFF;
+            int ql2 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + 32L + index) & 0xFF;
+            int qh = qWeight.get(ValueLayout.JAVA_BYTE, qhBase + index) & 0xFF;
+            int q1 = ((ql1 & 0x0F) | ((qh & 0x03) << 4)) - 32;
+            int q2 = ((ql2 & 0x0F) | (((qh >>> 2) & 0x03) << 4)) - 32;
+            int q3 = ((ql1 >>> 4) | (((qh >>> 4) & 0x03) << 4)) - 32;
+            int q4 = ((ql2 >>> 4) | (((qh >>> 6) & 0x03) << 4)) - 32;
+            int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+            int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+            int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+            int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+            int lane = index & 7;
+
+            integerSums[lane] += s1 * q1 * q8Quants[quantBase + index];
+            integerSums[lane] += s2 * q2 * q8Quants[quantBase + index + 32];
+            integerSums[lane] += s3 * q3 * q8Quants[quantBase + index + 64];
+            integerSums[lane] += s4 * q4 * q8Quants[quantBase + index + 96];
+          }
+        }
+
+        for (int lane = 0; lane < laneSums.length; lane++) {
+          laneSums[lane] = MathUtil.fma(d, integerSums[lane], laneSums[lane]);
+        }
+      }
+
+      float sum = 0.0f;
+      for (float laneSum : laneSums) {
+        sum += laneSum;
+      }
+      out[row] = sum;
+    }
+  }
+
   /** Batched row-major GEMV over GGUF Q8_0 rows. */
   default void ggufQ8_0MatVecDot(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
     long rowBytes = ggufQ8_0RowBytes(cols);
     for (int row = 0; row < rows; row++) {
       out[row] = ggufQ8_0DotProduct(query, qWeight, row * rowBytes, cols);
+    }
+  }
+
+  /** GGML-compatible Q8_0 by Q8_0 GEMV. The activation is quantized once and reused across rows. */
+  default void ggufQ8_0Q8_0MatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ8_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int row = 0; row < rows; row++) {
+      float sum = 0.0f;
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+        float scale =
+            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+        long quantOffset = blockOffset + Short.BYTES;
+        int queryOffset = block * GGUF_Q_BLOCK_SIZE;
+        int integerSum = 0;
+        for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
+          integerSum +=
+              qWeight.get(ValueLayout.JAVA_BYTE, quantOffset + index)
+                  * q8Quants[queryOffset + index];
+        }
+        sum = MathUtil.fma(scale, integerSum, sum);
+      }
+      out[row] = sum;
     }
   }
 
@@ -499,6 +643,59 @@ public interface VectorUtilSupport {
   private static long ggufQ6_KRowBytes(int dimensions) {
     checkGgufQ6_KBlockAligned(dimensions);
     return (long) (dimensions / GGUF_Q6_K_BLOCK_SIZE) * GGUF_Q6_K_BLOCK_BYTES;
+  }
+
+  private static void quantizeQ8_K(float[] query, int dimensions, byte[] quants, float[] scales) {
+    int blocks = dimensions / GGUF_Q6_K_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      int offset = block * GGUF_Q6_K_BLOCK_SIZE;
+      float max = 0.0f;
+      float absoluteMax = 0.0f;
+      for (int index = 0; index < GGUF_Q6_K_BLOCK_SIZE; index++) {
+        float value = query[offset + index];
+        float absolute = Math.abs(value);
+        if (absolute > absoluteMax) {
+          absoluteMax = absolute;
+          max = value;
+        }
+      }
+
+      if (absoluteMax == 0.0f) {
+        java.util.Arrays.fill(quants, offset, offset + GGUF_Q6_K_BLOCK_SIZE, (byte) 0);
+        scales[block] = 0.0f;
+        continue;
+      }
+
+      float inverseScale = -127.0f / max;
+      for (int index = 0; index < GGUF_Q6_K_BLOCK_SIZE; index++) {
+        int quant = ggmlNearestInt(inverseScale * query[offset + index]);
+        quants[offset + index] = (byte) Math.min(127, quant);
+      }
+      scales[block] = 1.0f / inverseScale;
+    }
+  }
+
+  private static void quantizeQ8_0(float[] query, int dimensions, byte[] quants, float[] scales) {
+    int blocks = dimensions / GGUF_Q_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      int offset = block * GGUF_Q_BLOCK_SIZE;
+      float absoluteMax = 0.0f;
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
+        absoluteMax = Math.max(absoluteMax, Math.abs(query[offset + index]));
+      }
+
+      float scale = absoluteMax / 127.0f;
+      float inverseScale = absoluteMax == 0.0f ? 0.0f : 127.0f / absoluteMax;
+      scales[block] = Float.float16ToFloat(Float.floatToFloat16(scale));
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
+        quants[offset + index] = (byte) ggmlNearestInt(query[offset + index] * inverseScale);
+      }
+    }
+  }
+
+  private static int ggmlNearestInt(float value) {
+    int bits = Float.floatToRawIntBits(value + 12_582_912.0f);
+    return (bits & 0x007F_FFFF) - 0x0040_0000;
   }
 
   /**

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -162,6 +162,30 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0BatchDotProduct_quantizesEachQueryBlockUsingGgmlSemantics() {
+    float[] query = new float[32];
+    query[0] = 1.0f;
+    query[1] = 0.49f;
+    byte[] row0 = q4Block(1.0f, query, (lo, hi) -> 0x99);
+    byte[] row1 = q4Block(1.0f, query, (lo, hi) -> 0xAA);
+    float[] out = new float[2];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[query.length / 32];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+
+      VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+          query, segment, 2, query.length, out, q8Quants, q8Scales);
+
+      float q8Scale = Float.float16ToFloat(Float.floatToFloat16(1.0f / 127.0f));
+      assertThat(out[0]).isCloseTo(189.0f * q8Scale, within(1e-6f));
+      assertThat(out[1]).isCloseTo(378.0f * q8Scale, within(1e-6f));
+      assertThat(out[0]).isNotEqualTo(1.49f);
+    }
+  }
+
+  @Test
   void q8_0BatchDotProduct_respectsRowOffsets() {
     float[] query = ones(32);
     byte[] row0 = q8Block(1.0f);
@@ -182,6 +206,58 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0BatchDotProduct_quantizesEachQueryBlockUsingGgmlSemantics() {
+    float[] query = new float[32];
+    query[0] = 1.0f;
+    query[1] = 0.49f;
+    byte[] row0 = q8Block(1.0f, ignored -> 1);
+    byte[] row1 = q8Block(1.0f, ignored -> 2);
+    float[] out = new float[2];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[query.length / 32];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+
+      VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+          query, segment, 2, query.length, out, q8Quants, q8Scales);
+
+      float q8Scale = Float.float16ToFloat(Float.floatToFloat16(1.0f / 127.0f));
+      assertThat(out[0]).isCloseTo(189.0f * q8Scale, within(1e-6f));
+      assertThat(out[1]).isCloseTo(378.0f * q8Scale, within(1e-6f));
+      assertThat(out[0]).isNotEqualTo(1.49f);
+    }
+  }
+
+  @Test
+  void activationQuantizedBatchDotProducts_rejectUndersizedScratch() {
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment q4 = copy(arena, q4Block(1.0f, ones(32), null));
+      MemorySegment q8 = copy(arena, q8Block(1.0f));
+      MemorySegment q6 = copy(arena, q6KBlock(1.0f, ignored -> 1, ignored -> 1));
+
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+                      ones(32), q4, 1, 32, new float[1], new byte[31], new float[1]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("q8Quants.length");
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+                      ones(32), q8, 1, 32, new float[1], new byte[32], new float[0]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("q8Scales.length");
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+                      ones(256), q6, 1, 256, new float[1], new byte[255], new float[1]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("q8Quants.length");
+    }
+  }
+
+  @Test
   void q6_KBatchDotProduct_respectsRowOffsets() {
     float[] query = patternedQuery(256);
     byte[] row0 = q6KBlock(0.125f, i -> (i % 64) - 32, i -> (i % 7) - 3);
@@ -198,6 +274,29 @@ class GgufQuantizedDotTest {
           .isCloseTo(VectorUtil.ggufQ6_KDotProduct(query, segment, 0, 256), within(1e-5f));
       assertThat(out[1])
           .isCloseTo(VectorUtil.ggufQ6_KDotProduct(query, segment, 210, 256), within(1e-5f));
+    }
+  }
+
+  @Test
+  void q6_KQ8_KBatchDotProduct_quantizesTheQueryOnceUsingGgmlSemantics() {
+    float[] query = new float[256];
+    query[0] = 1.0f;
+    query[1] = 0.49f;
+    byte[] row0 = q6KBlock(1.0f, ignored -> 1, ignored -> 1);
+    byte[] row1 = q6KBlock(1.0f, ignored -> 2, ignored -> 1);
+    float[] out = new float[2];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[query.length / 256];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+
+      VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+          query, segment, 2, query.length, out, q8Quants, q8Scales);
+
+      assertThat(out[0]).isCloseTo(189.0f / 127.0f, within(1e-6f));
+      assertThat(out[1]).isCloseTo(378.0f / 127.0f, within(1e-6f));
+      assertThat(out[0]).isNotEqualTo(1.49f);
     }
   }
 
@@ -236,10 +335,14 @@ class GgufQuantizedDotTest {
   }
 
   private static byte[] q8Block(float scale) {
+    return q8Block(scale, i -> i - 16);
+  }
+
+  private static byte[] q8Block(float scale, IntUnaryOperator quantFactory) {
     byte[] block = new byte[34];
     ByteBuffer.wrap(block).order(ByteOrder.LITTLE_ENDIAN).putShort(0, Float.floatToFloat16(scale));
     for (int i = 0; i < 32; i++) {
-      block[2 + i] = (byte) (i - 16);
+      block[2 + i] = (byte) quantFactory.applyAsInt(i);
     }
     return block;
   }


### PR DESCRIPTION
## Summary
- add GGML-compatible Q4_0 x Q8_0, Q8_0 x Q8_0, and Q6_K x Q8_K mapped GEMV APIs
- keep activation scratch caller-owned for allocation-free model hot paths
- add reference tests, validation coverage, and a repeatable JMH comparison

## Verification
- `./gradlew :vectors-core:test :vectors-core:spotbugsMain :vectors-core:spotlessCheck :vectors-bench:jmhClasses :vectors-bench:spotlessCheck --no-daemon`
- focused JMH on JDK 25 / AVX2: Q4_0 2.852 -> 2.062 ms, Q6_K 5.143 -> 4.173 ms, Q8_0 2.862 -> 1.754 ms for 1024x2048 GEMV