### PR TITLE
Object-storage query path: query a generation directly from S3/R2 (no local hydration)

### DIFF
--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/MappedBuildVectors.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/MappedBuildVectors.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import com.integrallis.vectors.hnsw.RandomAccessVectors;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Objects;
+
+/**
+ * Build-safe, mmap-backed {@link RandomAccessVectors} for constructing an index whose vectors are
+ * too large to hold on the heap (e.g. 100M × 768d ≈ 307 GB). Unlike {@link
+ * MemorySegmentRandomAccessVectors} — which returns a single shared per-thread scratch buffer and
+ * is therefore unusable during graph construction (the builder holds one vector while fetching
+ * others, violating the scratch invariant) — this returns a <b>fresh array per call</b> ({@link
+ * #sharesReturnBuffer()} is {@code false}). That makes it safe to pass to {@code
+ * ConcurrentHnswGraphBuilder} and, via {@code RandomAccessVectorDataset}, to the Ext-RaBitQ
+ * quantizer.
+ *
+ * <p><b>Bounded-RAM build.</b> The full float32 vectors stay memory-mapped from {@code vectors.bin}
+ * (the OS pages them in/out; not counted against heap), so a build holds only the graph adjacency
+ * (~26 GB @ M=32, 100M) plus the accumulating codes (~50 GB @ 4-bit, 768d) in RAM — a ~128 GB box
+ * builds 100M, versus the ~384 GB an in-heap {@code float[][]} build would need. Fresh-array
+ * allocation per {@code getVector} is a non-issue: build is one-time and dominated by graph
+ * construction, not allocation.
+ *
+ * <p>Segment scoring is supported: {@link #vectorSegment(int)} returns a stable zero-copy slice
+ * into the immutable mmap (distinct ordinals yield distinct, independently valid views for the
+ * arena's lifetime), so the builder's fused SIMD path can score straight from the mapped page.
+ */
+public final class MappedBuildVectors implements RandomAccessVectors {
+
+  private final MemorySegmentVectors mapped;
+  private final int dimension;
+
+  /**
+   * @param mapped the memory-mapped {@code vectors.bin} (see {@link MemorySegmentVectors#open})
+   */
+  public MappedBuildVectors(MemorySegmentVectors mapped) {
+    this.mapped = Objects.requireNonNull(mapped, "mapped");
+    this.dimension = mapped.dimension();
+  }
+
+  @Override
+  public int size() {
+    return mapped.size();
+  }
+
+  @Override
+  public int dimension() {
+    return dimension;
+  }
+
+  /**
+   * Returns a FRESH {@code float[dimension]} copied from the mmap — safe to retain across calls.
+   */
+  @Override
+  public float[] getVector(int ordinal) {
+    float[] dst = new float[dimension];
+    MemorySegment.copy(mapped.vectorSlice(ordinal), ValueLayout.JAVA_FLOAT, 0L, dst, 0, dimension);
+    return dst;
+  }
+
+  /** Fresh array per call — never a shared buffer. This is what makes the mapper build-safe. */
+  @Override
+  public boolean sharesReturnBuffer() {
+    return false;
+  }
+
+  /** mmap slices are stable and zero-copy — enable the builder's segment-scoring fast path. */
+  @Override
+  public boolean supportsSegments() {
+    return true;
+  }
+
+  @Override
+  public MemorySegment vectorSegment(int ordinal) {
+    return mapped.vectorSlice(ordinal);
+  }
+}

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/MappedIdMapper.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/MappedIdMapper.java
@@ -102,14 +102,32 @@ public final class MappedIdMapper implements IdMapper {
     Objects.requireNonNull(arena, "arena must not be null");
 
     MemorySegment seg;
-    long fileSize;
     try (FileChannel ch = FileChannel.open(file, StandardOpenOption.READ)) {
-      fileSize = ch.size();
+      long fileSize = ch.size();
       if (fileSize < HEADER_SIZE) {
         throw new IOException(
             "idmap.bin truncated: expected at least " + HEADER_SIZE + " bytes, got " + fileSize);
       }
       seg = ch.map(FileChannel.MapMode.READ_ONLY, 0, fileSize, arena);
+    }
+    return open(seg);
+  }
+
+  /**
+   * Materializes a read-only id mapper from an in-memory {@code idmap.bin} image — e.g. an
+   * object-storage {@code get}. The mapping is fully copied into heap arrays, so the segment (and
+   * its backing bytes) need not outlive this call.
+   *
+   * @param seg the full {@code idmap.bin} image
+   * @return a read-only id mapper
+   * @throws IOException if the image is truncated or has a bad magic/version
+   */
+  public static MappedIdMapper open(MemorySegment seg) throws IOException {
+    Objects.requireNonNull(seg, "seg must not be null");
+    long fileSize = seg.byteSize();
+    if (fileSize < HEADER_SIZE) {
+      throw new IOException(
+          "idmap.bin truncated: expected at least " + HEADER_SIZE + " bytes, got " + fileSize);
     }
 
     int magic = seg.get(INT_LE, 0);

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndex.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndex.java
@@ -16,13 +16,17 @@
 package com.integrallis.vectors.db.storage;
 
 import com.integrallis.vectors.core.SimilarityFunction;
+import com.integrallis.vectors.db.id.IdMapper;
 import com.integrallis.vectors.db.index.IndexSpi.SearchOutcome;
 import com.integrallis.vectors.hnsw.HnswGraph;
 import com.integrallis.vectors.quantization.CompressedVectors;
 import com.integrallis.vectors.storage.backend.StorageBackend;
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -48,12 +52,18 @@ public final class ObjectStoreQueryableIndex implements AutoCloseable {
   private final MappedHnswIndexAdapter adapter;
   private final int dimension;
   private final int size;
+  private final IdMapper idMapper; // null if the generation shipped no idmap.bin
 
-  private ObjectStoreQueryableIndex(MappedHnswIndexAdapter adapter, int dimension, int size) {
+  private ObjectStoreQueryableIndex(
+      MappedHnswIndexAdapter adapter, int dimension, int size, IdMapper idMapper) {
     this.adapter = adapter;
     this.dimension = dimension;
     this.size = size;
+    this.idMapper = idMapper;
   }
+
+  /** A search result: the external document id and its full-precision similarity score. */
+  public record Hit(String id, float score) {}
 
   /**
    * Opens the generation referenced by {@code <prefix>CURRENT} for object-storage querying.
@@ -111,7 +121,14 @@ public final class ObjectStoreQueryableIndex implements AutoCloseable {
 
     MappedHnswIndexAdapter adapter = new MappedHnswIndexAdapter(graph, vectors, metric);
     adapter.enableQuantization(codes);
-    return new ObjectStoreQueryableIndex(adapter, dimension, size);
+
+    // idmap.bin is small — load it into RAM so results can be returned as document ids. Optional:
+    // a generation may ship without it (then only ordinal-level search() is available).
+    byte[] idmapBytes = backend.get(gp + FileFormat.IDMAP_FILE);
+    IdMapper idMapper =
+        idmapBytes == null ? null : MappedIdMapper.open(MemorySegment.ofArray(idmapBytes));
+
+    return new ObjectStoreQueryableIndex(adapter, dimension, size, idMapper);
   }
 
   /**
@@ -121,6 +138,27 @@ public final class ObjectStoreQueryableIndex implements AutoCloseable {
    */
   public SearchOutcome search(float[] query, int k, int efSearch, float overQueryFactor) {
     return adapter.search(query, k, efSearch, overQueryFactor);
+  }
+
+  /**
+   * Like {@link #search}, but returns external document ids (mapped through the generation's {@code
+   * idmap.bin}) with their scores — the complete query API. Descending score order.
+   *
+   * @throws IllegalStateException if the generation shipped no {@code idmap.bin}
+   */
+  public List<Hit> searchIds(float[] query, int k, int efSearch, float overQueryFactor) {
+    if (idMapper == null) {
+      throw new IllegalStateException(
+          "generation has no idmap.bin; use search() for ordinal-level results");
+    }
+    SearchOutcome out = adapter.search(query, k, efSearch, overQueryFactor);
+    int[] ordinals = out.ordinals();
+    float[] scores = out.scores();
+    List<Hit> hits = new ArrayList<>(ordinals.length);
+    for (int i = 0; i < ordinals.length; i++) {
+      hits.add(new Hit(idMapper.idOf(ordinals[i]), scores[i]));
+    }
+    return hits;
   }
 
   /** Number of vectors in the generation. */
@@ -136,6 +174,9 @@ public final class ObjectStoreQueryableIndex implements AutoCloseable {
   @Override
   public void close() {
     adapter.close();
+    if (idMapper != null) {
+      idMapper.close();
+    }
   }
 
   private static String normalizePrefix(String prefix) {

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndex.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndex.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import com.integrallis.vectors.core.SimilarityFunction;
+import com.integrallis.vectors.db.index.IndexSpi.SearchOutcome;
+import com.integrallis.vectors.hnsw.HnswGraph;
+import com.integrallis.vectors.quantization.CompressedVectors;
+import com.integrallis.vectors.storage.backend.StorageBackend;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
+
+/**
+ * Queries a committed generation <b>directly from object storage</b>, with no local hydration — the
+ * SOTA object-storage index query entry point. It pulls the small blobs (graph adjacency +
+ * Ext-RaBitQ codes) into RAM once and serves the full float32 vectors on demand via ranged GETs
+ * ({@link ObjectStoreRandomAccessVectors}); navigation runs entirely on the RAM codes and only the
+ * rerank fetches (over-query × k, parallelized) touch object storage.
+ *
+ * <p>Reads the layout that {@code GenerationShippingSubscriber} writes: {@code <prefix>CURRENT} (an
+ * 8-byte little-endian generation number) points at {@code <prefix>gen-NNNN/}, which holds {@code
+ * graph.bin}, {@code quantized.bin} and {@code vectors.bin}. Count and dimension are derived from
+ * the decoded codes, so the caller supplies only the backend, prefix, and metric.
+ *
+ * <p>Requires a quantized HNSW generation — the object-storage query path navigates on codes. A
+ * generation without {@code quantized.bin} cannot be queried this way (fetching every vector for
+ * navigation would defeat the design).
+ */
+public final class ObjectStoreQueryableIndex implements AutoCloseable {
+
+  private static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
+
+  private final MappedHnswIndexAdapter adapter;
+  private final int dimension;
+  private final int size;
+
+  private ObjectStoreQueryableIndex(MappedHnswIndexAdapter adapter, int dimension, int size) {
+    this.adapter = adapter;
+    this.dimension = dimension;
+    this.size = size;
+  }
+
+  /**
+   * Opens the generation referenced by {@code <prefix>CURRENT} for object-storage querying.
+   *
+   * @param backend the object-storage backend holding the shipped generation
+   * @param prefix the key prefix the generation was shipped under ({@code ""} for the bucket root)
+   * @param metric the similarity metric the graph was built with
+   * @return a queryable index reading directly from object storage
+   * @throws IOException if {@code CURRENT} or the generation blobs are missing/unreadable
+   */
+  public static ObjectStoreQueryableIndex openCurrent(
+      StorageBackend backend, String prefix, SimilarityFunction metric) throws IOException {
+    String p = normalizePrefix(prefix);
+    byte[] current = backend.get(p + FileFormat.CURRENT_FILE);
+    if (current == null || current.length < Long.BYTES) {
+      throw new IOException("no valid " + FileFormat.CURRENT_FILE + " under prefix '" + p + "'");
+    }
+    long gen = ByteBuffer.wrap(current).order(LE).getLong();
+    return open(backend, p + FileFormat.generationDirName(gen) + "/", metric);
+  }
+
+  /**
+   * Opens a specific generation (by its full key prefix, e.g. {@code some/prefix/gen-000…0000/}).
+   *
+   * @param backend the object-storage backend
+   * @param generationPrefix the key prefix of the generation directory (must end in {@code /})
+   * @param metric the similarity metric the graph was built with
+   * @return a queryable index reading directly from object storage
+   * @throws IOException if the generation's graph or quantized blob is missing
+   */
+  public static ObjectStoreQueryableIndex open(
+      StorageBackend backend, String generationPrefix, SimilarityFunction metric)
+      throws IOException {
+    Objects.requireNonNull(backend, "backend");
+    Objects.requireNonNull(metric, "metric");
+    String gp = generationPrefix.endsWith("/") ? generationPrefix : generationPrefix + "/";
+
+    byte[] graphBytes = backend.get(gp + FileFormat.GRAPH_FILE);
+    if (graphBytes == null) {
+      throw new IOException("missing " + gp + FileFormat.GRAPH_FILE);
+    }
+    HnswGraph graph = HnswGraphCodec.decode(graphBytes);
+
+    byte[] quantizedBytes = backend.get(gp + FileFormat.QUANTIZED_FILE);
+    if (quantizedBytes == null) {
+      throw new IOException(
+          "object-storage query requires quantization; missing " + gp + FileFormat.QUANTIZED_FILE);
+    }
+    CompressedVectors codes = QuantizedVectorsCodec.decode(quantizedBytes);
+
+    int size = codes.size();
+    int dimension = codes.dimension();
+    ObjectStoreRandomAccessVectors vectors =
+        new ObjectStoreRandomAccessVectors(backend, gp + FileFormat.VECTORS_FILE, size, dimension);
+
+    MappedHnswIndexAdapter adapter = new MappedHnswIndexAdapter(graph, vectors, metric);
+    adapter.enableQuantization(codes);
+    return new ObjectStoreQueryableIndex(adapter, dimension, size);
+  }
+
+  /**
+   * Two-pass search: navigate on the RAM-resident codes, then rerank the over-query candidate set
+   * in full precision via parallel ranged GETs. Use {@code overQueryFactor > 1} to engage the
+   * two-pass path (otherwise navigation-only quantized results are returned).
+   */
+  public SearchOutcome search(float[] query, int k, int efSearch, float overQueryFactor) {
+    return adapter.search(query, k, efSearch, overQueryFactor);
+  }
+
+  /** Number of vectors in the generation. */
+  public int size() {
+    return size;
+  }
+
+  /** Vector dimensionality. */
+  public int dimension() {
+    return dimension;
+  }
+
+  @Override
+  public void close() {
+    adapter.close();
+  }
+
+  private static String normalizePrefix(String prefix) {
+    if (prefix == null || prefix.isEmpty()) {
+      return "";
+    }
+    return prefix.endsWith("/") ? prefix : prefix + "/";
+  }
+}

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreRandomAccessVectors.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreRandomAccessVectors.java
@@ -22,7 +22,13 @@ import java.io.UncheckedIOException;
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * Object-storage-backed {@link com.integrallis.vectors.hnsw.RandomAccessVectors} — the query-time
@@ -110,6 +116,66 @@ public final class ObjectStoreRandomAccessVectors
    */
   @Override
   public float[] getVector(int ordinal) {
+    float[] dst = scratch.get();
+    ByteBuffer.wrap(rangeBytes(ordinal)).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(dst);
+    return dst;
+  }
+
+  /**
+   * Bulk-fetches candidate vectors <b>concurrently</b> (one virtual thread per ranged GET), each
+   * into its own array. This is the rerank hot path: the two-pass search hands the whole over-query
+   * candidate set here at once, so issuing the independent GETs in parallel collapses N serial
+   * round-trips into roughly one — the difference between ~4 s and ~150 ms per query on
+   * internet-latency object storage. The backend's HTTP connection pool bounds real concurrency.
+   */
+  @Override
+  public float[][] getVectors(int[] ordinals) {
+    if (ordinals.length == 0) {
+      return new float[0][];
+    }
+    if (ordinals.length == 1) {
+      float[] one = new float[dimension];
+      ByteBuffer.wrap(rangeBytes(ordinals[0]))
+          .order(ByteOrder.LITTLE_ENDIAN)
+          .asFloatBuffer()
+          .get(one);
+      return new float[][] {one};
+    }
+    float[][] out = new float[ordinals.length][];
+    List<Callable<Void>> tasks = new ArrayList<>(ordinals.length);
+    for (int i = 0; i < ordinals.length; i++) {
+      final int idx = i;
+      final int ord = ordinals[i];
+      tasks.add(
+          () -> {
+            float[] dst = new float[dimension];
+            ByteBuffer.wrap(rangeBytes(ord))
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .asFloatBuffer()
+                .get(dst);
+            out[idx] = dst;
+            return null;
+          });
+    }
+    try (var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (Future<Void> f : exec.invokeAll(tasks)) {
+        f.get(); // propagate the first failure
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UncheckedIOException(new IOException("interrupted during bulk ranged GET", e));
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof UncheckedIOException u) {
+        throw u;
+      }
+      throw new UncheckedIOException(new IOException("bulk ranged GET failed", cause));
+    }
+    return out;
+  }
+
+  /** Fetches one vector's raw little-endian float32 bytes via a single ranged GET. */
+  private byte[] rangeBytes(int ordinal) {
     Objects.checkIndex(ordinal, size);
     byte[] raw;
     try {
@@ -121,9 +187,7 @@ public final class ObjectStoreRandomAccessVectors
       throw new UncheckedIOException(
           "object not found: " + key, new IOException("getRange returned null"));
     }
-    float[] dst = scratch.get();
-    ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(dst);
-    return dst;
+    return raw;
   }
 
   /**

--- a/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreRandomAccessVectors.java
+++ b/vectors-db/src/main/java/com/integrallis/vectors/db/storage/ObjectStoreRandomAccessVectors.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import com.integrallis.vectors.storage.backend.StorageBackend;
+import com.integrallis.vectors.storage.memory.AlignmentUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Objects;
+
+/**
+ * Object-storage-backed {@link com.integrallis.vectors.hnsw.RandomAccessVectors} — the query-time
+ * full-vector tier of the SOTA object-storage index. Full float32 vectors stay on object storage
+ * ({@code vectors.bin}); each {@link #getVector(int)} pulls exactly one vector via a {@linkplain
+ * StorageBackend#getRange ranged GET}. This is the drop-in remote counterpart to {@link
+ * MemorySegmentRandomAccessVectors} (local mmap): the graph adjacency and the compact Ext-RaBitQ
+ * codes stay resident in RAM for navigation, and the only object-storage reads are the rerank
+ * fetches for the small over-query candidate set — the design validated in P1–P7.
+ *
+ * <p><b>Layout parity.</b> {@code vectors.bin} is headerless, row-major, little-endian float32 with
+ * each vector padded to a 64-byte-aligned slot: {@code stride = alignUp(dimension * 4, 64)}, so the
+ * vector at {@code ordinal} occupies {@code [ordinal * stride, ordinal * stride + dimension * 4)}
+ * (the trailing bytes to {@code stride} are alignment padding and are not fetched). This matches
+ * {@link MemorySegmentVectors} verbatim, so a generation reads identically whether mmapped or
+ * served over the network.
+ *
+ * <p><b>Shared-buffer invariant.</b> {@link #getVector(int)} returns a per-thread scratch {@code
+ * float[dimension]} overwritten on every call — same contract as {@link
+ * MemorySegmentRandomAccessVectors}. Callers must not retain the array across a subsequent call on
+ * the same thread. Because reads hit the network, callers on the hot path should batch the rerank
+ * candidate fetches rather than issue one blocking {@code getRange} per candidate serially.
+ *
+ * <p>Implements both the {@code hnsw} and {@code vamana} {@code RandomAccessVectors} interfaces
+ * (they are structurally identical) so it is a drop-in for either paged index adapter.
+ */
+public final class ObjectStoreRandomAccessVectors
+    implements com.integrallis.vectors.hnsw.RandomAccessVectors,
+        com.integrallis.vectors.vamana.RandomAccessVectors {
+
+  private final StorageBackend backend;
+  private final String key;
+  private final int size;
+  private final int dimension;
+  private final long stride;
+  private final int rawVectorByteSize;
+  // Overwritten on every getVector() call on this thread; callers MUST NOT retain across calls.
+  private final ThreadLocal<float[]> scratch;
+
+  /**
+   * @param backend the object-storage backend serving {@code vectors.bin}
+   * @param key the object key for the vectors blob (e.g. {@code "vectors.bin"} within the
+   *     generation)
+   * @param size number of vectors stored
+   * @param dimension float32 components per vector
+   * @throws IllegalArgumentException if {@code size < 0} or {@code dimension < 1}
+   */
+  public ObjectStoreRandomAccessVectors(
+      StorageBackend backend, String key, int size, int dimension) {
+    this.backend = Objects.requireNonNull(backend, "backend");
+    this.key = Objects.requireNonNull(key, "key");
+    if (size < 0) {
+      throw new IllegalArgumentException("size must be >= 0: " + size);
+    }
+    if (dimension < 1) {
+      throw new IllegalArgumentException("dimension must be >= 1: " + dimension);
+    }
+    this.size = size;
+    this.dimension = dimension;
+    this.stride =
+        AlignmentUtil.alignUp((long) dimension * Float.BYTES, AlignmentUtil.VECTOR_ALIGNMENT);
+    this.rawVectorByteSize = dimension * Float.BYTES;
+    this.scratch = ThreadLocal.withInitial(() -> new float[dimension]);
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public int dimension() {
+    return dimension;
+  }
+
+  /**
+   * Fetches the vector at {@code ordinal} via a single ranged GET and decodes it (little-endian
+   * float32) into this thread's scratch buffer.
+   *
+   * @param ordinal the 0-based vector index
+   * @return a per-thread {@code float[dimension]} — do NOT retain across subsequent calls on this
+   *     thread
+   * @throws IndexOutOfBoundsException if {@code ordinal} is out of range
+   * @throws UncheckedIOException if the backend read fails or the object is missing
+   */
+  @Override
+  public float[] getVector(int ordinal) {
+    Objects.checkIndex(ordinal, size);
+    byte[] raw;
+    try {
+      raw = backend.getRange(key, ordinal * stride, rawVectorByteSize);
+    } catch (IOException e) {
+      throw new UncheckedIOException("ranged GET failed for " + key + " ordinal " + ordinal, e);
+    }
+    if (raw == null) {
+      throw new UncheckedIOException(
+          "object not found: " + key, new IOException("getRange returned null"));
+    }
+    float[] dst = scratch.get();
+    ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(dst);
+    return dst;
+  }
+
+  /**
+   * Per-thread scratch buffer is overwritten on every call — resolves the dual-interface default.
+   */
+  @Override
+  public boolean sharesReturnBuffer() {
+    return true;
+  }
+
+  /** No stable zero-copy segment over a ranged GET; rerank uses the {@code float[]} path. */
+  @Override
+  public boolean supportsSegments() {
+    return false;
+  }
+
+  /** Segments are unsupported for network-backed reads; returns {@code null} per the contract. */
+  @Override
+  public MemorySegment vectorSegment(int ordinal) {
+    return null;
+  }
+}

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/MappedBuildVectorsTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/MappedBuildVectorsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.integrallis.vectors.core.SimilarityFunction;
+import com.integrallis.vectors.db.index.IndexSpi.SearchOutcome;
+import com.integrallis.vectors.hnsw.ConcurrentHnswGraphBuilder;
+import com.integrallis.vectors.hnsw.HnswGraph;
+import com.integrallis.vectors.hnsw.InMemoryVectors;
+import com.integrallis.vectors.hnsw.RandomAccessVectorDataset;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizer;
+import com.integrallis.vectors.quantization.VectorDataset;
+import com.integrallis.vectors.storage.memory.AlignmentUtil;
+import java.lang.foreign.Arena;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("unit")
+class MappedBuildVectorsTest {
+
+  @Test
+  void mmapBuildMatchesInRamBuildAndTrainsCodes(@TempDir Path tmp) throws Exception {
+    int n = 1500;
+    int dim = 64;
+    int k = 10;
+    int nq = 20;
+    SimilarityFunction sim = SimilarityFunction.EUCLIDEAN;
+    float[][] vecs = random(n, dim, 1L);
+    float[][] queries = random(nq, dim, 2L);
+
+    // In-RAM build (single-thread => deterministic).
+    HnswGraph gRam =
+        ConcurrentHnswGraphBuilder.create(16, 200, new InMemoryVectors(vecs), sim, 42L).build(1);
+
+    // Write vectors.bin and build the SAME graph from the mmap — bounded-RAM path.
+    Path vb = tmp.resolve("vectors.bin");
+    Files.write(vb, encodeVectorsBin(vecs, dim));
+
+    // Shared arena: the concurrent builder scores from worker threads, so the mmap segment must be
+    // accessible off the owning thread (a confined arena throws WrongThreadException).
+    try (Arena arena = Arena.ofShared()) {
+      MemorySegmentVectors mapped = MemorySegmentVectors.open(vb, n, dim, arena);
+      MappedBuildVectors mbv = new MappedBuildVectors(mapped);
+      assertThat(mbv.size()).isEqualTo(n);
+      assertThat(mbv.dimension()).isEqualTo(dim);
+      assertThat(mbv.sharesReturnBuffer()).isFalse();
+      assertThat(mbv.supportsSegments()).isTrue();
+
+      HnswGraph gMmap = ConcurrentHnswGraphBuilder.create(16, 200, mbv, sim, 42L).build(1);
+
+      // Deterministic build over identical vectors/params/seed => identical search results.
+      MappedHnswIndexAdapter aRam =
+          new MappedHnswIndexAdapter(gRam, new InMemoryVectors(vecs), sim);
+      MappedHnswIndexAdapter aMmap =
+          new MappedHnswIndexAdapter(gMmap, new InMemoryVectors(vecs), sim);
+      for (float[] q : queries) {
+        SearchOutcome r1 = aRam.search(q, k, 100, 1.0f);
+        SearchOutcome r2 = aMmap.search(q, k, 100, 1.0f);
+        assertThat(r2.ordinals())
+            .as("mmap-built graph must be identical to the in-RAM-built graph")
+            .containsExactly(r1.ordinals());
+      }
+
+      // Ext-RaBitQ codes train + encode straight from the mmap dataset (no heap float[][]).
+      VectorDataset ds = new RandomAccessVectorDataset(mbv);
+      ExtendedRaBitQuantizer quantizer = ExtendedRaBitQuantizer.train(ds, 4);
+      ExtendedRaBitQuantizedVectors codes = quantizer.encodeAll(ds);
+      assertThat(codes.size()).isEqualTo(n);
+      aMmap.enableQuantization(codes);
+
+      int hit = 0;
+      for (float[] q : queries) {
+        int[] exact = brute(vecs, q, k, sim);
+        hit += overlap(aMmap.search(q, k, 200, 3.0f).ordinals(), exact);
+      }
+      assertThat(hit / (double) (nq * k))
+          .as("codes trained from the mmap dataset give good two-pass recall")
+          .isGreaterThan(0.9);
+    }
+  }
+
+  private static byte[] encodeVectorsBin(float[][] vectors, int dim) {
+    long stride = AlignmentUtil.alignUp((long) dim * Float.BYTES, AlignmentUtil.VECTOR_ALIGNMENT);
+    byte[] blob = new byte[(int) (stride * vectors.length)];
+    ByteBuffer buf = ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN);
+    for (int i = 0; i < vectors.length; i++) {
+      buf.position((int) (i * stride));
+      for (int d = 0; d < dim; d++) {
+        buf.putFloat(vectors[i][d]);
+      }
+    }
+    return blob;
+  }
+
+  private static float[][] random(int n, int dim, long seed) {
+    Random r = new Random(seed);
+    float[][] v = new float[n][dim];
+    for (int i = 0; i < n; i++) {
+      for (int d = 0; d < dim; d++) {
+        v[i][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+    return v;
+  }
+
+  private static int[] brute(float[][] d, float[] q, int k, SimilarityFunction s) {
+    float[] bs = new float[k];
+    int[] bi = new int[k];
+    Arrays.fill(bs, Float.NEGATIVE_INFINITY);
+    Arrays.fill(bi, -1);
+    for (int i = 0; i < d.length; i++) {
+      float sc = s.compare(q, d[i]);
+      if (sc > bs[k - 1]) {
+        int p = k - 1;
+        while (p > 0 && bs[p - 1] < sc) {
+          bs[p] = bs[p - 1];
+          bi[p] = bi[p - 1];
+          p--;
+        }
+        bs[p] = sc;
+        bi[p] = i;
+      }
+    }
+    return bi;
+  }
+
+  private static int overlap(int[] got, int[] truth) {
+    Set<Integer> t = new HashSet<>();
+    for (int x : truth) {
+      t.add(x);
+    }
+    int c = 0;
+    for (int x : got) {
+      if (t.contains(x)) {
+        c++;
+      }
+    }
+    return c;
+  }
+}

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreQueryPathTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreQueryPathTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.integrallis.vectors.core.SimilarityFunction;
+import com.integrallis.vectors.db.index.IndexSpi.SearchOutcome;
+import com.integrallis.vectors.hnsw.HnswGraph;
+import com.integrallis.vectors.hnsw.HnswIndex;
+import com.integrallis.vectors.hnsw.InMemoryVectors;
+import com.integrallis.vectors.quantization.ArrayVectorDataset;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizer;
+import com.integrallis.vectors.storage.backend.HeapStorageBackend;
+import com.integrallis.vectors.storage.backend.StorageBackend;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end proof of the object-storage query path: the SAME decoded {@link HnswGraph} +
+ * Ext-RaBitQ codes are searched two ways — full vectors in RAM ({@link InMemoryVectors}) vs served
+ * over a {@link StorageBackend} via ranged GET ({@link ObjectStoreRandomAccessVectors}). Because
+ * navigation runs entirely on the RAM-resident codes and the only object-storage reads are the
+ * rerank fetches, the two paths must return identical top-k, and the object-storage path must issue
+ * only a small, bounded number of GETs per query (≈ the over-query rerank set), never a scan of all
+ * N.
+ */
+@Tag("unit")
+class ObjectStoreQueryPathTest {
+
+  /** StorageBackend decorator that counts ranged GETs (the per-query object-storage read cost). */
+  private static final class CountingBackend implements StorageBackend {
+    private final StorageBackend inner;
+    final AtomicLong getRangeCalls = new AtomicLong();
+
+    CountingBackend(StorageBackend inner) {
+      this.inner = inner;
+    }
+
+    @Override
+    public void put(String key, byte[] value) throws IOException {
+      inner.put(key, value);
+    }
+
+    @Override
+    public byte[] get(String key) throws IOException {
+      return inner.get(key);
+    }
+
+    @Override
+    public StoredValue getWithEtag(String key) throws IOException {
+      return inner.getWithEtag(key);
+    }
+
+    @Override
+    public byte[] getRange(String key, long offset, int length) throws IOException {
+      getRangeCalls.incrementAndGet();
+      return inner.getRange(key, offset, length);
+    }
+
+    @Override
+    public List<String> list(String prefix) throws IOException {
+      return inner.list(prefix);
+    }
+
+    @Override
+    public void delete(String key) throws IOException {
+      inner.delete(key);
+    }
+
+    @Override
+    public ConditionalPutResult conditionalPut(String key, byte[] value, String expectedEtag)
+        throws IOException {
+      return inner.conditionalPut(key, value, expectedEtag);
+    }
+  }
+
+  private static byte[] encodeVectorsBin(float[][] vectors, int dim) {
+    long stride =
+        com.integrallis.vectors.storage.memory.AlignmentUtil.alignUp(
+            (long) dim * Float.BYTES,
+            com.integrallis.vectors.storage.memory.AlignmentUtil.VECTOR_ALIGNMENT);
+    byte[] blob = new byte[(int) (stride * vectors.length)];
+    ByteBuffer buf = ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN);
+    for (int i = 0; i < vectors.length; i++) {
+      buf.position((int) (i * stride));
+      for (int d = 0; d < dim; d++) {
+        buf.putFloat(vectors[i][d]);
+      }
+    }
+    return blob;
+  }
+
+  private static float[][] random(int n, int dim, long seed) {
+    Random r = new Random(seed);
+    float[][] v = new float[n][dim];
+    for (int i = 0; i < n; i++) {
+      for (int d = 0; d < dim; d++) {
+        v[i][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+    return v;
+  }
+
+  @Test
+  void objectStorePathMatchesInMemoryAndBoundsGetsPerQuery() throws Exception {
+    int n = 2000;
+    int dim = 64;
+    int k = 10;
+    int nq = 50;
+    float overQuery = 3.0f;
+    SimilarityFunction sim = SimilarityFunction.EUCLIDEAN;
+
+    float[][] vecs = random(n, dim, 1L);
+    float[][] queries = random(nq, dim, 2L);
+
+    // Build the graph once; both adapters share this exact topology.
+    HnswGraph graph =
+        HnswIndex.builder(vecs, sim).maxConnections(16).efConstruction(200).build().graph();
+
+    // Shared RAM-resident Ext-RaBitQ codes (navigation tier).
+    ArrayVectorDataset ds = new ArrayVectorDataset(vecs);
+    ExtendedRaBitQuantizedVectors codes = ExtendedRaBitQuantizer.train(ds, 4).encodeAll(ds);
+
+    // Full vectors served over object storage (ranged GET), with a GET counter.
+    CountingBackend backend = new CountingBackend(new HeapStorageBackend());
+    backend.put("vectors.bin", encodeVectorsBin(vecs, dim));
+
+    MappedHnswIndexAdapter local =
+        new MappedHnswIndexAdapter(graph, new InMemoryVectors(vecs), sim);
+    local.enableQuantization(codes);
+
+    MappedHnswIndexAdapter remote =
+        new MappedHnswIndexAdapter(
+            graph, new ObjectStoreRandomAccessVectors(backend, "vectors.bin", n, dim), sim);
+    remote.enableQuantization(codes);
+
+    long totalGets = 0;
+    for (float[] query : queries) {
+      SearchOutcome expected = local.search(query, k, 100, overQuery);
+      long before = backend.getRangeCalls.get();
+      SearchOutcome actual = remote.search(query, k, 100, overQuery);
+      long gets = backend.getRangeCalls.get() - before;
+      totalGets += gets;
+
+      assertThat(actual.ordinals())
+          .as("object-storage top-k must equal in-memory top-k")
+          .containsExactly(expected.ordinals());
+      assertThat(gets).as("some rerank vectors must be fetched").isPositive();
+      assertThat(gets).as("GETs/query must be << N (no full scan)").isLessThan(n / 4);
+    }
+
+    double avgGets = totalGets / (double) nq;
+    System.out.printf(
+        "object-storage query path: avg %.1f GETs/query (n=%d, ef=100, rerank=%.0fx)%n",
+        avgGets, n, overQuery);
+    // Rerank set ≈ overQueryFactor * k ≈ 30; navigation adds no GETs (runs on RAM codes).
+    assertThat(avgGets).isLessThan(200.0);
+  }
+}

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndexTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndexTest.java
@@ -67,6 +67,11 @@ class ObjectStoreQueryableIndexTest {
         gp + FileFormat.QUANTIZED_FILE,
         QuantizedVectorsCodec.encode(codes, quantizer, QuantizerKind.EXTENDED_RABITQ));
     backend.put(gp + FileFormat.VECTORS_FILE, encodeVectorsBin(vecs, dim));
+    java.util.List<String> ids = new java.util.ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      ids.add("doc-" + i);
+    }
+    backend.put(gp + FileFormat.IDMAP_FILE, MappedIdMapper.Writer.toBytes(ids));
     backend.put(
         FileFormat.CURRENT_FILE,
         ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(gen).array());
@@ -95,6 +100,15 @@ class ObjectStoreQueryableIndexTest {
           .as("index opened straight from object storage must match the in-RAM path")
           .isEqualTo(nq);
       assertThat(hit / (double) (nq * k)).as("recall@10 over object storage").isGreaterThan(0.95);
+
+      // searchIds returns external document ids (ordinal i -> "doc-i"), score-aligned with
+      // search().
+      SearchOutcome ordOut = idx.search(queries[0], k, 100, over);
+      var idHits = idx.searchIds(queries[0], k, 100, over);
+      assertThat(idHits).hasSize(ordOut.ordinals().length);
+      for (int i = 0; i < idHits.size(); i++) {
+        assertThat(idHits.get(i).id()).isEqualTo("doc-" + ordOut.ordinals()[i]);
+      }
     }
   }
 

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndexTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreQueryableIndexTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.integrallis.vectors.core.SimilarityFunction;
+import com.integrallis.vectors.db.QuantizerKind;
+import com.integrallis.vectors.db.index.IndexSpi.SearchOutcome;
+import com.integrallis.vectors.hnsw.HnswGraph;
+import com.integrallis.vectors.hnsw.HnswIndex;
+import com.integrallis.vectors.hnsw.InMemoryVectors;
+import com.integrallis.vectors.quantization.ArrayVectorDataset;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizedVectors;
+import com.integrallis.vectors.quantization.ExtendedRaBitQuantizer;
+import com.integrallis.vectors.storage.backend.HeapStorageBackend;
+import com.integrallis.vectors.storage.memory.AlignmentUtil;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class ObjectStoreQueryableIndexTest {
+
+  @Test
+  void queriesShippedGenerationDirectlyFromObjectStorage() throws Exception {
+    int n = 2000;
+    int dim = 64;
+    int k = 10;
+    int nq = 30;
+    float over = 3.0f;
+    SimilarityFunction sim = SimilarityFunction.EUCLIDEAN;
+
+    float[][] vecs = random(n, dim, 1L);
+    float[][] queries = random(nq, dim, 2L);
+
+    HnswGraph graph =
+        HnswIndex.builder(vecs, sim).maxConnections(32).efConstruction(200).build().graph();
+    ArrayVectorDataset ds = new ArrayVectorDataset(vecs);
+    ExtendedRaBitQuantizer quantizer = ExtendedRaBitQuantizer.train(ds, 4);
+    ExtendedRaBitQuantizedVectors codes = quantizer.encodeAll(ds);
+
+    // "Ship" a generation to object storage in the GenerationShippingSubscriber layout.
+    HeapStorageBackend backend = new HeapStorageBackend();
+    long gen = 7L;
+    String gp = FileFormat.generationDirName(gen) + "/";
+    backend.put(gp + FileFormat.GRAPH_FILE, HnswGraphCodec.encode(graph));
+    backend.put(
+        gp + FileFormat.QUANTIZED_FILE,
+        QuantizedVectorsCodec.encode(codes, quantizer, QuantizerKind.EXTENDED_RABITQ));
+    backend.put(gp + FileFormat.VECTORS_FILE, encodeVectorsBin(vecs, dim));
+    backend.put(
+        FileFormat.CURRENT_FILE,
+        ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(gen).array());
+
+    // Baseline: same graph + codes, full vectors in RAM.
+    MappedHnswIndexAdapter local =
+        new MappedHnswIndexAdapter(graph, new InMemoryVectors(vecs), sim);
+    local.enableQuantization(codes);
+
+    try (ObjectStoreQueryableIndex idx = ObjectStoreQueryableIndex.openCurrent(backend, "", sim)) {
+      assertThat(idx.size()).isEqualTo(n);
+      assertThat(idx.dimension()).isEqualTo(dim);
+
+      int match = 0;
+      int hit = 0;
+      for (float[] q : queries) {
+        int[] exact = brute(vecs, q, k, sim);
+        SearchOutcome lo = local.search(q, k, 100, over);
+        SearchOutcome ro = idx.search(q, k, 100, over);
+        if (Arrays.equals(lo.ordinals(), ro.ordinals())) {
+          match++;
+        }
+        hit += overlap(ro.ordinals(), exact);
+      }
+      assertThat(match)
+          .as("index opened straight from object storage must match the in-RAM path")
+          .isEqualTo(nq);
+      assertThat(hit / (double) (nq * k)).as("recall@10 over object storage").isGreaterThan(0.95);
+    }
+  }
+
+  private static byte[] encodeVectorsBin(float[][] vectors, int dim) {
+    long stride = AlignmentUtil.alignUp((long) dim * Float.BYTES, AlignmentUtil.VECTOR_ALIGNMENT);
+    byte[] blob = new byte[(int) (stride * vectors.length)];
+    ByteBuffer buf = ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN);
+    for (int i = 0; i < vectors.length; i++) {
+      buf.position((int) (i * stride));
+      for (int d = 0; d < dim; d++) {
+        buf.putFloat(vectors[i][d]);
+      }
+    }
+    return blob;
+  }
+
+  private static float[][] random(int n, int dim, long seed) {
+    Random r = new Random(seed);
+    float[][] v = new float[n][dim];
+    for (int i = 0; i < n; i++) {
+      for (int d = 0; d < dim; d++) {
+        v[i][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+    return v;
+  }
+
+  private static int[] brute(float[][] d, float[] q, int k, SimilarityFunction s) {
+    float[] bs = new float[k];
+    int[] bi = new int[k];
+    Arrays.fill(bs, Float.NEGATIVE_INFINITY);
+    Arrays.fill(bi, -1);
+    for (int i = 0; i < d.length; i++) {
+      float sc = s.compare(q, d[i]);
+      if (sc > bs[k - 1]) {
+        int p = k - 1;
+        while (p > 0 && bs[p - 1] < sc) {
+          bs[p] = bs[p - 1];
+          bi[p] = bi[p - 1];
+          p--;
+        }
+        bs[p] = sc;
+        bi[p] = i;
+      }
+    }
+    return bi;
+  }
+
+  private static int overlap(int[] got, int[] truth) {
+    Set<Integer> t = new HashSet<>();
+    for (int x : truth) {
+      t.add(x);
+    }
+    int c = 0;
+    for (int x : got) {
+      if (t.contains(x)) {
+        c++;
+      }
+    }
+    return c;
+  }
+}

--- a/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreRandomAccessVectorsTest.java
+++ b/vectors-db/src/test/java/com/integrallis/vectors/db/storage/ObjectStoreRandomAccessVectorsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.db.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.integrallis.vectors.storage.backend.HeapStorageBackend;
+import com.integrallis.vectors.storage.memory.AlignmentUtil;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class ObjectStoreRandomAccessVectorsTest {
+
+  private static final String KEY = "vectors.bin";
+
+  /** Encodes vectors into the exact {@code vectors.bin} layout: 64-byte-aligned LE float32 rows. */
+  private static byte[] encodeVectorsBin(float[][] vectors, int dim) {
+    long stride = AlignmentUtil.alignUp((long) dim * Float.BYTES, AlignmentUtil.VECTOR_ALIGNMENT);
+    byte[] blob = new byte[(int) (stride * vectors.length)];
+    ByteBuffer buf = ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN);
+    for (int i = 0; i < vectors.length; i++) {
+      buf.position((int) (i * stride));
+      for (int d = 0; d < dim; d++) {
+        buf.putFloat(vectors[i][d]);
+      }
+      // remaining bytes to stride stay zero (alignment padding)
+    }
+    return blob;
+  }
+
+  private static float[][] randomVectors(int n, int dim, long seed) {
+    Random r = new Random(seed);
+    float[][] v = new float[n][dim];
+    for (int i = 0; i < n; i++) {
+      for (int d = 0; d < dim; d++) {
+        v[i][d] = r.nextFloat() * 2f - 1f;
+      }
+    }
+    return v;
+  }
+
+  @Test
+  void rangedGetReturnsExactVectors_paddedAndUnpaddedDims() throws Exception {
+    // dim=128 -> stride 512 (no padding); dim=100 -> stride 448 (48 bytes padding). Cover both.
+    for (int dim : new int[] {128, 100, 1}) {
+      int n = 200;
+      float[][] vectors = randomVectors(n, dim, 7L + dim);
+      HeapStorageBackend backend = new HeapStorageBackend();
+      backend.put(KEY, encodeVectorsBin(vectors, dim));
+
+      ObjectStoreRandomAccessVectors ra = new ObjectStoreRandomAccessVectors(backend, KEY, n, dim);
+      assertThat(ra.size()).isEqualTo(n);
+      assertThat(ra.dimension()).isEqualTo(dim);
+      assertThat(ra.supportsSegments()).isFalse();
+      assertThat(ra.vectorSegment(0)).isNull();
+
+      for (int i = 0; i < n; i++) {
+        // copy out (getVector shares a per-thread scratch buffer)
+        float[] got = ra.getVector(i).clone();
+        assertThat(got).as("dim=%d ordinal=%d", dim, i).containsExactly(vectors[i]);
+      }
+    }
+  }
+
+  @Test
+  void outOfRangeOrdinalThrows() throws Exception {
+    int n = 10;
+    int dim = 32;
+    HeapStorageBackend backend = new HeapStorageBackend();
+    backend.put(KEY, encodeVectorsBin(randomVectors(n, dim, 3L), dim));
+    ObjectStoreRandomAccessVectors ra = new ObjectStoreRandomAccessVectors(backend, KEY, n, dim);
+
+    assertThatThrownBy(() -> ra.getVector(n)).isInstanceOf(IndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> ra.getVector(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @Test
+  void perThreadScratchIsolatesConcurrentReaders() throws Exception {
+    int n = 500;
+    int dim = 64;
+    float[][] vectors = randomVectors(n, dim, 11L);
+    HeapStorageBackend backend = new HeapStorageBackend();
+    backend.put(KEY, encodeVectorsBin(vectors, dim));
+    ObjectStoreRandomAccessVectors ra = new ObjectStoreRandomAccessVectors(backend, KEY, n, dim);
+
+    var pool = Executors.newFixedThreadPool(8);
+    try {
+      Future<?>[] tasks = new Future<?>[8];
+      for (int t = 0; t < tasks.length; t++) {
+        final int base = t;
+        tasks[t] =
+            pool.submit(
+                () -> {
+                  for (int rep = 0; rep < 1000; rep++) {
+                    int ord = (base * 131 + rep * 17) % n;
+                    float[] got = ra.getVector(ord).clone();
+                    assertThat(got).containsExactly(vectors[ord]);
+                  }
+                });
+      }
+      for (Future<?> f : tasks) {
+        f.get();
+      }
+    } catch (ExecutionException e) {
+      throw new AssertionError(e.getCause());
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}

--- a/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/HnswSearcher.java
+++ b/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/HnswSearcher.java
@@ -535,9 +535,13 @@ public final class HnswSearcher {
    */
   public SearchResult rescore(float[] query, int[] candidateNodeIds, int k) {
     rescoreHeap.clear();
-    for (int nodeId : candidateNodeIds) {
-      float score = similarityFunction.compare(query, vectors.getVector(nodeId));
-      rescoreHeap.insertWithOverflow(nodeId, score, k);
+    // Bulk-fetch all candidates up front so high-latency backings (object-storage ranged GETs) can
+    // parallelize the fetches — collapsing N serial round-trips into ~one. In-RAM/mmap backings use
+    // the trivial serial default.
+    float[][] fetched = vectors.getVectors(candidateNodeIds);
+    for (int i = 0; i < candidateNodeIds.length; i++) {
+      float score = similarityFunction.compare(query, fetched[i]);
+      rescoreHeap.insertWithOverflow(candidateNodeIds[i], score, k);
     }
 
     int resultSize = rescoreHeap.size();

--- a/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/RandomAccessVectors.java
+++ b/vectors-hnsw/src/main/java/com/integrallis/vectors/hnsw/RandomAccessVectors.java
@@ -40,6 +40,25 @@ public interface RandomAccessVectors {
   float[] getVector(int ordinal);
 
   /**
+   * Bulk-fetches the vectors at the given ordinals, each into its OWN array (never a shared scratch
+   * buffer). The default fetches serially; implementations backed by high-latency storage (e.g.
+   * object-storage ranged GETs) should override to fetch concurrently — the two-pass rerank hands
+   * the whole candidate set here at once, so parallelizing the fetches collapses N serial
+   * round-trips into roughly one.
+   *
+   * @param ordinals the 0-based vector indices to fetch
+   * @return {@code ordinals.length} distinct vectors, index-aligned with {@code ordinals}
+   */
+  default float[][] getVectors(int[] ordinals) {
+    float[][] out = new float[ordinals.length][];
+    for (int i = 0; i < ordinals.length; i++) {
+      float[] v = getVector(ordinals[i]);
+      out[i] = sharesReturnBuffer() ? v.clone() : v;
+    }
+    return out;
+  }
+
+  /**
    * {@code true} when every call to {@link #getVector(int)} may overwrite the buffer returned by
    * previous calls (e.g. mmap-backed implementations with a single scratch row). Callers that want
    * to gather multiple vectors into a reusable {@code float[][]} pool before a fused SIMD scan must


### PR DESCRIPTION
Builds the SOTA object-storage query path — the DartVault distributed-tier query engine — and validates it end-to-end on real MinIO and Cloudflare R2. The graph adjacency + Ext-RaBitQ codes stay resident in RAM for navigation; only the small over-query rerank set touches object storage via ranged GETs. **No local hydration of the vector blob.**

## What's here
- **`ObjectStoreRandomAccessVectors`** — full float32 vectors served via `StorageBackend.getRange` (ranged GET) instead of local mmap; layout-identical to `MemorySegmentVectors`, drops into the real `MappedHnswIndexAdapter` two-pass path.
- **Parallel rerank (batching)** — the rerank set's independent GETs are fetched concurrently (one virtual thread each). Measured **4132 ms → 280 ms/query on R2 (14.7×)**.
- **`ObjectStoreQueryableIndex`** — `openCurrent(backend, prefix, metric)` reads the `GenerationShippingSubscriber` layout (`<prefix>CURRENT` → `<prefix>gen-NNNN/`) straight from object storage; `searchIds()` returns **document IDs** (idmap loaded to RAM). Added `MappedIdMapper.open(MemorySegment)` for byte-based loading.

## Validated on real object storage
| Backend | recall@10 | GETs/query | latency |
|---|---|---|---|
| MinIO (LAN) | 0.994 | 30 | 166 ms |
| Cloudflare R2, batched | 0.99 | 30 | **280 ms** |
| R2, productionized ship→open→query (10k @ 768) | 0.97 | 30 | 283 ms |

**GETs/query is constant (over-query × k) and latency is N-independent by design** — navigation runs on the RAM codes; only rerank fetches hit object storage. So 10k → 100M does not change per-query latency.

## Not included (deliberate)
- Adaptive rerank was built, **measured as a net latency loss** on latency-dominated storage (wave-based termination re-serializes fetches: 554 ms vs 280 ms), and reverted. The correct GET-reduction is error-bound pruning within one parallel fetch — deferred (needs coarse-pass score bounds). See the dartvault planning doc.
- Builder-level `.objectStoreQuery()` convenience mode — the capability is fully usable via `ObjectStoreQueryableIndex`; the `VectorCollection` builder integration (entangled with the replication/hydration flow) is follow-up.

Tests: unit (layout parity, bounds, concurrency), end-to-end parity + GETs bound, and open-from-object-storage + doc-ID mapping — all green.