### PR TITLE
feat(core): add GGUF Q6_K dequantization

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -307,6 +307,43 @@ public final class VectorUtil {
     return IMPL.ggufQ6_KDotProduct(query, qWeight, byteOffset, dimensions);
   }
 
+  /** Dequantizes GGUF Q6_K blocks into a caller-owned float array. */
+  public static void ggufQ6_KDequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    Objects.requireNonNull(qWeight, "qWeight");
+    Objects.requireNonNull(out, "out");
+    if (byteOffset < 0) {
+      throw new IllegalArgumentException("byteOffset must be >= 0: " + byteOffset);
+    }
+    if (outOffset < 0 || dimensions < 0 || outOffset > out.length - dimensions) {
+      throw new IllegalArgumentException(
+          "out range is invalid: offset="
+              + outOffset
+              + ", dimensions="
+              + dimensions
+              + ", length="
+              + out.length);
+    }
+    if (dimensions % VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "GGUF Q6_K dimensions must be a multiple of 256: " + dimensions);
+    }
+    long required =
+        byteOffset
+            + ggufQuantizedRowBytes(
+                dimensions,
+                VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE,
+                VectorUtilSupport.GGUF_Q6_K_BLOCK_BYTES);
+    if (required < byteOffset || required > qWeight.byteSize()) {
+      throw new IllegalArgumentException(
+          "qWeight byteSize is too small for requested values: "
+              + qWeight.byteSize()
+              + " < "
+              + required);
+    }
+    IMPL.ggufQ6_KDequantize(qWeight, byteOffset, out, outOffset, dimensions);
+  }
+
   /** Batched row-major GEMV over GGUF Q4_0 rows. */
   public static void ggufQ4_0BatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -393,6 +393,53 @@ public interface VectorUtilSupport {
     return sum;
   }
 
+  /** Dequantizes GGUF Q6_K blocks into a caller-owned float array. */
+  default void ggufQ6_KDequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    checkGgufQ6_KBlockAligned(dimensions);
+    int blocks = dimensions / GGUF_Q6_K_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float d =
+          Float.float16ToFloat(
+              qWeight.get(
+                  GGUF_LE_SHORT,
+                  blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES));
+      long qlOffset = blockOffset;
+      long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+      long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+      int outputOffset = outOffset + block * GGUF_Q6_K_BLOCK_SIZE;
+
+      for (int superBlock = 0; superBlock < 2; superBlock++) {
+        long qlBase = qlOffset + (long) superBlock * 64;
+        long qhBase = qhOffset + (long) superBlock * 32;
+        long scaleBase = scaleOffset + (long) superBlock * 8;
+        int outBase = outputOffset + superBlock * 128;
+
+        for (int index = 0; index < 32; index++) {
+          int scaleIndex = index / 16;
+          int ql1 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + index) & 0xFF;
+          int ql2 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + 32L + index) & 0xFF;
+          int qh = qWeight.get(ValueLayout.JAVA_BYTE, qhBase + index) & 0xFF;
+          int q1 = ((ql1 & 0x0F) | ((qh & 0x03) << 4)) - 32;
+          int q2 = ((ql2 & 0x0F) | (((qh >>> 2) & 0x03) << 4)) - 32;
+          int q3 = ((ql1 >>> 4) | (((qh >>> 4) & 0x03) << 4)) - 32;
+          int q4 = ((ql2 >>> 4) | (((qh >>> 6) & 0x03) << 4)) - 32;
+
+          float d1 = d * qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+          float d2 = d * qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+          float d3 = d * qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+          float d4 = d * qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+
+          out[outBase + index] = d1 * q1;
+          out[outBase + index + 32] = d2 * q2;
+          out[outBase + index + 64] = d3 * q3;
+          out[outBase + index + 96] = d4 * q4;
+        }
+      }
+    }
+  }
+
   /** Batched row-major GEMV over GGUF Q4_0 rows. */
   default void ggufQ4_0MatVecDot(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -142,6 +142,28 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q6_KDequantize_matchesDecodedReferenceAtOutputOffset() {
+    byte[] block = q6KBlock(0.125f, i -> (i % 64) - 32, i -> (i % 7) - 3);
+    float[] decoded = new float[258];
+    decoded[0] = 99.0f;
+    decoded[257] = 98.0f;
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      VectorUtil.ggufQ6_KDequantize(segment, 0, decoded, 1, 256);
+    }
+
+    assertThat(decoded[0]).isEqualTo(99.0f);
+    assertThat(decoded[257]).isEqualTo(98.0f);
+    for (int index = 0; index < 256; index++) {
+      int quant = (index % 64) - 32;
+      int subScale = (index / 16) % 7 - 3;
+      assertThat(decoded[index + 1]).isCloseTo(0.125f * subScale * quant, within(1e-6f));
+    }
+  }
+
+  @Test
   void q4_KDotProduct_matchesDecodedReferenceWithPackedScalesAndMins() {
     float[] query = patternedQuery(256);
     int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};


### PR DESCRIPTION
## Summary
- expose caller-owned GGUF Q6_K row dequantization beside the existing fused dot/GEMV APIs
- validate offsets, dimensions, and source/output bounds in VectorUtil
- reuse the upstream-compatible bit layout already exercised by Q6_K dot-product tests

## Test-first evidence
- the new reference test first failed to compile because ggufQ6_KDequantize did not exist
- the implementation matches all 256 decoded reference values and preserves output sentinels

## Verification
- ./gradlew :vectors-core:test
- ./gradlew :vectors-core:spotlessApply
- ./gradlew :vectors-core:spotbugsMain