### PR TITLE
feat(core): parallelize quantized GGUF kernels

### DIFF
--- a/docs/content/modules/ROOT/pages/architecture.adoc
+++ b/docs/content/modules/ROOT/pages/architecture.adoc
@@ -160,6 +160,17 @@ Distance kernels use the Java Vector API (`jdk.incubator.vector`):
 * **Scalar tail** for dimensions not divisible by the lane width
 * A pure-scalar fallback (`ScalarVectorUtilSupport`) is always available
 
+GGUF matrix-vector kernels quantize each activation once and reuse it across every weight row.
+Large Q4_0, Q4_K, Q5_0, Q5_K, Q6_K, and Q8_0 matrices distribute independent rows across the
+bounded common fork-join pool. Parallel execution is used only for memory segments that are
+accessible from worker threads; confined segments stay on their owner thread. The default
+crossover is 1,048,576 matrix elements, with a 4,194,304-element floor for Q8_0 because smaller
+Q8_0 matrices are memory-bandwidth and scheduling limited.
+
+Set `-Dvectors.gguf.parallel=false` to force serial GGUF execution, or raise the global crossover
+with `-Dvectors.gguf.parallelThreshold=<elements>`. The active values are included in the
+`vectors-core` startup diagnostic line.
+
 == Memory Model
 
 * **Vectors** are stored off-heap via `MemorySegment` in persistent mode, or as `float[][]` on the heap in memory mode.

--- a/vectors-bench/build.gradle.kts
+++ b/vectors-bench/build.gradle.kts
@@ -74,6 +74,10 @@ jmh {
     listOf("wal.s3.bucket", "wal.s3.region", "wal.s3.endpoint").forEach { key ->
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
+    // Forward GGUF kernel controls so serial/parallel comparisons use the same JMH harness.
+    listOf("vectors.gguf.parallel", "vectors.gguf.parallelThreshold").forEach { key ->
+        (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
+    }
     // Time-box overrides for short/dev runs:
     //   -Pjmh.fork=1 -Pjmh.warmup=1 -Pjmh.iterations=2 -Pjmh.timeOnIteration=1s
     (project.findProperty("jmh.fork") as String?)?.let { fork.set(it.toInt()) }
@@ -333,4 +337,3 @@ tasks.register<JavaExec>("pqTrainProbe") {
     standardOutput = System.out
     errorOutput    = System.err
 }
-

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+
+/** Bounded row parallelism for large, thread-shareable GGUF matrices. */
+final class GgufParallelSupport {
+
+  static final long DEFAULT_MIN_ELEMENTS = 1_048_576L;
+  static final long Q8_MIN_ELEMENTS = 4_194_304L;
+
+  private static final boolean ENABLED =
+      Boolean.parseBoolean(System.getProperty("vectors.gguf.parallel", "true"));
+  private static final long MIN_ELEMENTS =
+      Math.max(1L, Long.getLong("vectors.gguf.parallelThreshold", DEFAULT_MIN_ELEMENTS));
+  private static final int PROCESSORS = Runtime.getRuntime().availableProcessors();
+  private static final Thread ACCESS_PROBE = Thread.ofPlatform().unstarted(() -> {});
+
+  private GgufParallelSupport() {}
+
+  static void forEachRow(MemorySegment weights, int rows, int cols, IntConsumer rowOperation) {
+    forEachRow(weights, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+  }
+
+  static void forEachRow(
+      MemorySegment weights, int rows, int cols, long formatMinElements, IntConsumer rowOperation) {
+    boolean shareable = weights.isAccessibleBy(ACCESS_PROBE);
+    long effectiveMinElements = Math.max(MIN_ELEMENTS, formatMinElements);
+    if (shareable && shouldParallelize(rows, cols, PROCESSORS, ENABLED, effectiveMinElements)) {
+      IntStream.range(0, rows).parallel().forEach(rowOperation);
+      return;
+    }
+    for (int row = 0; row < rows; row++) {
+      rowOperation.accept(row);
+    }
+  }
+
+  static boolean shouldParallelize(
+      int rows, int cols, int processors, boolean enabled, long minElements) {
+    return enabled && processors > 1 && (long) rows * cols >= minElements;
+  }
+
+  static boolean enabled() {
+    return ENABLED;
+  }
+
+  static long minElements() {
+    return MIN_ELEMENTS;
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+/** Shared activation quantization used by scalar and Panama GGUF kernels. */
+final class GgufQuantizationSupport {
+
+  private static final ThreadLocal<Q6Scratch> Q6_SCRATCH = ThreadLocal.withInitial(Q6Scratch::new);
+
+  private GgufQuantizationSupport() {}
+
+  static void quantizeQ8_0(float[] query, int dimensions, byte[] quants, float[] scales) {
+    int blocks = dimensions / VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      int offset = block * VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
+      float absoluteMax = 0.0f;
+      for (int index = 0; index < VectorUtilSupport.GGUF_Q_BLOCK_SIZE; index++) {
+        absoluteMax = Math.max(absoluteMax, Math.abs(query[offset + index]));
+      }
+
+      float scale = absoluteMax / 127.0f;
+      float inverseScale = absoluteMax == 0.0f ? 0.0f : 127.0f / absoluteMax;
+      scales[block] = Float.float16ToFloat(Float.floatToFloat16(scale));
+      for (int index = 0; index < VectorUtilSupport.GGUF_Q_BLOCK_SIZE; index++) {
+        quants[offset + index] = (byte) ggmlNearestInt(query[offset + index] * inverseScale);
+      }
+    }
+  }
+
+  static Q6Scratch q6Scratch() {
+    return Q6_SCRATCH.get();
+  }
+
+  private static int ggmlNearestInt(float value) {
+    int bits = Float.floatToRawIntBits(value + 12_582_912.0f);
+    return (bits & 0x007F_FFFF) - 0x0040_0000;
+  }
+
+  static final class Q6Scratch {
+    final int[] integerSums = new int[8];
+    final float[] laneSums = new float[8];
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -326,6 +326,89 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     };
   }
 
+  /** SIMD Q4_0 by Q8_0 GEMV with one activation quantization shared by all rows. */
+  @Override
+  public void ggufQ4_0Q8_0MatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+            float scale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+            int integerSum =
+                q4_0Q8_0IntegerDot(
+                    qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+            sum = MathUtil.fma(scale, integerSum, sum);
+          }
+          out[row] = sum;
+        });
+  }
+
+  private static int q4_0Q8_0IntegerDot(
+      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
+    if (VECTOR_BITSIZE >= 256) {
+      ByteVector packed =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
+      ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+      ShortVector low16 =
+          (ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      ShortVector high16 =
+          (ShortVector) high.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      ShortVector qLow16 =
+          (ShortVector)
+              ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      ShortVector qHigh16 =
+          (ShortVector)
+              ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      return low16.mul(qLow16).reduceLanes(VectorOperators.ADD)
+          + high16.mul(qHigh16).reduceLanes(VectorOperators.ADD);
+    }
+
+    int sum = 0;
+    for (int half = 0; half < 16; half += 8) {
+      ByteVector packed =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, nibbleOffset + half, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
+      ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+      ShortVector low16 =
+          (ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+      ShortVector high16 =
+          (ShortVector) high.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+      ShortVector qLow16 =
+          (ShortVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + half)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+      ShortVector qHigh16 =
+          (ShortVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + 16 + half)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+      sum += low16.mul(qLow16).reduceLanes(VectorOperators.ADD);
+      sum += high16.mul(qHigh16).reduceLanes(VectorOperators.ADD);
+    }
+    return sum;
+  }
+
   // --- Byte dot product: widening to avoid overflow ---
   //
   // Tiered widening strategy (B2I = byte-to-int, 4x lane expansion):

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -589,45 +589,50 @@ public interface VectorUtilSupport {
 
     long rowBytes = ggufQ4_KRowBytes(cols);
     int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
-    for (int row = 0; row < rows; row++) {
-      float sum = 0.0f;
-      long rowOffset = row * rowBytes;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
 
-      for (int block = 0; block < blocks; block++) {
-        long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-        float q8Scale = q8Scales[block];
-        float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-        float dMin =
-            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
-        long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-        long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-        int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-        int quantizedSum = 0;
-        int minimumSum = 0;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+            float q8Scale = q8Scales[block];
+            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+            float dMin =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                    * q8Scale;
+            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+            int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+            int quantizedSum = 0;
+            int minimumSum = 0;
 
-        for (int group = 0; group < 8; group++) {
-          int scale = qKScale(qWeight, scalesOffset, group);
-          int min = qKMin(qWeight, scalesOffset, group);
-          long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-          int shift = (group & 1) * 4;
-          int groupActivationOffset = activationOffset + group * 32;
-          int groupDot = 0;
+            for (int group = 0; group < 8; group++) {
+              int scale = qKScale(qWeight, scalesOffset, group);
+              int min = qKMin(qWeight, scalesOffset, group);
+              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+              int shift = (group & 1) * 4;
+              int groupActivationOffset = activationOffset + group * 32;
+              int groupDot = 0;
 
-          for (int index = 0; index < 32; index++) {
-            int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
-            int quant = (packed >>> shift) & 0x0F;
-            groupDot += quant * q8Quants[groupActivationOffset + index];
+              for (int index = 0; index < 32; index++) {
+                int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+                int quant = (packed >>> shift) & 0x0F;
+                groupDot += quant * q8Quants[groupActivationOffset + index];
+              }
+              quantizedSum += scale * groupDot;
+              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+            }
+
+            sum = MathUtil.fma(d, quantizedSum, sum);
+            sum = MathUtil.fma(-dMin, minimumSum, sum);
           }
-          quantizedSum += scale * groupDot;
-          int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-          minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-        }
-
-        sum = MathUtil.fma(d, quantizedSum, sum);
-        sum = MathUtil.fma(-dMin, minimumSum, sum);
-      }
-      out[row] = sum;
-    }
+          out[row] = sum;
+        });
   }
 
   /** Batched row-major GEMV over GGUF Q5_K rows. */
@@ -653,48 +658,53 @@ public interface VectorUtilSupport {
 
     long rowBytes = ggufQ5_KRowBytes(cols);
     int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
-    for (int row = 0; row < rows; row++) {
-      float sum = 0.0f;
-      long rowOffset = row * rowBytes;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
 
-      for (int block = 0; block < blocks; block++) {
-        long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
-        float q8Scale = q8Scales[block];
-        float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-        float dMin =
-            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
-        long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
-        long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
-        long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
-        int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
-        int quantizedSum = 0;
-        int minimumSum = 0;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+            float q8Scale = q8Scales[block];
+            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+            float dMin =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                    * q8Scale;
+            long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+            long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+            int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+            int quantizedSum = 0;
+            int minimumSum = 0;
 
-        for (int group = 0; group < 8; group++) {
-          int scale = qKScale(qWeight, scalesOffset, group);
-          int min = qKMin(qWeight, scalesOffset, group);
-          long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-          int shift = (group & 1) * 4;
-          int highBit = 1 << group;
-          int groupActivationOffset = activationOffset + group * 32;
-          int groupDot = 0;
+            for (int group = 0; group < 8; group++) {
+              int scale = qKScale(qWeight, scalesOffset, group);
+              int min = qKMin(qWeight, scalesOffset, group);
+              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+              int shift = (group & 1) * 4;
+              int highBit = 1 << group;
+              int groupActivationOffset = activationOffset + group * 32;
+              int groupDot = 0;
 
-          for (int index = 0; index < 32; index++) {
-            int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
-            int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
-            int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
-            groupDot += quant * q8Quants[groupActivationOffset + index];
+              for (int index = 0; index < 32; index++) {
+                int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+                int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
+                int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
+                groupDot += quant * q8Quants[groupActivationOffset + index];
+              }
+              quantizedSum += scale * groupDot;
+              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+            }
+
+            sum = MathUtil.fma(d, quantizedSum, sum);
+            sum = MathUtil.fma(-dMin, minimumSum, sum);
           }
-          quantizedSum += scale * groupDot;
-          int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-          minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-        }
-
-        sum = MathUtil.fma(d, quantizedSum, sum);
-        sum = MathUtil.fma(-dMin, minimumSum, sum);
-      }
-      out[row] = sum;
-    }
+          out[row] = sum;
+        });
   }
 
   /** Batched row-major GEMV over GGUF Q5_0 rows. */
@@ -719,28 +729,32 @@ public interface VectorUtilSupport {
 
     long rowBytes = ggufQ5_0RowBytes(cols);
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
-    for (int row = 0; row < rows; row++) {
-      float sum = 0.0f;
-      long rowOffset = row * rowBytes;
-      for (int block = 0; block < blocks; block++) {
-        long blockOffset = rowOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
-        float scale =
-            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
-        int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
-        long quantsOffset = blockOffset + Short.BYTES + Integer.BYTES;
-        int activationOffset = block * GGUF_Q_BLOCK_SIZE;
-        int integerSum = 0;
-        for (int index = 0; index < 16; index++) {
-          int packed = qWeight.get(ValueLayout.JAVA_BYTE, quantsOffset + index) & 0xFF;
-          int low = (packed & 0x0F) | (((highBits >>> index) & 1) << 4);
-          int high = (packed >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
-          integerSum += (low - 16) * q8Quants[activationOffset + index];
-          integerSum += (high - 16) * q8Quants[activationOffset + index + 16];
-        }
-        sum = MathUtil.fma(scale, integerSum, sum);
-      }
-      out[row] = sum;
-    }
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+            float scale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+            int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+            long quantsOffset = blockOffset + Short.BYTES + Integer.BYTES;
+            int activationOffset = block * GGUF_Q_BLOCK_SIZE;
+            int integerSum = 0;
+            for (int index = 0; index < 16; index++) {
+              int packed = qWeight.get(ValueLayout.JAVA_BYTE, quantsOffset + index) & 0xFF;
+              int low = (packed & 0x0F) | (((highBits >>> index) & 1) << 4);
+              int high = (packed >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
+              integerSum += (low - 16) * q8Quants[activationOffset + index];
+              integerSum += (high - 16) * q8Quants[activationOffset + index + 16];
+            }
+            sum = MathUtil.fma(scale, integerSum, sum);
+          }
+          out[row] = sum;
+        });
   }
 
   /** Batched row-major GEMV over GGUF Q6_K rows. */
@@ -765,65 +779,73 @@ public interface VectorUtilSupport {
 
     long rowBytes = ggufQ6_KRowBytes(cols);
     int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
-    int[] integerSums = new int[8];
-    float[] laneSums = new float[8];
-    for (int row = 0; row < rows; row++) {
-      java.util.Arrays.fill(laneSums, 0.0f);
-      long rowOffset = row * rowBytes;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          GgufQuantizationSupport.Q6Scratch scratch = GgufQuantizationSupport.q6Scratch();
+          int[] integerSums = scratch.integerSums;
+          float[] laneSums = scratch.laneSums;
+          java.util.Arrays.fill(laneSums, 0.0f);
+          long rowOffset = row * rowBytes;
 
-      for (int block = 0; block < blocks; block++) {
-        java.util.Arrays.fill(integerSums, 0);
-        long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
-        float d =
-            Float.float16ToFloat(
-                    qWeight.get(
-                        GGUF_LE_SHORT,
-                        blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES))
-                * q8Scales[block];
-        long qlOffset = blockOffset;
-        long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
-        long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
-        int queryOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+          for (int block = 0; block < blocks; block++) {
+            java.util.Arrays.fill(integerSums, 0);
+            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+            float d =
+                Float.float16ToFloat(
+                        qWeight.get(
+                            GGUF_LE_SHORT,
+                            blockOffset
+                                + GGUF_Q6_K_QL_BYTES
+                                + GGUF_Q6_K_QH_BYTES
+                                + GGUF_Q6_K_SCALES))
+                    * q8Scales[block];
+            long qlOffset = blockOffset;
+            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+            int queryOffset = block * GGUF_Q6_K_BLOCK_SIZE;
 
-        for (int superBlock = 0; superBlock < 2; superBlock++) {
-          long qlBase = qlOffset + (long) superBlock * 64;
-          long qhBase = qhOffset + (long) superBlock * 32;
-          long scaleBase = scaleOffset + (long) superBlock * 8;
-          int quantBase = queryOffset + superBlock * 128;
+            for (int superBlock = 0; superBlock < 2; superBlock++) {
+              long qlBase = qlOffset + (long) superBlock * 64;
+              long qhBase = qhOffset + (long) superBlock * 32;
+              long scaleBase = scaleOffset + (long) superBlock * 8;
+              int quantBase = queryOffset + superBlock * 128;
 
-          for (int index = 0; index < 32; index++) {
-            int scaleIndex = index / 16;
-            int ql1 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + index) & 0xFF;
-            int ql2 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + 32L + index) & 0xFF;
-            int qh = qWeight.get(ValueLayout.JAVA_BYTE, qhBase + index) & 0xFF;
-            int q1 = ((ql1 & 0x0F) | ((qh & 0x03) << 4)) - 32;
-            int q2 = ((ql2 & 0x0F) | (((qh >>> 2) & 0x03) << 4)) - 32;
-            int q3 = ((ql1 >>> 4) | (((qh >>> 4) & 0x03) << 4)) - 32;
-            int q4 = ((ql2 >>> 4) | (((qh >>> 6) & 0x03) << 4)) - 32;
-            int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
-            int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
-            int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
-            int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
-            int lane = index & 7;
+              for (int index = 0; index < 32; index++) {
+                int scaleIndex = index / 16;
+                int ql1 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + index) & 0xFF;
+                int ql2 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + 32L + index) & 0xFF;
+                int qh = qWeight.get(ValueLayout.JAVA_BYTE, qhBase + index) & 0xFF;
+                int q1 = ((ql1 & 0x0F) | ((qh & 0x03) << 4)) - 32;
+                int q2 = ((ql2 & 0x0F) | (((qh >>> 2) & 0x03) << 4)) - 32;
+                int q3 = ((ql1 >>> 4) | (((qh >>> 4) & 0x03) << 4)) - 32;
+                int q4 = ((ql2 >>> 4) | (((qh >>> 6) & 0x03) << 4)) - 32;
+                int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+                int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+                int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+                int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+                int lane = index & 7;
 
-            integerSums[lane] += s1 * q1 * q8Quants[quantBase + index];
-            integerSums[lane] += s2 * q2 * q8Quants[quantBase + index + 32];
-            integerSums[lane] += s3 * q3 * q8Quants[quantBase + index + 64];
-            integerSums[lane] += s4 * q4 * q8Quants[quantBase + index + 96];
+                integerSums[lane] += s1 * q1 * q8Quants[quantBase + index];
+                integerSums[lane] += s2 * q2 * q8Quants[quantBase + index + 32];
+                integerSums[lane] += s3 * q3 * q8Quants[quantBase + index + 64];
+                integerSums[lane] += s4 * q4 * q8Quants[quantBase + index + 96];
+              }
+            }
+
+            for (int lane = 0; lane < laneSums.length; lane++) {
+              laneSums[lane] = MathUtil.fma(d, integerSums[lane], laneSums[lane]);
+            }
           }
-        }
 
-        for (int lane = 0; lane < laneSums.length; lane++) {
-          laneSums[lane] = MathUtil.fma(d, integerSums[lane], laneSums[lane]);
-        }
-      }
-
-      float sum = 0.0f;
-      for (float laneSum : laneSums) {
-        sum += laneSum;
-      }
-      out[row] = sum;
-    }
+          float sum = 0.0f;
+          for (float laneSum : laneSums) {
+            sum += laneSum;
+          }
+          out[row] = sum;
+        });
   }
 
   /** Batched row-major GEMV over GGUF Q8_0 rows. */
@@ -848,25 +870,30 @@ public interface VectorUtilSupport {
 
     long rowBytes = ggufQ8_0RowBytes(cols);
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
-    for (int row = 0; row < rows; row++) {
-      float sum = 0.0f;
-      long rowOffset = row * rowBytes;
-      for (int block = 0; block < blocks; block++) {
-        long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
-        float scale =
-            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
-        long quantOffset = blockOffset + Short.BYTES;
-        int queryOffset = block * GGUF_Q_BLOCK_SIZE;
-        int integerSum = 0;
-        for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
-          integerSum +=
-              qWeight.get(ValueLayout.JAVA_BYTE, quantOffset + index)
-                  * q8Quants[queryOffset + index];
-        }
-        sum = MathUtil.fma(scale, integerSum, sum);
-      }
-      out[row] = sum;
-    }
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+            float scale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+            long quantOffset = blockOffset + Short.BYTES;
+            int queryOffset = block * GGUF_Q_BLOCK_SIZE;
+            int integerSum = 0;
+            for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
+              integerSum +=
+                  qWeight.get(ValueLayout.JAVA_BYTE, quantOffset + index)
+                      * q8Quants[queryOffset + index];
+            }
+            sum = MathUtil.fma(scale, integerSum, sum);
+          }
+          out[row] = sum;
+        });
   }
 
   /**
@@ -1155,21 +1182,7 @@ public interface VectorUtilSupport {
   }
 
   private static void quantizeQ8_0(float[] query, int dimensions, byte[] quants, float[] scales) {
-    int blocks = dimensions / GGUF_Q_BLOCK_SIZE;
-    for (int block = 0; block < blocks; block++) {
-      int offset = block * GGUF_Q_BLOCK_SIZE;
-      float absoluteMax = 0.0f;
-      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
-        absoluteMax = Math.max(absoluteMax, Math.abs(query[offset + index]));
-      }
-
-      float scale = absoluteMax / 127.0f;
-      float inverseScale = absoluteMax == 0.0f ? 0.0f : 127.0f / absoluteMax;
-      scales[block] = Float.float16ToFloat(Float.floatToFloat16(scale));
-      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
-        quants[offset + index] = (byte) ggmlNearestInt(query[offset + index] * inverseScale);
-      }
-    }
+    GgufQuantizationSupport.quantizeQ8_0(query, dimensions, quants, scales);
   }
 
   private static int ggmlNearestInt(float value) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -97,6 +97,8 @@ public final class VectorizationProvider {
     String maxBits = System.getProperty("vectors.maxBits");
     String useVectorFMA = System.getProperty("vectors.useVectorFMA");
     String useScalarFMA = System.getProperty("vectors.useScalarFMA");
+    String ggufParallel = System.getProperty("vectors.gguf.parallel");
+    String ggufParallelThreshold = System.getProperty("vectors.gguf.parallelThreshold");
 
     StringBuilder sb = new StringBuilder("vectors-core: provider=");
     sb.append(impl.getClass().getSimpleName());
@@ -106,6 +108,8 @@ public final class VectorizationProvider {
     sb.append(" fastVectorFMA=").append(PanamaConstants.HAS_FAST_VECTOR_FMA);
     sb.append(" fastScalarFMA=").append(PanamaConstants.HAS_FAST_SCALAR_FMA);
     sb.append(" sve=").append(PanamaConstants.HAS_SVE);
+    sb.append(" ggufParallel=").append(GgufParallelSupport.enabled());
+    sb.append(" ggufParallelThreshold=").append(GgufParallelSupport.minElements());
     sb.append(" toggles=[");
     boolean first = true;
     if (forceScalar != null) {
@@ -125,6 +129,16 @@ public final class VectorizationProvider {
     if (useScalarFMA != null) {
       if (!first) sb.append(", ");
       sb.append("vectors.useScalarFMA=").append(useScalarFMA);
+      first = false;
+    }
+    if (ggufParallel != null) {
+      if (!first) sb.append(", ");
+      sb.append("vectors.gguf.parallel=").append(ggufParallel);
+      first = false;
+    }
+    if (ggufParallelThreshold != null) {
+      if (!first) sb.append(", ");
+      sb.append("vectors.gguf.parallelThreshold=").append(ggufParallelThreshold);
       first = false;
     }
     if (first) sb.append("(defaults — no -Dvectors.* overrides)");

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.foreign.Arena;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class GgufParallelSupportTest {
+
+  @Test
+  void parallelizesOnlyLargeMatricesWhenMultipleProcessorsAreAvailable() {
+    assertThat(GgufParallelSupport.shouldParallelize(1024, 2048, 8, true, 1_048_576L)).isTrue();
+    assertThat(GgufParallelSupport.shouldParallelize(32, 2048, 8, true, 1_048_576L)).isFalse();
+    assertThat(GgufParallelSupport.shouldParallelize(1024, 2048, 1, true, 1_048_576L)).isFalse();
+    assertThat(GgufParallelSupport.shouldParallelize(1024, 2048, 8, false, 1_048_576L)).isFalse();
+  }
+
+  @Test
+  void workCalculationDoesNotOverflowIntRange() {
+    assertThat(
+            GgufParallelSupport.shouldParallelize(
+                Integer.MAX_VALUE, Integer.MAX_VALUE, 8, true, Integer.MAX_VALUE))
+        .isTrue();
+  }
+
+  @Test
+  void q8ThresholdKeepsSmallMatricesSerialAndLargeMatricesParallel() {
+    assertThat(
+            GgufParallelSupport.shouldParallelize(
+                1024, 2048, 8, true, GgufParallelSupport.Q8_MIN_ELEMENTS))
+        .isFalse();
+    assertThat(
+            GgufParallelSupport.shouldParallelize(
+                8192, 2048, 8, true, GgufParallelSupport.Q8_MIN_ELEMENTS))
+        .isTrue();
+  }
+
+  @Test
+  void confinedSegmentsRemainOnTheirOwnerThread() {
+    AtomicInteger rowsVisited = new AtomicInteger();
+    Set<Thread> threads = ConcurrentHashMap.newKeySet();
+    Thread owner = Thread.currentThread();
+
+    try (Arena arena = Arena.ofConfined()) {
+      GgufParallelSupport.forEachRow(
+          arena.allocate(1),
+          1024,
+          2048,
+          ignored -> {
+            rowsVisited.incrementAndGet();
+            threads.add(Thread.currentThread());
+          });
+    }
+
+    assertThat(rowsVisited).hasValue(1024);
+    assertThat(threads).containsExactly(owner);
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -472,6 +472,41 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q6_KQ8_KBatchDotProduct_reusesIndependentScratchAcrossParallelRows() {
+    int rows = 4096;
+    float[] query = patternedQuery(256);
+    byte[] row = q6KBlock(0.125f, index -> (index * 5 + 3) % 64 - 32, index -> index - 8);
+    float[] expected = new float[1];
+    float[] out = new float[rows];
+    byte[] expectedQuants = new byte[query.length];
+    float[] expectedScales = new float[1];
+    byte[] q8Quants = new byte[query.length];
+    float[] q8Scales = new float[1];
+
+    new ScalarVectorUtilSupport()
+        .ggufQ6_KQ8_KMatVecDot(
+            query,
+            MemorySegment.ofArray(row),
+            1,
+            query.length,
+            expected,
+            expectedQuants,
+            expectedScales);
+    VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+        query,
+        MemorySegment.ofArray(repeat(row, rows)),
+        rows,
+        query.length,
+        out,
+        q8Quants,
+        q8Scales);
+
+    assertThat(q8Quants).containsExactly(expectedQuants);
+    assertThat(q8Scales).containsExactly(expectedScales);
+    assertThat(out).containsOnly(expected[0]);
+  }
+
+  @Test
   void q4_KQ8_KBatchDotProduct_quantizesTheQueryOnceUsingGgmlSemantics() {
     float[] query = new float[256];
     query[0] = 1.0f;
@@ -649,6 +684,14 @@ class GgufQuantizedDotTest {
       }
     }
     return block;
+  }
+
+  private static byte[] repeat(byte[] row, int count) {
+    byte[] result = new byte[Math.multiplyExact(row.length, count)];
+    for (int index = 0; index < count; index++) {
+      System.arraycopy(row, 0, result, index * row.length, row.length);
+    }
+    return result;
   }
 
   private static byte[] q8Block(float scale) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class PanamaGgufQuantizedDotTest {
+
+  @Test
+  void panamaProviderOwnsQ4_0Q8_0Kernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ4_0Q8_0MatVecDot");
+  }
+
+  @Test
+  void q4_0Q8_0KernelMatchesScalarReferenceAcrossRowsAndBlocks() {
+    int rows = 512;
+    int cols = 2048;
+    Random random = new Random(0x5148L);
+    float[] query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 18];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 18) {
+      float scale = random.nextFloat() * 0.05f + 0.001f;
+      buffer.putShort(offset, Float.floatToFloat16(scale));
+    }
+
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+    byte[] expectedQuants = new byte[cols];
+    byte[] actualQuants = new byte[cols];
+    float[] expectedScales = new float[cols / 32];
+    float[] actualScales = new float[cols / 32];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ4_0Q8_0MatVecDot(
+            query, weightSegment, rows, cols, expected, expectedQuants, expectedScales);
+    new PanamaVectorUtilSupport()
+        .ggufQ4_0Q8_0MatVecDot(
+            query, weightSegment, rows, cols, actual, actualQuants, actualScales);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actual).containsExactly(expected);
+  }
+}


### PR DESCRIPTION
## What changed

- add a Panama-owned Q4_0 x Q8_0 SIMD kernel
- parallelize independent GGUF rows for Q4_0, Q4_K, Q5_0, Q5_K, Q6_K, and large Q8_0 matrices
- keep confined memory segments on their owner thread and use per-worker Q6_K scratch
- expose `vectors.gguf.parallel` and `vectors.gguf.parallelThreshold` controls and log their resolved values
- document the execution policy and allow serial/parallel JMH controls

## Why

The pure-Java models backend selected the Panama provider, but its dominant Q4_0 x Q8_0 kernel inherited the scalar, single-threaded default. JFR attributed most generation CPU samples to that fallback. The same issue affected the other fused GGUF quantized kernels.

On a 2019 Intel i7 Mac, the 1024 x 2048 JMH serial controls improved by 3.5x to 4.7x for Q4/Q5/Q6. Q8 stays serial below four million elements; at 8192 x 2048 it improved from 15.37 ms to 2.49 ms. End-to-end Qwen3-0.6B decode improved from 1.68 to 9.93 tokens/second.

## Validation

- `./gradlew :vectors-core:check`
- randomized scalar-equivalence test for the Panama Q4_0 x Q8_0 kernel
- shared/confined memory-scope scheduler tests
- large parallel Q6_K scratch-isolation test
- serial and parallel `GgufQuantizedMatVecBenchmark` JMH controls
