### PR TITLE
feat(core): add GGUF Q5_K kernels

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -268,6 +268,56 @@ public final class VectorUtil {
     IMPL.ggufQ4_KDequantize(qWeight, byteOffset, out, outOffset, dimensions);
   }
 
+  /** Dot product of a full-precision query with one GGUF Q5_K quantized row. */
+  public static float ggufQ5_KDotProduct(
+      float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
+    checkGgufQuantizedDotArguments(
+        query,
+        qWeight,
+        byteOffset,
+        dimensions,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    return IMPL.ggufQ5_KDotProduct(query, qWeight, byteOffset, dimensions);
+  }
+
+  /** Dequantizes GGUF Q5_K blocks into a caller-owned float array. */
+  public static void ggufQ5_KDequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    Objects.requireNonNull(qWeight, "qWeight");
+    Objects.requireNonNull(out, "out");
+    if (byteOffset < 0) {
+      throw new IllegalArgumentException("byteOffset must be >= 0: " + byteOffset);
+    }
+    if (outOffset < 0 || dimensions < 0 || outOffset > out.length - dimensions) {
+      throw new IllegalArgumentException(
+          "out range is invalid: offset="
+              + outOffset
+              + ", dimensions="
+              + dimensions
+              + ", length="
+              + out.length);
+    }
+    if (dimensions % VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "GGUF Q5_K dimensions must be a multiple of 256: " + dimensions);
+    }
+    long required =
+        byteOffset
+            + ggufQuantizedRowBytes(
+                dimensions,
+                VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+                VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    if (required < byteOffset || required > qWeight.byteSize()) {
+      throw new IllegalArgumentException(
+          "qWeight byteSize is too small for requested values: "
+              + qWeight.byteSize()
+              + " < "
+              + required);
+    }
+    IMPL.ggufQ5_KDequantize(qWeight, byteOffset, out, outOffset, dimensions);
+  }
+
   /** Dot product of a full-precision query with one GGUF Q5_0 quantized row. */
   public static float ggufQ5_0DotProduct(
       float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
@@ -417,18 +467,51 @@ public final class VectorUtil {
         VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
         VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
     checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
-    Objects.requireNonNull(q8Sums, "q8Sums");
-    int requiredSums = cols / VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE;
-    if (q8Sums.length < requiredSums) {
-      throw new IllegalArgumentException(
-          "q8Sums.length must be >= dimensions / "
-              + VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE
-              + ": "
-              + q8Sums.length
-              + " < "
-              + requiredSums);
-    }
+    checkGgufQ8KSums(q8Sums, cols);
     IMPL.ggufQ4_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
+  }
+
+  /** Batched row-major GEMV over GGUF Q5_K rows. */
+  public static void ggufQ5_KBatchDotProduct(
+      float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    IMPL.ggufQ5_KMatVecDot(query, qWeight, rows, cols, out);
+  }
+
+  /**
+   * GGML-compatible GEMV over Q5_K rows using a Q8_K-quantized activation vector.
+   *
+   * @param q8Quants scratch space with at least {@code cols} entries
+   * @param q8Scales scratch space with at least {@code cols / 256} entries
+   * @param q8Sums scratch space with at least {@code cols / 16} entries
+   */
+  public static void ggufQ5_KQ8_KBatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, cols);
+    IMPL.ggufQ5_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
   }
 
   /** Batched row-major GEMV over GGUF Q5_0 rows. */
@@ -884,6 +967,20 @@ public final class VectorUtil {
               + q8Scales.length
               + " < "
               + blocks);
+    }
+  }
+
+  private static void checkGgufQ8KSums(short[] q8Sums, int dimensions) {
+    Objects.requireNonNull(q8Sums, "q8Sums");
+    int requiredSums = dimensions / VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE;
+    if (q8Sums.length < requiredSums) {
+      throw new IllegalArgumentException(
+          "q8Sums.length must be >= dimensions / "
+              + VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE
+              + ": "
+              + q8Sums.length
+              + " < "
+              + requiredSums);
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -41,6 +41,11 @@ public interface VectorUtilSupport {
   int GGUF_Q4_K_BLOCK_BYTES = 144;
   int GGUF_Q4_K_SCALES_OFFSET = 4;
   int GGUF_Q4_K_QUANTS_OFFSET = 16;
+  int GGUF_Q5_K_BLOCK_SIZE = 256;
+  int GGUF_Q5_K_BLOCK_BYTES = 176;
+  int GGUF_Q5_K_SCALES_OFFSET = 4;
+  int GGUF_Q5_K_HIGH_BITS_OFFSET = 16;
+  int GGUF_Q5_K_QUANTS_OFFSET = 48;
   int GGUF_Q8_K_SUM_BLOCK_SIZE = 16;
   int GGUF_Q6_K_BLOCK_SIZE = 256;
   int GGUF_Q6_K_BLOCK_BYTES = 210;
@@ -234,8 +239,8 @@ public interface VectorUtilSupport {
       int queryOffset = block * GGUF_Q4_K_BLOCK_SIZE;
 
       for (int group = 0; group < 8; group++) {
-        int scale = q4KScale(qWeight, scalesOffset, group);
-        int min = q4KMin(qWeight, scalesOffset, group);
+        int scale = qKScale(qWeight, scalesOffset, group);
+        int min = qKMin(qWeight, scalesOffset, group);
         float scaledD = d * scale;
         float minimum = dMin * min;
         long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
@@ -267,8 +272,8 @@ public interface VectorUtilSupport {
       int outputOffset = outOffset + block * GGUF_Q4_K_BLOCK_SIZE;
 
       for (int group = 0; group < 8; group++) {
-        int scale = q4KScale(qWeight, scalesOffset, group);
-        int min = q4KMin(qWeight, scalesOffset, group);
+        int scale = qKScale(qWeight, scalesOffset, group);
+        int min = qKMin(qWeight, scalesOffset, group);
         float scaledD = d * scale;
         float minimum = dMin * min;
         long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
@@ -278,6 +283,82 @@ public interface VectorUtilSupport {
         for (int index = 0; index < 32; index++) {
           int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
           int quant = (packed >>> shift) & 0x0F;
+          out[groupOutputOffset + index] = scaledD * quant - minimum;
+        }
+      }
+    }
+  }
+
+  /**
+   * Dot product of a full-precision query with one GGUF Q5_K quantized row.
+   *
+   * <p>Each 256-value super-block stores binary16 scale and minimum factors, eight packed 6-bit
+   * scale/minimum pairs, 32 high-bit bytes, and eight groups of 32 low nibbles.
+   */
+  default float ggufQ5_KDotProduct(
+      float[] query, MemorySegment qWeight, long byteOffset, int dimensions) {
+    checkGgufQ5_KBlockAligned(dimensions);
+    float sum = 0.0f;
+    int blocks = dimensions / GGUF_Q5_K_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float dMin = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int queryOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = qKScale(qWeight, scalesOffset, group);
+        int min = qKMin(qWeight, scalesOffset, group);
+        float scaledD = d * scale;
+        float minimum = dMin * min;
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int highBit = 1 << group;
+        int groupQueryOffset = queryOffset + group * 32;
+
+        for (int index = 0; index < 32; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+          int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
+          int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
+          float weight = scaledD * quant - minimum;
+          sum = MathUtil.fma(query[groupQueryOffset + index], weight, sum);
+        }
+      }
+    }
+    return sum;
+  }
+
+  /** Dequantizes GGUF Q5_K blocks into a caller-owned float array. */
+  default void ggufQ5_KDequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    checkGgufQ5_KBlockAligned(dimensions);
+    int blocks = dimensions / GGUF_Q5_K_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float dMin = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int outputOffset = outOffset + block * GGUF_Q5_K_BLOCK_SIZE;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = qKScale(qWeight, scalesOffset, group);
+        int min = qKMin(qWeight, scalesOffset, group);
+        float scaledD = d * scale;
+        float minimum = dMin * min;
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int highBit = 1 << group;
+        int groupOutputOffset = outputOffset + group * 32;
+
+        for (int index = 0; index < 32; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+          int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
+          int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
           out[groupOutputOffset + index] = scaledD * quant - minimum;
         }
       }
@@ -525,8 +606,8 @@ public interface VectorUtilSupport {
         int minimumSum = 0;
 
         for (int group = 0; group < 8; group++) {
-          int scale = q4KScale(qWeight, scalesOffset, group);
-          int min = q4KMin(qWeight, scalesOffset, group);
+          int scale = qKScale(qWeight, scalesOffset, group);
+          int min = qKMin(qWeight, scalesOffset, group);
           long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
           int shift = (group & 1) * 4;
           int groupActivationOffset = activationOffset + group * 32;
@@ -535,6 +616,73 @@ public interface VectorUtilSupport {
           for (int index = 0; index < 32; index++) {
             int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
             int quant = (packed >>> shift) & 0x0F;
+            groupDot += quant * q8Quants[groupActivationOffset + index];
+          }
+          quantizedSum += scale * groupDot;
+          int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+          minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+        }
+
+        sum = MathUtil.fma(d, quantizedSum, sum);
+        sum = MathUtil.fma(-dMin, minimumSum, sum);
+      }
+      out[row] = sum;
+    }
+  }
+
+  /** Batched row-major GEMV over GGUF Q5_K rows. */
+  default void ggufQ5_KMatVecDot(
+      float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
+    long rowBytes = ggufQ5_KRowBytes(cols);
+    for (int row = 0; row < rows; row++) {
+      out[row] = ggufQ5_KDotProduct(query, qWeight, row * rowBytes, cols);
+    }
+  }
+
+  /** GGML-compatible Q5_K by Q8_K GEMV. The activation is quantized once and reused across rows. */
+  default void ggufQ5_KQ8_KMatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = ggufQ5_KRowBytes(cols);
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    for (int row = 0; row < rows; row++) {
+      float sum = 0.0f;
+      long rowOffset = row * rowBytes;
+
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+        float q8Scale = q8Scales[block];
+        float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+        float dMin =
+            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+        long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+        long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+        long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+        int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+        int quantizedSum = 0;
+        int minimumSum = 0;
+
+        for (int group = 0; group < 8; group++) {
+          int scale = qKScale(qWeight, scalesOffset, group);
+          int min = qKMin(qWeight, scalesOffset, group);
+          long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+          int shift = (group & 1) * 4;
+          int highBit = 1 << group;
+          int groupActivationOffset = activationOffset + group * 32;
+          int groupDot = 0;
+
+          for (int index = 0; index < 32; index++) {
+            int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+            int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
+            int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
             groupDot += quant * q8Quants[groupActivationOffset + index];
           }
           quantizedSum += scale * groupDot;
@@ -900,6 +1048,13 @@ public interface VectorUtilSupport {
     }
   }
 
+  private static void checkGgufQ5_KBlockAligned(int dimensions) {
+    if (dimensions % GGUF_Q5_K_BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "GGUF Q5_K dimensions must be a multiple of 256: " + dimensions);
+    }
+  }
+
   private static long ggufQ4_0RowBytes(int dimensions) {
     checkGgufBlockAligned(dimensions);
     return (long) (dimensions / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
@@ -918,6 +1073,11 @@ public interface VectorUtilSupport {
   private static long ggufQ4_KRowBytes(int dimensions) {
     checkGgufQ4_KBlockAligned(dimensions);
     return (long) (dimensions / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
+  }
+
+  private static long ggufQ5_KRowBytes(int dimensions) {
+    checkGgufQ5_KBlockAligned(dimensions);
+    return (long) (dimensions / GGUF_Q5_K_BLOCK_SIZE) * GGUF_Q5_K_BLOCK_BYTES;
   }
 
   private static long ggufQ6_KRowBytes(int dimensions) {
@@ -976,7 +1136,7 @@ public interface VectorUtilSupport {
     }
   }
 
-  private static int q4KScale(MemorySegment qWeight, long scalesOffset, int group) {
+  private static int qKScale(MemorySegment qWeight, long scalesOffset, int group) {
     if (group < 4) {
       return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0x3F;
     }
@@ -985,7 +1145,7 @@ public interface VectorUtilSupport {
     return low | (high << 4);
   }
 
-  private static int q4KMin(MemorySegment qWeight, long scalesOffset, int group) {
+  private static int qKMin(MemorySegment qWeight, long scalesOffset, int group) {
     if (group < 4) {
       return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x3F;
     }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -211,6 +211,55 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_KDotProduct_matchesDecodedReferenceWithHighBitsScalesAndMins() {
+    float[] query = patternedQuery(256);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] block = q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins);
+
+    float expected = 0.0f;
+    for (int index = 0; index < query.length; index++) {
+      int group = index / 32;
+      int quant = (index * 7 + 3) % 32;
+      float weight = 0.125f * scales[group] * quant - 0.0625f * mins[group];
+      expected = Math.fma(query[index], weight, expected);
+    }
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      float actual = VectorUtil.ggufQ5_KDotProduct(query, segment, 0, query.length);
+
+      assertThat(actual).isCloseTo(expected, within(1e-3f));
+    }
+  }
+
+  @Test
+  void q5_KDequantize_matchesDecodedReferenceAtOutputOffset() {
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] block = q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins);
+    float[] decoded = new float[258];
+    decoded[0] = 99.0f;
+    decoded[257] = 98.0f;
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      VectorUtil.ggufQ5_KDequantize(segment, 0, decoded, 1, 256);
+    }
+
+    assertThat(decoded[0]).isEqualTo(99.0f);
+    assertThat(decoded[257]).isEqualTo(98.0f);
+    for (int index = 0; index < 256; index++) {
+      int group = index / 32;
+      int quant = (index * 7 + 3) % 32;
+      float expected = 0.125f * scales[group] * quant - 0.0625f * mins[group];
+      assertThat(decoded[index + 1]).isCloseTo(expected, within(1e-6f));
+    }
+  }
+
+  @Test
   void q5_0DotProduct_matchesDecodedReferenceWithHighBitMask() {
     float[] query = patternedQuery(32);
     byte[] block = q5Block(0.25f, i -> (i * 7) % 32 - 16);
@@ -326,6 +375,10 @@ class GgufQuantizedDotTest {
               arena,
               q4KBlock(1.0f, 0.0f, ignored -> 1, new int[] {1, 1, 1, 1, 1, 1, 1, 1}, new int[8]));
       MemorySegment q8 = copy(arena, q8Block(1.0f));
+      MemorySegment q5K =
+          copy(
+              arena,
+              q5KBlock(1.0f, 0.0f, ignored -> 1, new int[] {1, 1, 1, 1, 1, 1, 1, 1}, new int[8]));
       MemorySegment q6 = copy(arena, q6KBlock(1.0f, ignored -> 1, ignored -> 1));
 
       assertThatThrownBy(
@@ -351,6 +404,19 @@ class GgufQuantizedDotTest {
                   VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
                       ones(256),
                       q4K,
+                      1,
+                      256,
+                      new float[1],
+                      new byte[256],
+                      new float[1],
+                      new short[15]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("q8Sums.length");
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+                      ones(256),
+                      q5K,
                       1,
                       256,
                       new float[1],
@@ -460,6 +526,56 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_KBatchDotProduct_respectsRowOffsets() {
+    float[] query = patternedQuery(256);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] row0 = q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins);
+    byte[] row1 = q5KBlock(-0.25f, 0.03125f, i -> 31 - (i % 32), scales, mins);
+    float[] out = new float[2];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+
+      VectorUtil.ggufQ5_KBatchDotProduct(query, segment, 2, query.length, out);
+
+      assertThat(out[0])
+          .isCloseTo(VectorUtil.ggufQ5_KDotProduct(query, segment, 0, 256), within(1e-5f));
+      assertThat(out[1])
+          .isCloseTo(VectorUtil.ggufQ5_KDotProduct(query, segment, 176, 256), within(1e-5f));
+    }
+  }
+
+  @Test
+  void q5_KQ8_KBatchDotProduct_matchesQuantizedActivationReferenceWithMins() {
+    float[] query = patternedQuery(256);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] row = q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins);
+    float[] out = new float[1];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[1];
+    short[] q8Sums = new short[16];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, row);
+
+      VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+          query, segment, 1, query.length, out, q8Quants, q8Scales, q8Sums);
+    }
+
+    float expected = 0.0f;
+    for (int index = 0; index < query.length; index++) {
+      int group = index / 32;
+      int quant = (index * 7 + 3) % 32;
+      float weight = 0.125f * scales[group] * quant - 0.0625f * mins[group];
+      float activation = q8Scales[0] * q8Quants[index];
+      expected = Math.fma(weight, activation, expected);
+    }
+    assertThat(out[0]).isCloseTo(expected, within(1e-3f));
+  }
+
+  @Test
   void q5_0Q8_0BatchDotProduct_quantizesTheQueryOnceUsingGgmlSemantics() {
     float[] query = new float[32];
     query[0] = 1.0f;
@@ -493,6 +609,10 @@ class GgufQuantizedDotTest {
               q4KBlock(1.0f, 0.0f, ignored -> 1, new int[] {1, 1, 1, 1, 1, 1, 1, 1}, new int[8]));
       MemorySegment q8 = copy(arena, q8Block(1.0f));
       MemorySegment q5 = copy(arena, q5Block(1.0f, ignored -> 1));
+      MemorySegment q5K =
+          copy(
+              arena,
+              q5KBlock(1.0f, 0.0f, ignored -> 1, new int[] {1, 1, 1, 1, 1, 1, 1, 1}, new int[8]));
       MemorySegment q6 = copy(arena, q6KBlock(1.0f, i -> 0, i -> 1));
 
       assertThatThrownBy(() -> VectorUtil.ggufQ4_0DotProduct(ones(31), q4, 0, 31))
@@ -508,6 +628,9 @@ class GgufQuantizedDotTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("multiple of 256");
       assertThatThrownBy(() -> VectorUtil.ggufQ4_KDotProduct(ones(255), q4K, 0, 255))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("multiple of 256");
+      assertThatThrownBy(() -> VectorUtil.ggufQ5_KDotProduct(ones(255), q5K, 0, 255))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("multiple of 256");
     }
@@ -593,6 +716,35 @@ class GgufQuantizedDotTest {
                     | (((q2 >>> 4) & 0x03) << 2)
                     | (((q3 >>> 4) & 0x03) << 4)
                     | (((q4 >>> 4) & 0x03) << 6));
+      }
+    }
+    return block;
+  }
+
+  private static byte[] q5KBlock(
+      float scale, float minScale, IntUnaryOperator quantFactory, int[] scales, int[] mins) {
+    byte[] block = new byte[176];
+    ByteBuffer buffer = ByteBuffer.wrap(block).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putShort(0, Float.floatToFloat16(scale));
+    buffer.putShort(2, Float.floatToFloat16(minScale));
+
+    for (int group = 0; group < 4; group++) {
+      block[4 + group] = (byte) scales[group];
+      block[8 + group] = (byte) mins[group];
+    }
+    for (int group = 4; group < 8; group++) {
+      block[4 + group + 4] = (byte) ((scales[group] & 0x0F) | ((mins[group] & 0x0F) << 4));
+      block[4 + group - 4] |= (byte) ((scales[group] >>> 4) << 6);
+      block[4 + group] |= (byte) ((mins[group] >>> 4) << 6);
+    }
+
+    for (int group = 0; group < 8; group++) {
+      int byteOffset = 48 + (group >>> 1) * 32;
+      int shift = (group & 1) * 4;
+      for (int index = 0; index < 32; index++) {
+        int quant = quantFactory.applyAsInt(group * 32 + index);
+        block[byteOffset + index] |= (byte) ((quant & 0x0F) << shift);
+        block[16 + index] |= (byte) (((quant >>> 4) & 1) << group);
       }
     }
     return block;


### PR DESCRIPTION
## Summary
- add Q5_K dot-product and dequantization primitives
- add Q5_K/Q8_K fused GEMV with reusable activation scratch
- verify packed scales, minima, high bits, row offsets, and validation contracts

## Verification
- `./gradlew :vectors-core:check --no-daemon`