### PR TITLE
feat(core): add GGUF Q4_K and Q5_0 kernels

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -54,11 +54,14 @@ public class GgufQuantizedMatVecBenchmark {
 
   private float[] query;
   private MemorySegment q4Weights;
+  private MemorySegment q4KWeights;
+  private MemorySegment q5Weights;
   private MemorySegment q8Weights;
   private MemorySegment q6Weights;
   private float[] out;
   private byte[] q8Quants;
   private float[] q8Scales;
+  private short[] q8Sums;
 
   @Setup(Level.Trial)
   public void setUp() {
@@ -69,14 +72,19 @@ public class GgufQuantizedMatVecBenchmark {
     }
 
     byte[] q4 = randomBlocks(random, rows * (cols / 32) * 18, 18, 0);
+    byte[] q4K = randomQ4KBlocks(random, rows * (cols / 256) * 144);
+    byte[] q5 = randomBlocks(random, rows * (cols / 32) * 22, 22, 0);
     byte[] q8 = randomBlocks(random, rows * (cols / 32) * 34, 34, 0);
     byte[] q6 = randomBlocks(random, rows * (cols / 256) * 210, 210, 208);
     q4Weights = MemorySegment.ofArray(q4);
+    q4KWeights = MemorySegment.ofArray(q4K);
+    q5Weights = MemorySegment.ofArray(q5);
     q8Weights = MemorySegment.ofArray(q8);
     q6Weights = MemorySegment.ofArray(q6);
     out = new float[rows];
     q8Quants = new byte[cols];
     q8Scales = new float[cols / 32];
+    q8Sums = new short[cols / 16];
   }
 
   @Benchmark
@@ -88,6 +96,31 @@ public class GgufQuantizedMatVecBenchmark {
   @Benchmark
   public void q4_0WithQ8_0Activation(Blackhole blackhole) {
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
+    blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q4_KWithF32Activation(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KBatchDotProduct(query, q4KWeights, rows, cols, out);
+    blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q4_KWithQ8_KActivation(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, q4KWeights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q5_0WithF32Activation(Blackhole blackhole) {
+    VectorUtil.ggufQ5_0BatchDotProduct(query, q5Weights, rows, cols, out);
+    blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q5_0WithQ8_0Activation(Blackhole blackhole) {
+    VectorUtil.ggufQ5_0Q8_0BatchDotProduct(query, q5Weights, rows, cols, out, q8Quants, q8Scales);
     blackhole.consume(out);
   }
 
@@ -123,6 +156,16 @@ public class GgufQuantizedMatVecBenchmark {
     short scale = Float.floatToFloat16(0.01f);
     for (int offset = 0; offset < byteCount; offset += blockBytes) {
       buffer.putShort(offset + scaleOffset, scale);
+    }
+    return blocks;
+  }
+
+  private static byte[] randomQ4KBlocks(Random random, int byteCount) {
+    byte[] blocks = randomBlocks(random, byteCount, 144, 0);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short minScale = Float.floatToFloat16(0.005f);
+    for (int offset = 0; offset < byteCount; offset += 144) {
+      buffer.putShort(offset + Short.BYTES, minScale);
     }
     return blocks;
   }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -214,6 +214,69 @@ public final class VectorUtil {
   }
 
   /**
+   * Dot product of a full-precision query with one GGUF Q4_K quantized row.
+   *
+   * <p>The operation fuses Q4_K dequantization and dot-product accumulation without allocating a
+   * temporary decoded row.
+   */
+  public static float ggufQ4_KDotProduct(
+      float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
+    checkGgufQuantizedDotArguments(
+        query,
+        qWeight,
+        byteOffset,
+        dimensions,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    return IMPL.ggufQ4_KDotProduct(query, qWeight, byteOffset, dimensions);
+  }
+
+  /** Dequantizes GGUF Q4_K blocks into a caller-owned float array. */
+  public static void ggufQ4_KDequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    Objects.requireNonNull(qWeight, "qWeight");
+    Objects.requireNonNull(out, "out");
+    if (byteOffset < 0) {
+      throw new IllegalArgumentException("byteOffset must be >= 0: " + byteOffset);
+    }
+    if (outOffset < 0 || dimensions < 0 || outOffset > out.length - dimensions) {
+      throw new IllegalArgumentException(
+          "out range is invalid: offset="
+              + outOffset
+              + ", dimensions="
+              + dimensions
+              + ", length="
+              + out.length);
+    }
+    if (dimensions % VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "GGUF Q4_K dimensions must be a multiple of 256: " + dimensions);
+    }
+    long required =
+        byteOffset
+            + ggufQuantizedRowBytes(
+                dimensions,
+                VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+                VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    if (required < byteOffset || required > qWeight.byteSize()) {
+      throw new IllegalArgumentException(
+          "qWeight byteSize is too small for requested values: "
+              + qWeight.byteSize()
+              + " < "
+              + required);
+    }
+    IMPL.ggufQ4_KDequantize(qWeight, byteOffset, out, outOffset, dimensions);
+  }
+
+  /** Dot product of a full-precision query with one GGUF Q5_0 quantized row. */
+  public static float ggufQ5_0DotProduct(
+      float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
+    checkGgufQuantizedDotArguments(
+        query, qWeight, byteOffset, dimensions, VectorUtilSupport.GGUF_Q5_0_BLOCK_BYTES);
+    return IMPL.ggufQ5_0DotProduct(query, qWeight, byteOffset, dimensions);
+  }
+
+  /**
    * Dot product of a full-precision query with one GGUF Q8_0 quantized row.
    *
    * <p>The operation fuses Q8_0 dequantization and dot-product accumulation without allocating a
@@ -273,6 +336,90 @@ public final class VectorUtil {
         query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
     IMPL.ggufQ4_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
+  }
+
+  /** Batched row-major GEMV over GGUF Q4_K rows. */
+  public static void ggufQ4_KBatchDotProduct(
+      float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    IMPL.ggufQ4_KMatVecDot(query, qWeight, rows, cols, out);
+  }
+
+  /**
+   * GGML-compatible GEMV over Q4_K rows using a Q8_K-quantized activation vector.
+   *
+   * <p>The query is quantized once per call into caller-owned scratch arrays, then reused for every
+   * matrix row. The 16-value sums carry Q8_K's block sums used by Q4_K's minimum correction.
+   *
+   * @param q8Quants scratch space with at least {@code cols} entries
+   * @param q8Scales scratch space with at least {@code cols / 256} entries
+   * @param q8Sums scratch space with at least {@code cols / 16} entries
+   */
+  public static void ggufQ4_KQ8_KBatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
+    Objects.requireNonNull(q8Sums, "q8Sums");
+    int requiredSums = cols / VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE;
+    if (q8Sums.length < requiredSums) {
+      throw new IllegalArgumentException(
+          "q8Sums.length must be >= dimensions / "
+              + VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE
+              + ": "
+              + q8Sums.length
+              + " < "
+              + requiredSums);
+    }
+    IMPL.ggufQ4_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
+  }
+
+  /** Batched row-major GEMV over GGUF Q5_0 rows. */
+  public static void ggufQ5_0BatchDotProduct(
+      float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
+    checkGgufQuantizedBatchArguments(
+        query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q5_0_BLOCK_BYTES);
+    IMPL.ggufQ5_0MatVecDot(query, qWeight, rows, cols, out);
+  }
+
+  /**
+   * GGML-compatible GEMV over Q5_0 rows using a Q8_0-quantized activation vector.
+   *
+   * @param q8Quants scratch space with at least {@code cols} entries
+   * @param q8Scales scratch space with at least {@code cols / 32} entries
+   */
+  public static void ggufQ5_0Q8_0BatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q5_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ5_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
   }
 
   /** Batched row-major GEMV over GGUF Q8_0 rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -30,11 +30,18 @@ public interface VectorUtilSupport {
 
   ValueLayout.OfShort GGUF_LE_SHORT =
       ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+  ValueLayout.OfInt GGUF_LE_INT = ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
   ValueLayout.OfFloat GGUF_LE_FLOAT =
       ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
   int GGUF_Q_BLOCK_SIZE = 32;
   int GGUF_Q4_0_BLOCK_BYTES = 18;
+  int GGUF_Q5_0_BLOCK_BYTES = 22;
   int GGUF_Q8_0_BLOCK_BYTES = 34;
+  int GGUF_Q4_K_BLOCK_SIZE = 256;
+  int GGUF_Q4_K_BLOCK_BYTES = 144;
+  int GGUF_Q4_K_SCALES_OFFSET = 4;
+  int GGUF_Q4_K_QUANTS_OFFSET = 16;
+  int GGUF_Q8_K_SUM_BLOCK_SIZE = 16;
   int GGUF_Q6_K_BLOCK_SIZE = 256;
   int GGUF_Q6_K_BLOCK_BYTES = 210;
   int GGUF_Q6_K_QL_BYTES = 128;
@@ -207,6 +214,105 @@ public interface VectorUtilSupport {
   }
 
   /**
+   * Dot product of a full-precision query with one GGUF Q4_K quantized row.
+   *
+   * <p>Each 256-value super-block stores binary16 scale and minimum factors, eight packed 6-bit
+   * scale/minimum pairs, and eight groups of 32 unsigned 4-bit quants. This follows GGML's Q4_K
+   * layout and fuses dequantization with accumulation.
+   */
+  default float ggufQ4_KDotProduct(
+      float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
+    checkGgufQ4_KBlockAligned(dimensions);
+    float sum = 0.0f;
+    int blocks = dimensions / GGUF_Q4_K_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float dMin = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int queryOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = q4KScale(qWeight, scalesOffset, group);
+        int min = q4KMin(qWeight, scalesOffset, group);
+        float scaledD = d * scale;
+        float minimum = dMin * min;
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int groupQueryOffset = queryOffset + group * 32;
+
+        for (int index = 0; index < 32; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+          int quant = (packed >>> shift) & 0x0F;
+          float weight = scaledD * quant - minimum;
+          sum = MathUtil.fma(query[groupQueryOffset + index], weight, sum);
+        }
+      }
+    }
+    return sum;
+  }
+
+  /** Dequantizes GGUF Q4_K blocks into a caller-owned float array. */
+  default void ggufQ4_KDequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    checkGgufQ4_KBlockAligned(dimensions);
+    int blocks = dimensions / GGUF_Q4_K_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float dMin = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int outputOffset = outOffset + block * GGUF_Q4_K_BLOCK_SIZE;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = q4KScale(qWeight, scalesOffset, group);
+        int min = q4KMin(qWeight, scalesOffset, group);
+        float scaledD = d * scale;
+        float minimum = dMin * min;
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int groupOutputOffset = outputOffset + group * 32;
+
+        for (int index = 0; index < 32; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+          int quant = (packed >>> shift) & 0x0F;
+          out[groupOutputOffset + index] = scaledD * quant - minimum;
+        }
+      }
+    }
+  }
+
+  /**
+   * Dot product of a full-precision query with one GGUF Q5_0 quantized row.
+   *
+   * <p>Each 32-value block stores a binary16 scale, a 32-bit high-bit mask, and 16 split low
+   * nibbles. The reconstructed unsigned 5-bit value is centered by subtracting 16.
+   */
+  default float ggufQ5_0DotProduct(
+      float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
+    checkGgufBlockAligned(dimensions);
+    float sum = 0.0f;
+    int blocks = dimensions / GGUF_Q_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+      long quantsOffset = blockOffset + Short.BYTES + Integer.BYTES;
+      int queryOffset = block * GGUF_Q_BLOCK_SIZE;
+      for (int index = 0; index < 16; index++) {
+        int packed = qWeight.get(ValueLayout.JAVA_BYTE, quantsOffset + index) & 0xFF;
+        int low = (packed & 0x0F) | (((highBits >>> index) & 1) << 4);
+        int high = (packed >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
+        sum = MathUtil.fma(query[queryOffset + index], (low - 16) * scale, sum);
+        sum = MathUtil.fma(query[queryOffset + index + 16], (high - 16) * scale, sum);
+      }
+    }
+    return sum;
+  }
+
+  /**
    * Dot product of a full-precision query with one GGUF Q8_0 quantized row.
    *
    * <p>Q8_0 stores each 32-value block as a little-endian binary16 scale followed by 32 signed int8
@@ -325,6 +431,116 @@ public interface VectorUtilSupport {
           int hi = ((packed >>> 4) & 0x0F) - 8;
           integerSum += lo * q8Quants[quantOffset + index];
           integerSum += hi * q8Quants[quantOffset + index + 16];
+        }
+        sum = MathUtil.fma(scale, integerSum, sum);
+      }
+      out[row] = sum;
+    }
+  }
+
+  /** Batched row-major GEMV over GGUF Q4_K rows. */
+  default void ggufQ4_KMatVecDot(
+      float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
+    long rowBytes = ggufQ4_KRowBytes(cols);
+    for (int row = 0; row < rows; row++) {
+      out[row] = ggufQ4_KDotProduct(query, qWeight, row * rowBytes, cols);
+    }
+  }
+
+  /** GGML-compatible Q4_K by Q8_K GEMV. The activation is quantized once and reused across rows. */
+  default void ggufQ4_KQ8_KMatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = ggufQ4_KRowBytes(cols);
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    for (int row = 0; row < rows; row++) {
+      float sum = 0.0f;
+      long rowOffset = row * rowBytes;
+
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+        float q8Scale = q8Scales[block];
+        float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+        float dMin =
+            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+        long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+        long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+        int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+        int quantizedSum = 0;
+        int minimumSum = 0;
+
+        for (int group = 0; group < 8; group++) {
+          int scale = q4KScale(qWeight, scalesOffset, group);
+          int min = q4KMin(qWeight, scalesOffset, group);
+          long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+          int shift = (group & 1) * 4;
+          int groupActivationOffset = activationOffset + group * 32;
+          int groupDot = 0;
+
+          for (int index = 0; index < 32; index++) {
+            int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+            int quant = (packed >>> shift) & 0x0F;
+            groupDot += quant * q8Quants[groupActivationOffset + index];
+          }
+          quantizedSum += scale * groupDot;
+          int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+          minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+        }
+
+        sum = MathUtil.fma(d, quantizedSum, sum);
+        sum = MathUtil.fma(-dMin, minimumSum, sum);
+      }
+      out[row] = sum;
+    }
+  }
+
+  /** Batched row-major GEMV over GGUF Q5_0 rows. */
+  default void ggufQ5_0MatVecDot(
+      float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
+    long rowBytes = ggufQ5_0RowBytes(cols);
+    for (int row = 0; row < rows; row++) {
+      out[row] = ggufQ5_0DotProduct(query, qWeight, row * rowBytes, cols);
+    }
+  }
+
+  /** GGML-compatible Q5_0 by Q8_0 GEMV. The activation is quantized once and reused across rows. */
+  default void ggufQ5_0Q8_0MatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ5_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int row = 0; row < rows; row++) {
+      float sum = 0.0f;
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+        float scale =
+            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+        int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+        long quantsOffset = blockOffset + Short.BYTES + Integer.BYTES;
+        int activationOffset = block * GGUF_Q_BLOCK_SIZE;
+        int integerSum = 0;
+        for (int index = 0; index < 16; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, quantsOffset + index) & 0xFF;
+          int low = (packed & 0x0F) | (((highBits >>> index) & 1) << 4);
+          int high = (packed >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
+          integerSum += (low - 16) * q8Quants[activationOffset + index];
+          integerSum += (high - 16) * q8Quants[activationOffset + index + 16];
         }
         sum = MathUtil.fma(scale, integerSum, sum);
       }
@@ -630,14 +846,31 @@ public interface VectorUtilSupport {
     }
   }
 
+  private static void checkGgufQ4_KBlockAligned(int dimensions) {
+    if (dimensions % GGUF_Q4_K_BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "GGUF Q4_K dimensions must be a multiple of 256: " + dimensions);
+    }
+  }
+
   private static long ggufQ4_0RowBytes(int dimensions) {
     checkGgufBlockAligned(dimensions);
     return (long) (dimensions / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
   }
 
+  private static long ggufQ5_0RowBytes(int dimensions) {
+    checkGgufBlockAligned(dimensions);
+    return (long) (dimensions / GGUF_Q_BLOCK_SIZE) * GGUF_Q5_0_BLOCK_BYTES;
+  }
+
   private static long ggufQ8_0RowBytes(int dimensions) {
     checkGgufBlockAligned(dimensions);
     return (long) (dimensions / GGUF_Q_BLOCK_SIZE) * GGUF_Q8_0_BLOCK_BYTES;
+  }
+
+  private static long ggufQ4_KRowBytes(int dimensions) {
+    checkGgufQ4_KBlockAligned(dimensions);
+    return (long) (dimensions / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
   }
 
   private static long ggufQ6_KRowBytes(int dimensions) {
@@ -646,6 +879,11 @@ public interface VectorUtilSupport {
   }
 
   private static void quantizeQ8_K(float[] query, int dimensions, byte[] quants, float[] scales) {
+    quantizeQ8_K(query, dimensions, quants, scales, null);
+  }
+
+  private static void quantizeQ8_K(
+      float[] query, int dimensions, byte[] quants, float[] scales, short[] sums) {
     int blocks = dimensions / GGUF_Q6_K_BLOCK_SIZE;
     for (int block = 0; block < blocks; block++) {
       int offset = block * GGUF_Q6_K_BLOCK_SIZE;
@@ -662,17 +900,51 @@ public interface VectorUtilSupport {
 
       if (absoluteMax == 0.0f) {
         java.util.Arrays.fill(quants, offset, offset + GGUF_Q6_K_BLOCK_SIZE, (byte) 0);
+        if (sums != null) {
+          java.util.Arrays.fill(
+              sums,
+              offset / GGUF_Q8_K_SUM_BLOCK_SIZE,
+              (offset + GGUF_Q6_K_BLOCK_SIZE) / GGUF_Q8_K_SUM_BLOCK_SIZE,
+              (short) 0);
+        }
         scales[block] = 0.0f;
         continue;
       }
 
       float inverseScale = -127.0f / max;
+      int sum = 0;
       for (int index = 0; index < GGUF_Q6_K_BLOCK_SIZE; index++) {
         int quant = ggmlNearestInt(inverseScale * query[offset + index]);
-        quants[offset + index] = (byte) Math.min(127, quant);
+        byte stored = (byte) Math.min(127, quant);
+        quants[offset + index] = stored;
+        if (sums != null) {
+          sum += stored;
+          if ((index + 1) % GGUF_Q8_K_SUM_BLOCK_SIZE == 0) {
+            sums[(offset + index) / GGUF_Q8_K_SUM_BLOCK_SIZE] = (short) sum;
+            sum = 0;
+          }
+        }
       }
       scales[block] = 1.0f / inverseScale;
     }
+  }
+
+  private static int q4KScale(MemorySegment qWeight, long scalesOffset, int group) {
+    if (group < 4) {
+      return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0x3F;
+    }
+    int low = qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x0F;
+    int high = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group - 4L) & 0xFF) >>> 6;
+    return low | (high << 4);
+  }
+
+  private static int q4KMin(MemorySegment qWeight, long scalesOffset, int group) {
+    if (group < 4) {
+      return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x3F;
+    }
+    int low = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0xFF) >>> 4;
+    int high = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0xFF) >>> 6;
+    return low | (high << 4);
   }
 
   private static void quantizeQ8_0(float[] query, int dimensions, byte[] quants, float[] scales) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -142,6 +142,72 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KDotProduct_matchesDecodedReferenceWithPackedScalesAndMins() {
+    float[] query = patternedQuery(256);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] block = q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins);
+
+    float expected = 0f;
+    for (int i = 0; i < query.length; i++) {
+      int group = i / 32;
+      float weight = 0.125f * scales[group] * (i % 16) - 0.0625f * mins[group];
+      expected = Math.fma(query[i], weight, expected);
+    }
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      float actual = VectorUtil.ggufQ4_KDotProduct(query, segment, 0, query.length);
+
+      assertThat(actual).isCloseTo(expected, within(1e-4f));
+    }
+  }
+
+  @Test
+  void q4_KDequantize_matchesDecodedReferenceAtOutputOffset() {
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] block = q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins);
+    float[] decoded = new float[258];
+    decoded[0] = 99.0f;
+    decoded[257] = 98.0f;
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      VectorUtil.ggufQ4_KDequantize(segment, 0, decoded, 1, 256);
+    }
+
+    assertThat(decoded[0]).isEqualTo(99.0f);
+    assertThat(decoded[257]).isEqualTo(98.0f);
+    for (int index = 0; index < 256; index++) {
+      int group = index / 32;
+      float expected = 0.125f * scales[group] * (index % 16) - 0.0625f * mins[group];
+      assertThat(decoded[index + 1]).isCloseTo(expected, within(1e-6f));
+    }
+  }
+
+  @Test
+  void q5_0DotProduct_matchesDecodedReferenceWithHighBitMask() {
+    float[] query = patternedQuery(32);
+    byte[] block = q5Block(0.25f, i -> (i * 7) % 32 - 16);
+
+    float expected = 0.0f;
+    for (int i = 0; i < query.length; i++) {
+      expected = Math.fma(query[i], 0.25f * ((i * 7) % 32 - 16), expected);
+    }
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      float actual = VectorUtil.ggufQ5_0DotProduct(query, segment, 0, query.length);
+
+      assertThat(actual).isCloseTo(expected, within(1e-5f));
+    }
+  }
+
+  @Test
   void q4_0BatchDotProduct_respectsRowOffsets() {
     float[] query = ones(32);
     byte[] row0 = q4Block(1.0f, query, (lo, hi) -> 0x98);
@@ -233,6 +299,10 @@ class GgufQuantizedDotTest {
   void activationQuantizedBatchDotProducts_rejectUndersizedScratch() {
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment q4 = copy(arena, q4Block(1.0f, ones(32), null));
+      MemorySegment q4K =
+          copy(
+              arena,
+              q4KBlock(1.0f, 0.0f, ignored -> 1, new int[] {1, 1, 1, 1, 1, 1, 1, 1}, new int[8]));
       MemorySegment q8 = copy(arena, q8Block(1.0f));
       MemorySegment q6 = copy(arena, q6KBlock(1.0f, ignored -> 1, ignored -> 1));
 
@@ -254,6 +324,19 @@ class GgufQuantizedDotTest {
                       ones(256), q6, 1, 256, new float[1], new byte[255], new float[1]))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("q8Quants.length");
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+                      ones(256),
+                      q4K,
+                      1,
+                      256,
+                      new float[1],
+                      new byte[256],
+                      new float[1],
+                      new short[15]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("q8Sums.length");
     }
   }
 
@@ -301,10 +384,93 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KQ8_KBatchDotProduct_quantizesTheQueryOnceUsingGgmlSemantics() {
+    float[] query = new float[256];
+    query[0] = 1.0f;
+    query[1] = 0.49f;
+    int[] unitScales = {1, 1, 1, 1, 1, 1, 1, 1};
+    int[] zeroMins = new int[8];
+    byte[] row0 = q4KBlock(1.0f, 0.0f, ignored -> 1, unitScales, zeroMins);
+    byte[] row1 = q4KBlock(1.0f, 0.0f, ignored -> 2, unitScales, zeroMins);
+    float[] out = new float[2];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[query.length / 256];
+    short[] q8Sums = new short[query.length / 16];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+
+      VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+          query, segment, 2, query.length, out, q8Quants, q8Scales, q8Sums);
+
+      assertThat(out[0]).isCloseTo(189.0f / 127.0f, within(1e-6f));
+      assertThat(out[1]).isCloseTo(378.0f / 127.0f, within(1e-6f));
+      assertThat(out[0]).isNotEqualTo(1.49f);
+    }
+  }
+
+  @Test
+  void q4_KQ8_KBatchDotProduct_matchesDequantizedReferenceWithMins() {
+    float[] query = patternedQuery(256);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] row = q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins);
+    float[] out = new float[1];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[1];
+    short[] q8Sums = new short[16];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, row);
+
+      VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+          query, segment, 1, query.length, out, q8Quants, q8Scales, q8Sums);
+    }
+
+    float expected = 0.0f;
+    for (int index = 0; index < query.length; index++) {
+      int group = index / 32;
+      float weight = 0.125f * scales[group] * (index % 16) - 0.0625f * mins[group];
+      float activation = q8Scales[0] * q8Quants[index];
+      expected = Math.fma(weight, activation, expected);
+    }
+    assertThat(out[0]).isCloseTo(expected, within(1e-3f));
+  }
+
+  @Test
+  void q5_0Q8_0BatchDotProduct_quantizesTheQueryOnceUsingGgmlSemantics() {
+    float[] query = new float[32];
+    query[0] = 1.0f;
+    query[1] = 0.49f;
+    byte[] row0 = q5Block(1.0f, ignored -> 1);
+    byte[] row1 = q5Block(1.0f, ignored -> 2);
+    float[] out = new float[2];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[query.length / 32];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+
+      VectorUtil.ggufQ5_0Q8_0BatchDotProduct(
+          query, segment, 2, query.length, out, q8Quants, q8Scales);
+
+      float q8Scale = Float.float16ToFloat(Float.floatToFloat16(1.0f / 127.0f));
+      assertThat(out[0]).isCloseTo(189.0f * q8Scale, within(1e-6f));
+      assertThat(out[1]).isCloseTo(378.0f * q8Scale, within(1e-6f));
+      assertThat(out[0]).isNotEqualTo(1.49f);
+    }
+  }
+
+  @Test
   void quantizedDotRejectsNonBlockAlignedDimensions() {
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment q4 = copy(arena, q4Block(1.0f, ones(32), null));
+      MemorySegment q4K =
+          copy(
+              arena,
+              q4KBlock(1.0f, 0.0f, ignored -> 1, new int[] {1, 1, 1, 1, 1, 1, 1, 1}, new int[8]));
       MemorySegment q8 = copy(arena, q8Block(1.0f));
+      MemorySegment q5 = copy(arena, q5Block(1.0f, ignored -> 1));
       MemorySegment q6 = copy(arena, q6KBlock(1.0f, i -> 0, i -> 1));
 
       assertThatThrownBy(() -> VectorUtil.ggufQ4_0DotProduct(ones(31), q4, 0, 31))
@@ -313,7 +479,13 @@ class GgufQuantizedDotTest {
       assertThatThrownBy(() -> VectorUtil.ggufQ8_0DotProduct(ones(31), q8, 0, 31))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("multiple of 32");
+      assertThatThrownBy(() -> VectorUtil.ggufQ5_0DotProduct(ones(31), q5, 0, 31))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("multiple of 32");
       assertThatThrownBy(() -> VectorUtil.ggufQ6_KDotProduct(ones(255), q6, 0, 255))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("multiple of 256");
+      assertThatThrownBy(() -> VectorUtil.ggufQ4_KDotProduct(ones(255), q4K, 0, 255))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("multiple of 256");
     }
@@ -344,6 +516,22 @@ class GgufQuantizedDotTest {
     for (int i = 0; i < 32; i++) {
       block[2 + i] = (byte) quantFactory.applyAsInt(i);
     }
+    return block;
+  }
+
+  private static byte[] q5Block(float scale, IntUnaryOperator quantFactory) {
+    byte[] block = new byte[22];
+    ByteBuffer buffer = ByteBuffer.wrap(block).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putShort(0, Float.floatToFloat16(scale));
+    int highBits = 0;
+    for (int index = 0; index < 16; index++) {
+      int lowQuant = quantFactory.applyAsInt(index) + 16;
+      int highQuant = quantFactory.applyAsInt(index + 16) + 16;
+      block[6 + index] = (byte) ((lowQuant & 0x0F) | ((highQuant & 0x0F) << 4));
+      highBits |= ((lowQuant >>> 4) & 1) << index;
+      highBits |= ((highQuant >>> 4) & 1) << (index + 16);
+    }
+    buffer.putInt(2, highBits);
     return block;
   }
 
@@ -383,6 +571,34 @@ class GgufQuantizedDotTest {
                     | (((q2 >>> 4) & 0x03) << 2)
                     | (((q3 >>> 4) & 0x03) << 4)
                     | (((q4 >>> 4) & 0x03) << 6));
+      }
+    }
+    return block;
+  }
+
+  private static byte[] q4KBlock(
+      float scale, float minScale, IntUnaryOperator quantFactory, int[] scales, int[] mins) {
+    byte[] block = new byte[144];
+    ByteBuffer buffer = ByteBuffer.wrap(block).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putShort(0, Float.floatToFloat16(scale));
+    buffer.putShort(2, Float.floatToFloat16(minScale));
+
+    for (int group = 0; group < 4; group++) {
+      block[4 + group] = (byte) scales[group];
+      block[8 + group] = (byte) mins[group];
+    }
+    for (int group = 4; group < 8; group++) {
+      block[4 + group + 4] = (byte) ((scales[group] & 0x0F) | ((mins[group] & 0x0F) << 4));
+      block[4 + group - 4] |= (byte) ((scales[group] >>> 4) << 6);
+      block[4 + group] |= (byte) ((mins[group] >>> 4) << 6);
+    }
+
+    for (int group = 0; group < 8; group++) {
+      int byteOffset = 16 + (group >>> 1) * 32;
+      int shift = (group & 1) * 4;
+      for (int index = 0; index < 32; index++) {
+        block[byteOffset + index] |=
+            (byte) ((quantFactory.applyAsInt(group * 32 + index) & 0x0F) << shift);
       }
     }
     return block;


### PR DESCRIPTION
## Summary

- add GGUF Q4_K direct, dequantization, and Q8_K-activation GEMV APIs
- add GGUF Q5_0 direct and Q8_0-activation GEMV APIs
- add caller-owned Q8_K block sums and mixed-quant benchmarks
- cover packed scales/minima, high-bit masks, row offsets, and scratch validation

## Why

Mixed Q4_K_M model files use several tensor encodings. These kernels let the pure-Java models backend execute those files without materializing full F32 matrices.

## Validation

- `./gradlew :vectors-core:test`
- `./gradlew :vectors-core:spotbugsMain`
- `./gradlew :vectors-core:spotlessCheck`
- `./gradlew :vectors-bench:jmhClasses`
- quick JMH: Q4_K with Q8_K activations was about 31% faster than the F32-activation path at 1024x2048 on Intel AVX2
