### PR TITLE
perf(core): vectorize Q8 and Q4_K GGUF matvec

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
@@ -15,6 +15,10 @@
  */
 package com.integrallis.vectors.core;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Arrays;
+
 /** Shared activation quantization used by scalar and Panama GGUF kernels. */
 final class GgufQuantizationSupport {
 
@@ -38,6 +42,69 @@ final class GgufQuantizationSupport {
         quants[offset + index] = (byte) ggmlNearestInt(query[offset + index] * inverseScale);
       }
     }
+  }
+
+  static void quantizeQ8_K(
+      float[] query, int dimensions, byte[] quants, float[] scales, short[] sums) {
+    int blockSize = VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE;
+    int sumBlockSize = VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE;
+    int blocks = dimensions / blockSize;
+    for (int block = 0; block < blocks; block++) {
+      int offset = block * blockSize;
+      float max = 0.0f;
+      float absoluteMax = 0.0f;
+      for (int index = 0; index < blockSize; index++) {
+        float value = query[offset + index];
+        float absolute = Math.abs(value);
+        if (absolute > absoluteMax) {
+          absoluteMax = absolute;
+          max = value;
+        }
+      }
+
+      if (absoluteMax == 0.0f) {
+        Arrays.fill(quants, offset, offset + blockSize, (byte) 0);
+        if (sums != null) {
+          Arrays.fill(sums, offset / sumBlockSize, (offset + blockSize) / sumBlockSize, (short) 0);
+        }
+        scales[block] = 0.0f;
+        continue;
+      }
+
+      float inverseScale = -127.0f / max;
+      int sum = 0;
+      for (int index = 0; index < blockSize; index++) {
+        int quant = ggmlNearestInt(inverseScale * query[offset + index]);
+        byte stored = (byte) Math.min(127, quant);
+        quants[offset + index] = stored;
+        if (sums != null) {
+          sum += stored;
+          if ((index + 1) % sumBlockSize == 0) {
+            sums[(offset + index) / sumBlockSize] = (short) sum;
+            sum = 0;
+          }
+        }
+      }
+      scales[block] = 1.0f / inverseScale;
+    }
+  }
+
+  static int qKScale(MemorySegment qWeight, long scalesOffset, int group) {
+    if (group < 4) {
+      return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0x3F;
+    }
+    int low = qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x0F;
+    int high = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group - 4L) & 0xFF) >>> 6;
+    return low | (high << 4);
+  }
+
+  static int qKMin(MemorySegment qWeight, long scalesOffset, int group) {
+    if (group < 4) {
+      return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x3F;
+    }
+    int low = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0xFF) >>> 4;
+    int high = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0xFF) >>> 6;
+    return low | (high << 4);
   }
 
   static Q6Scratch q6Scratch() {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -409,6 +409,115 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return sum;
   }
 
+  /** SIMD Q8_0 by Q8_0 GEMV with one activation quantization shared by all rows. */
+  @Override
+  public void ggufQ8_0Q8_0MatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q8_0_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+            float scale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+            int integerSum =
+                q8_0Q8_0IntegerDot(
+                    qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+            sum = MathUtil.fma(scale, integerSum, sum);
+          }
+          out[row] = sum;
+        });
+  }
+
+  private static int q8_0Q8_0IntegerDot(
+      MemorySegment qWeight, long weightOffset, byte[] q8Quants, int quantOffset) {
+    if (VECTOR_BITSIZE >= 512) {
+      IntVector accumulator = IntVector.zero(IntVector.SPECIES_512);
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 16) {
+        ByteVector weights =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_128, qWeight, weightOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector quants =
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + index);
+        IntVector weightInts =
+            (IntVector) weights.convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0);
+        IntVector quantInts =
+            (IntVector) quants.convertShape(VectorOperators.B2I, IntVector.SPECIES_512, 0);
+        accumulator = accumulator.add(weightInts.mul(quantInts));
+      }
+      return accumulator.reduceLanes(VectorOperators.ADD);
+    }
+
+    if (VECTOR_BITSIZE >= 256) {
+      IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 8) {
+        ByteVector weights =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_64, qWeight, weightOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector quants =
+            ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index);
+        IntVector weightInts =
+            (IntVector) weights.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        IntVector quantInts =
+            (IntVector) quants.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        accumulator = accumulator.add(weightInts.mul(quantInts));
+      }
+      return accumulator.reduceLanes(VectorOperators.ADD);
+    }
+
+    if (VECTOR_BITSIZE >= 128) {
+      IntVector lowAccumulator = IntVector.zero(IntVector.SPECIES_128);
+      IntVector highAccumulator = IntVector.zero(IntVector.SPECIES_128);
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 8) {
+        ShortVector weights =
+            (ShortVector)
+                ByteVector.fromMemorySegment(
+                        ByteVector.SPECIES_64,
+                        qWeight,
+                        weightOffset + index,
+                        ByteOrder.LITTLE_ENDIAN)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+        ShortVector quants =
+            (ShortVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+        IntVector weightLow =
+            (IntVector) weights.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+        IntVector weightHigh =
+            (IntVector) weights.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 1);
+        IntVector quantLow =
+            (IntVector) quants.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+        IntVector quantHigh =
+            (IntVector) quants.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 1);
+        lowAccumulator = lowAccumulator.add(weightLow.mul(quantLow));
+        highAccumulator = highAccumulator.add(weightHigh.mul(quantHigh));
+      }
+      return lowAccumulator.add(highAccumulator).reduceLanes(VectorOperators.ADD);
+    }
+
+    int sum = 0;
+    for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
+      sum +=
+          qWeight.get(ValueLayout.JAVA_BYTE, weightOffset + index) * q8Quants[quantOffset + index];
+    }
+    return sum;
+  }
+
   // --- Byte dot product: widening to avoid overflow ---
   //
   // Tiered widening strategy (B2I = byte-to-int, 4x lane expansion):

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -409,6 +409,107 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return sum;
   }
 
+  /** SIMD Q4_K by Q8_K GEMV with one activation quantization shared by all rows. */
+  @Override
+  public void ggufQ4_KQ8_KMatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = (long) (cols / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+            float q8Scale = q8Scales[block];
+            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+            float dMin =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                    * q8Scale;
+            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+            int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+            int quantizedSum = 0;
+            int minimumSum = 0;
+
+            for (int group = 0; group < 8; group++) {
+              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+              int shift = (group & 1) * 4;
+              int groupActivationOffset = activationOffset + group * 32;
+              int groupDot =
+                  q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+              quantizedSum += scale * groupDot;
+              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+            }
+
+            sum = MathUtil.fma(d, quantizedSum, sum);
+            sum = MathUtil.fma(-dMin, minimumSum, sum);
+          }
+          out[row] = sum;
+        });
+  }
+
+  private static int q4_KQ8_KIntegerDot(
+      MemorySegment qWeight, long packedOffset, int shift, byte[] q8Quants, int quantOffset) {
+    if (VECTOR_BITSIZE >= 256) {
+      int sum = 0;
+      for (int index = 0; index < 32; index += 16) {
+        ByteVector packed =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_128, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector q4 = packed.lanewise(VectorOperators.LSHR, shift).and((byte) 0x0F);
+        ShortVector q4Shorts =
+            (ShortVector) q4.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+        ShortVector q8Shorts =
+            (ShortVector)
+                ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + index)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+        sum += q4Shorts.mul(q8Shorts).reduceLanes(VectorOperators.ADD);
+      }
+      return sum;
+    }
+
+    if (VECTOR_BITSIZE >= 128) {
+      int sum = 0;
+      for (int index = 0; index < 32; index += 8) {
+        ByteVector packed =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_64, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector q4 = packed.lanewise(VectorOperators.LSHR, shift).and((byte) 0x0F);
+        ShortVector q4Shorts =
+            (ShortVector) q4.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+        ShortVector q8Shorts =
+            (ShortVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+        sum += q4Shorts.mul(q8Shorts).reduceLanes(VectorOperators.ADD);
+      }
+      return sum;
+    }
+
+    int sum = 0;
+    for (int index = 0; index < 32; index++) {
+      int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+      sum += ((packed >>> shift) & 0x0F) * q8Quants[quantOffset + index];
+    }
+    return sum;
+  }
+
   /** SIMD Q8_0 by Q8_0 GEMV with one activation quantization shared by all rows. */
   @Override
   public void ggufQ8_0Q8_0MatVecDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -239,8 +239,8 @@ public interface VectorUtilSupport {
       int queryOffset = block * GGUF_Q4_K_BLOCK_SIZE;
 
       for (int group = 0; group < 8; group++) {
-        int scale = qKScale(qWeight, scalesOffset, group);
-        int min = qKMin(qWeight, scalesOffset, group);
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
         float scaledD = d * scale;
         float minimum = dMin * min;
         long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
@@ -272,8 +272,8 @@ public interface VectorUtilSupport {
       int outputOffset = outOffset + block * GGUF_Q4_K_BLOCK_SIZE;
 
       for (int group = 0; group < 8; group++) {
-        int scale = qKScale(qWeight, scalesOffset, group);
-        int min = qKMin(qWeight, scalesOffset, group);
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
         float scaledD = d * scale;
         float minimum = dMin * min;
         long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
@@ -310,8 +310,8 @@ public interface VectorUtilSupport {
       int queryOffset = block * GGUF_Q5_K_BLOCK_SIZE;
 
       for (int group = 0; group < 8; group++) {
-        int scale = qKScale(qWeight, scalesOffset, group);
-        int min = qKMin(qWeight, scalesOffset, group);
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
         float scaledD = d * scale;
         float minimum = dMin * min;
         long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
@@ -346,8 +346,8 @@ public interface VectorUtilSupport {
       int outputOffset = outOffset + block * GGUF_Q5_K_BLOCK_SIZE;
 
       for (int group = 0; group < 8; group++) {
-        int scale = qKScale(qWeight, scalesOffset, group);
-        int min = qKMin(qWeight, scalesOffset, group);
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
         float scaledD = d * scale;
         float minimum = dMin * min;
         long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
@@ -611,8 +611,8 @@ public interface VectorUtilSupport {
             int minimumSum = 0;
 
             for (int group = 0; group < 8; group++) {
-              int scale = qKScale(qWeight, scalesOffset, group);
-              int min = qKMin(qWeight, scalesOffset, group);
+              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
               long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
               int shift = (group & 1) * 4;
               int groupActivationOffset = activationOffset + group * 32;
@@ -681,8 +681,8 @@ public interface VectorUtilSupport {
             int minimumSum = 0;
 
             for (int group = 0; group < 8; group++) {
-              int scale = qKScale(qWeight, scalesOffset, group);
-              int min = qKMin(qWeight, scalesOffset, group);
+              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
               long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
               int shift = (group & 1) * 4;
               int highBit = 1 << group;
@@ -1113,81 +1113,16 @@ public interface VectorUtilSupport {
   }
 
   private static void quantizeQ8_K(float[] query, int dimensions, byte[] quants, float[] scales) {
-    quantizeQ8_K(query, dimensions, quants, scales, null);
+    GgufQuantizationSupport.quantizeQ8_K(query, dimensions, quants, scales, null);
   }
 
   private static void quantizeQ8_K(
       float[] query, int dimensions, byte[] quants, float[] scales, short[] sums) {
-    int blocks = dimensions / GGUF_Q6_K_BLOCK_SIZE;
-    for (int block = 0; block < blocks; block++) {
-      int offset = block * GGUF_Q6_K_BLOCK_SIZE;
-      float max = 0.0f;
-      float absoluteMax = 0.0f;
-      for (int index = 0; index < GGUF_Q6_K_BLOCK_SIZE; index++) {
-        float value = query[offset + index];
-        float absolute = Math.abs(value);
-        if (absolute > absoluteMax) {
-          absoluteMax = absolute;
-          max = value;
-        }
-      }
-
-      if (absoluteMax == 0.0f) {
-        java.util.Arrays.fill(quants, offset, offset + GGUF_Q6_K_BLOCK_SIZE, (byte) 0);
-        if (sums != null) {
-          java.util.Arrays.fill(
-              sums,
-              offset / GGUF_Q8_K_SUM_BLOCK_SIZE,
-              (offset + GGUF_Q6_K_BLOCK_SIZE) / GGUF_Q8_K_SUM_BLOCK_SIZE,
-              (short) 0);
-        }
-        scales[block] = 0.0f;
-        continue;
-      }
-
-      float inverseScale = -127.0f / max;
-      int sum = 0;
-      for (int index = 0; index < GGUF_Q6_K_BLOCK_SIZE; index++) {
-        int quant = ggmlNearestInt(inverseScale * query[offset + index]);
-        byte stored = (byte) Math.min(127, quant);
-        quants[offset + index] = stored;
-        if (sums != null) {
-          sum += stored;
-          if ((index + 1) % GGUF_Q8_K_SUM_BLOCK_SIZE == 0) {
-            sums[(offset + index) / GGUF_Q8_K_SUM_BLOCK_SIZE] = (short) sum;
-            sum = 0;
-          }
-        }
-      }
-      scales[block] = 1.0f / inverseScale;
-    }
-  }
-
-  private static int qKScale(MemorySegment qWeight, long scalesOffset, int group) {
-    if (group < 4) {
-      return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0x3F;
-    }
-    int low = qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x0F;
-    int high = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group - 4L) & 0xFF) >>> 6;
-    return low | (high << 4);
-  }
-
-  private static int qKMin(MemorySegment qWeight, long scalesOffset, int group) {
-    if (group < 4) {
-      return qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0x3F;
-    }
-    int low = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group + 4L) & 0xFF) >>> 4;
-    int high = (qWeight.get(ValueLayout.JAVA_BYTE, scalesOffset + group) & 0xFF) >>> 6;
-    return low | (high << 4);
+    GgufQuantizationSupport.quantizeQ8_K(query, dimensions, quants, scales, sums);
   }
 
   private static void quantizeQ8_0(float[] query, int dimensions, byte[] quants, float[] scales) {
     GgufQuantizationSupport.quantizeQ8_0(query, dimensions, quants, scales);
-  }
-
-  private static int ggmlNearestInt(float value) {
-    int bits = Float.floatToRawIntBits(value + 12_582_912.0f);
-    return (bits & 0x007F_FFFF) - 0x0040_0000;
   }
 
   /**

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -36,6 +36,13 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ8_0Q8_0Kernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ8_0Q8_0MatVecDot");
+  }
+
+  @Test
   void q4_0Q8_0KernelMatchesScalarReferenceAcrossRowsAndBlocks() {
     int rows = 512;
     int cols = 2048;
@@ -66,6 +73,44 @@ class PanamaGgufQuantizedDotTest {
             query, weightSegment, rows, cols, expected, expectedQuants, expectedScales);
     new PanamaVectorUtilSupport()
         .ggufQ4_0Q8_0MatVecDot(
+            query, weightSegment, rows, cols, actual, actualQuants, actualScales);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q8_0Q8_0KernelMatchesScalarReferenceAcrossRowsAndBlocks() {
+    int rows = 512;
+    int cols = 2048;
+    Random random = new Random(0x5188L);
+    float[] query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 34];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 34) {
+      float scale = random.nextFloat() * 0.05f + 0.001f;
+      buffer.putShort(offset, Float.floatToFloat16(scale));
+    }
+
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+    byte[] expectedQuants = new byte[cols];
+    byte[] actualQuants = new byte[cols];
+    float[] expectedScales = new float[cols / 32];
+    float[] actualScales = new float[cols / 32];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ8_0Q8_0MatVecDot(
+            query, weightSegment, rows, cols, expected, expectedQuants, expectedScales);
+    new PanamaVectorUtilSupport()
+        .ggufQ8_0Q8_0MatVecDot(
             query, weightSegment, rows, cols, actual, actualQuants, actualScales);
 
     assertThat(actualQuants).containsExactly(expectedQuants);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -43,6 +43,13 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ4_KQ8_KKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ4_KQ8_KMatVecDot");
+  }
+
+  @Test
   void q4_0Q8_0KernelMatchesScalarReferenceAcrossRowsAndBlocks() {
     int rows = 512;
     int cols = 2048;
@@ -115,6 +122,56 @@ class PanamaGgufQuantizedDotTest {
 
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q4_KQ8_KKernelMatchesScalarReferenceAcrossRowsAndBlocks() {
+    int rows = 512;
+    int cols = 2048;
+    Random random = new Random(0x514B48L);
+    float[] query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 256) * 144];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 144) {
+      float scale = random.nextFloat() * 0.05f + 0.001f;
+      float minScale = random.nextFloat() * 0.05f;
+      buffer.putShort(offset, Float.floatToFloat16(scale));
+      buffer.putShort(offset + Short.BYTES, Float.floatToFloat16(minScale));
+    }
+
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+    byte[] expectedQuants = new byte[cols];
+    byte[] actualQuants = new byte[cols];
+    float[] expectedScales = new float[cols / 256];
+    float[] actualScales = new float[cols / 256];
+    short[] expectedSums = new short[cols / 16];
+    short[] actualSums = new short[cols / 16];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ4_KQ8_KMatVecDot(
+            query,
+            weightSegment,
+            rows,
+            cols,
+            expected,
+            expectedQuants,
+            expectedScales,
+            expectedSums);
+    new PanamaVectorUtilSupport()
+        .ggufQ4_KQ8_KMatVecDot(
+            query, weightSegment, rows, cols, actual, actualQuants, actualScales, actualSums);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actualSums).containsExactly(expectedSums);
     assertThat(actual).containsExactly(expected);
   }
 }


### PR DESCRIPTION
## Summary
- add Panama-owned fused Q8_0 x Q8_0 and Q4_K x Q8_K GGUF matvec kernels
- widen signed products without overflow on 128-, 256-, and 512-bit vector widths
- share Q8_K activation quantization and K-quant scale parsing across scalar and Panama paths
- preserve exact scalar/GGML arithmetic with randomized multi-row coverage

## Performance
`GgufQuantizedMatVecBenchmark` (1024x2048, JDK 25, 256-bit provider):

| Kernel | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Q8_0 x Q8_0 | 2.460 ms/op | 1.071 ms/op | 2.30x |
| Q4_K x Q8_K | 0.683 ms/op | 0.453 ms/op | 1.51x |

The Q8 change reduced controlled SmolLM2 360M Q8_0 pure-Java TTFT from about 29.95s in the interrupted pre-change baseline to 10.55s across the completed 10-trial run. A controlled MiniCPM5 rerun will quantify the Q4_K end-to-end effect after this PR lands.

## Validation
- failing ownership tests were added before each provider override
- randomized kernels match scalar outputs exactly across 512 rows and 2048 columns
- `./gradlew :vectors-core:test --tests com.integrallis.vectors.core.PanamaGgufQuantizedDotTest`
- `./gradlew :vectors-core:spotlessApply :vectors-core:check`