### PR TITLE
perf(core): accelerate pure-Java GGUF execution

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -71,6 +71,20 @@
         <Class name="com.integrallis.vectors.bench.TieredIvfRecallQpsBenchmark"/>
         <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
     </Match>
+    <!-- vectors-bench: GgufBatchedMatmulBenchmark reuses one fixed-seed Random for every
+         activation and weight value in @Setup. SpotBugs reports the allocation as one-shot
+         even though the nested loops and block generators make repeated calls. -->
+    <Match>
+        <Class name="com.integrallis.vectors.bench.GgufBatchedMatmulBenchmark"/>
+        <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
+    </Match>
+    <!-- vectors-bench: GgufRowDispatchBenchmark's query, weights, and IntConsumer are JMH
+         @State read from a method-reference callback reached by the @Benchmark method. The
+         generated JMH caller is unavailable during SpotBugs analysis, producing UrF warnings. -->
+    <Match>
+        <Class name="com.integrallis.vectors.core.GgufRowDispatchBenchmark"/>
+        <Bug pattern="URF_UNREAD_FIELD"/>
+    </Match>
     <!-- HNSW: SearchResult record exposes/stores arrays intentionally for zero-copy access -->
     <Match>
         <Class name="com.integrallis.vectors.hnsw.SearchResult"/>

--- a/vectors-bench/build.gradle.kts
+++ b/vectors-bench/build.gradle.kts
@@ -75,7 +75,7 @@ jmh {
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
     // Forward GGUF kernel controls so serial/parallel comparisons use the same JMH harness.
-    listOf("vectors.gguf.parallel", "vectors.gguf.parallelThreshold", "vectors.gguf.parallelism").forEach { key ->
+    listOf("vectors.gguf.parallel", "vectors.gguf.parallelThreshold").forEach { key ->
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
     // Time-box overrides for short/dev runs:

--- a/vectors-bench/build.gradle.kts
+++ b/vectors-bench/build.gradle.kts
@@ -75,7 +75,7 @@ jmh {
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
     // Forward GGUF kernel controls so serial/parallel comparisons use the same JMH harness.
-    listOf("vectors.gguf.parallel", "vectors.gguf.parallelThreshold").forEach { key ->
+    listOf("vectors.gguf.parallel", "vectors.gguf.parallelThreshold", "vectors.gguf.parallelism").forEach { key ->
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
     // Time-box overrides for short/dev runs:

--- a/vectors-bench/build.gradle.kts
+++ b/vectors-bench/build.gradle.kts
@@ -75,7 +75,13 @@ jmh {
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
     // Forward GGUF kernel controls so serial/parallel comparisons use the same JMH harness.
-    listOf("vectors.gguf.parallel", "vectors.gguf.parallelThreshold").forEach { key ->
+    listOf(
+        "vectors.gguf.parallel",
+        "vectors.gguf.parallelThreshold",
+        "vectors.gguf.executor",
+        "vectors.gguf.threads",
+        "vectors.gguf.chunksPerThread"
+    ).forEach { key ->
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }
     // Time-box overrides for short/dev runs:

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
@@ -62,6 +62,7 @@ public class GgufBatchedMatmulBenchmark {
   private float[] independentOut;
   private byte[] batchedQuants;
   private float[] batchedScales;
+  private float[] batchedLanes;
   private byte[] independentQuants;
   private float[] independentScales;
 
@@ -90,6 +91,7 @@ public class GgufBatchedMatmulBenchmark {
     independentOut = new float[rows];
     batchedQuants = new byte[batchSize * cols];
     batchedScales = new float[batchSize * (cols / 32)];
+    batchedLanes = new float[batchSize * rows * 8];
     independentQuants = new byte[cols];
     independentScales = new float[cols / 32];
   }
@@ -104,7 +106,8 @@ public class GgufBatchedMatmulBenchmark {
         cols,
         batchedOut,
         batchedQuants,
-        batchedScales);
+        batchedScales,
+        batchedLanes);
     blackhole.consume(batchedOut);
   }
 
@@ -112,13 +115,7 @@ public class GgufBatchedMatmulBenchmark {
   public void independent(Blackhole blackhole) {
     for (float[] query : independentQueries) {
       VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-          query,
-          weights,
-          rows,
-          cols,
-          independentOut,
-          independentQuants,
-          independentScales);
+          query, weights, rows, cols, independentOut, independentQuants, independentScales);
       blackhole.consume(independentOut);
     }
   }

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares weight-reusing Q4_0 batched matmul with independent GEMV calls. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufBatchedMatmulBenchmark {
+
+  @Param({"1", "8", "32"})
+  int batchSize;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] queries;
+  private float[][] independentQueries;
+  private MemorySegment weights;
+  private float[] batchedOut;
+  private float[] independentOut;
+  private byte[] batchedQuants;
+  private float[] batchedScales;
+  private byte[] independentQuants;
+  private float[] independentScales;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(42L);
+    queries = new float[batchSize * cols];
+    independentQueries = new float[batchSize][cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        float value = random.nextFloat() * 2.0f - 1.0f;
+        queries[batch * cols + col] = value;
+        independentQueries[batch][col] = value;
+      }
+    }
+
+    byte[] blocks = new byte[rows * (cols / 32) * 18];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    for (int offset = 0; offset < blocks.length; offset += 18) {
+      buffer.putShort(offset, scale);
+    }
+    weights = MemorySegment.ofArray(blocks);
+    batchedOut = new float[batchSize * rows];
+    independentOut = new float[rows];
+    batchedQuants = new byte[batchSize * cols];
+    batchedScales = new float[batchSize * (cols / 32)];
+    independentQuants = new byte[cols];
+    independentScales = new float[cols / 32];
+  }
+
+  @Benchmark
+  public void batched(Blackhole blackhole) {
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQuants,
+        batchedScales);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void independent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+          query,
+          weights,
+          rows,
+          cols,
+          independentOut,
+          independentQuants,
+          independentScales);
+      blackhole.consume(independentOut);
+    }
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -54,11 +54,15 @@ public class GgufQuantizedMatVecBenchmark {
 
   private float[] query;
   private MemorySegment q4Weights;
+  private MemorySegment secondQ4Weights;
+  private MemorySegment thirdQ4Weights;
   private MemorySegment q4KWeights;
   private MemorySegment q5Weights;
   private MemorySegment q8Weights;
   private MemorySegment q6Weights;
   private float[] out;
+  private float[] secondOut;
+  private float[] thirdOut;
   private byte[] q8Quants;
   private float[] q8Scales;
   private short[] q8Sums;
@@ -77,11 +81,17 @@ public class GgufQuantizedMatVecBenchmark {
     byte[] q8 = randomBlocks(random, rows * (cols / 32) * 34, 34, 0);
     byte[] q6 = randomBlocks(random, rows * (cols / 256) * 210, 210, 208);
     q4Weights = MemorySegment.ofArray(q4);
+    secondQ4Weights = MemorySegment.ofArray(randomBlocks(random, rows * (cols / 32) * 18, 18, 0));
+    int auxiliaryRows = Math.max(1, rows / 8);
+    thirdQ4Weights =
+        MemorySegment.ofArray(randomBlocks(random, auxiliaryRows * (cols / 32) * 18, 18, 0));
     q4KWeights = MemorySegment.ofArray(q4K);
     q5Weights = MemorySegment.ofArray(q5);
     q8Weights = MemorySegment.ofArray(q8);
     q6Weights = MemorySegment.ofArray(q6);
     out = new float[rows];
+    secondOut = new float[rows];
+    thirdOut = new float[auxiliaryRows];
     q8Quants = new byte[cols];
     q8Scales = new float[cols / 32];
     q8Sums = new short[cols / 16];
@@ -97,6 +107,58 @@ public class GgufQuantizedMatVecBenchmark {
   public void q4_0WithQ8_0Activation(Blackhole blackhole) {
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
     blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q4_0SeparateDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, secondQ4Weights, rows, cols, secondOut, q8Quants, q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q4_0GroupedDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ4_0Q8_0DualBatchDotProduct(
+        query, q4Weights, rows, out, secondQ4Weights, rows, secondOut, cols, q8Quants, q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q4_0SeparateQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = Math.max(1, rows / 8);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, secondQ4Weights, auxiliaryRows, cols, secondOut, q8Quants, q8Scales);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, thirdQ4Weights, auxiliaryRows, cols, thirdOut, q8Quants, q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
+  }
+
+  @Benchmark
+  public void q4_0GroupedQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = Math.max(1, rows / 8);
+    VectorUtil.ggufQ4_0Q8_0TripleBatchDotProduct(
+        query,
+        q4Weights,
+        rows,
+        out,
+        secondQ4Weights,
+        auxiliaryRows,
+        secondOut,
+        thirdQ4Weights,
+        auxiliaryRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
   }
 
   @Benchmark

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufRowDispatchBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufRowDispatchBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Measures repeated row-executor handoffs using a decode-sized matrix-vector workload. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Threads(1)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufRowDispatchBenchmark {
+
+  @Param({"COMMON", "DEDICATED", "PERSISTENT"})
+  String executionMode;
+
+  @Param({"1", "141"})
+  int projections;
+
+  @Param("1024")
+  int rows;
+
+  @Param("1024")
+  int cols;
+
+  private GgufRowExecutor executor;
+  private float[] query;
+  private float[] weights;
+  private float[] output;
+  private IntConsumer rowOperation;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(42L);
+    query = randomFloats(random, cols);
+    weights = randomFloats(random, rows * cols);
+    output = new float[rows];
+    rowOperation = this::dotRow;
+    int parallelism = Runtime.getRuntime().availableProcessors();
+    executor =
+        GgufParallelSupport.newExecutor(
+            GgufParallelSupport.ExecutionMode.parse(executionMode),
+            parallelism,
+            4,
+            "vectors-bench");
+  }
+
+  @Benchmark
+  public void projectionSequence(Blackhole blackhole) {
+    for (int projection = 0; projection < projections; projection++) {
+      executor.forEach(rows, rowOperation);
+    }
+    blackhole.consume(output);
+  }
+
+  private void dotRow(int row) {
+    int offset = row * cols;
+    float sum = 0.0f;
+    for (int col = 0; col < cols; col++) {
+      sum = Math.fma(weights[offset + col], query[col], sum);
+    }
+    output[row] = sum;
+  }
+
+  private static float[] randomFloats(Random random, int size) {
+    float[] values = new float[size];
+    for (int index = 0; index < size; index++) {
+      values[index] = random.nextFloat() * 2.0f - 1.0f;
+    }
+    return values;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    executor.close();
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufDedicatedRowExecutor.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufDedicatedRowExecutor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+
+/** A dedicated fork-join pool that isolates GGUF work from the JVM common pool. */
+final class GgufDedicatedRowExecutor implements GgufRowExecutor {
+
+  private final ForkJoinPool pool;
+
+  GgufDedicatedRowExecutor(int parallelism, String threadNamePrefix) {
+    if (parallelism < 1) {
+      throw new IllegalArgumentException("parallelism must be positive");
+    }
+    AtomicInteger workerIds = new AtomicInteger();
+    ForkJoinPool.ForkJoinWorkerThreadFactory workerFactory =
+        owner -> newWorker(owner, threadNamePrefix, workerIds.getAndIncrement());
+    pool = new ForkJoinPool(parallelism, workerFactory, null, true);
+  }
+
+  @Override
+  public void forEach(int rows, IntConsumer rowOperation) {
+    pool.submit(() -> IntStream.range(0, rows).parallel().forEach(rowOperation)).join();
+  }
+
+  private static ForkJoinWorkerThread newWorker(
+      ForkJoinPool owner, String threadNamePrefix, int workerId) {
+    ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(owner);
+    worker.setName(threadNamePrefix + '-' + workerId);
+    return worker;
+  }
+
+  @Override
+  public void close() {
+    pool.shutdown();
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -34,7 +34,7 @@ final class GgufParallelSupport {
   private static final int PARALLELISM =
       positiveIntProperty("vectors.gguf.threads", PROCESSORS, PROCESSORS);
   private static final int CHUNKS_PER_THREAD =
-      positiveIntProperty("vectors.gguf.chunksPerThread", 4, Integer.MAX_VALUE);
+      positiveIntProperty("vectors.gguf.chunksPerThread", 2, Integer.MAX_VALUE);
   private static final ExecutionMode EXECUTION_MODE =
       ExecutionMode.parse(System.getProperty("vectors.gguf.executor"));
   private static final Thread ACCESS_PROBE = Thread.ofPlatform().unstarted(() -> {});
@@ -79,6 +79,10 @@ final class GgufParallelSupport {
     return PARALLELISM;
   }
 
+  static int chunksPerThread() {
+    return CHUNKS_PER_THREAD;
+  }
+
   static GgufRowExecutor newExecutor(
       ExecutionMode mode, int parallelism, int chunksPerThread, String threadNamePrefix) {
     return switch (mode) {
@@ -113,7 +117,7 @@ final class GgufParallelSupport {
 
     static ExecutionMode parse(String configured) {
       if (configured == null || configured.isBlank()) {
-        return COMMON;
+        return PERSISTENT;
       }
       try {
         return valueOf(configured.trim().toUpperCase(Locale.ROOT));

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -16,6 +16,7 @@
 package com.integrallis.vectors.core;
 
 import java.lang.foreign.MemorySegment;
+import java.util.Locale;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
@@ -30,6 +31,12 @@ final class GgufParallelSupport {
   private static final long MIN_ELEMENTS =
       Math.max(1L, Long.getLong("vectors.gguf.parallelThreshold", DEFAULT_MIN_ELEMENTS));
   private static final int PROCESSORS = Runtime.getRuntime().availableProcessors();
+  private static final int PARALLELISM =
+      positiveIntProperty("vectors.gguf.threads", PROCESSORS, PROCESSORS);
+  private static final int CHUNKS_PER_THREAD =
+      positiveIntProperty("vectors.gguf.chunksPerThread", 4, Integer.MAX_VALUE);
+  private static final ExecutionMode EXECUTION_MODE =
+      ExecutionMode.parse(System.getProperty("vectors.gguf.executor"));
   private static final Thread ACCESS_PROBE = Thread.ofPlatform().unstarted(() -> {});
 
   private GgufParallelSupport() {}
@@ -42,8 +49,8 @@ final class GgufParallelSupport {
       MemorySegment weights, int rows, int cols, long formatMinElements, IntConsumer rowOperation) {
     boolean shareable = weights.isAccessibleBy(ACCESS_PROBE);
     long effectiveMinElements = Math.max(MIN_ELEMENTS, formatMinElements);
-    if (shareable && shouldParallelize(rows, cols, PROCESSORS, ENABLED, effectiveMinElements)) {
-      IntStream.range(0, rows).parallel().forEach(rowOperation);
+    if (shareable && shouldParallelize(rows, cols, PARALLELISM, ENABLED, effectiveMinElements)) {
+      ExecutorHolder.INSTANCE.forEach(rows, rowOperation);
       return;
     }
     for (int row = 0; row < rows; row++) {
@@ -62,5 +69,66 @@ final class GgufParallelSupport {
 
   static long minElements() {
     return MIN_ELEMENTS;
+  }
+
+  static ExecutionMode executionMode() {
+    return EXECUTION_MODE;
+  }
+
+  static int parallelism() {
+    return PARALLELISM;
+  }
+
+  static GgufRowExecutor newExecutor(
+      ExecutionMode mode, int parallelism, int chunksPerThread, String threadNamePrefix) {
+    return switch (mode) {
+      case COMMON ->
+          (rows, rowOperation) -> IntStream.range(0, rows).parallel().forEach(rowOperation);
+      case DEDICATED -> new GgufDedicatedRowExecutor(parallelism, threadNamePrefix);
+      case PERSISTENT ->
+          new GgufPersistentRowExecutor(parallelism, chunksPerThread, threadNamePrefix);
+    };
+  }
+
+  private static int positiveIntProperty(String name, int defaultValue, int maximum) {
+    String configured = System.getProperty(name);
+    if (configured == null) {
+      return defaultValue;
+    }
+    try {
+      int value = Integer.parseInt(configured);
+      if (value < 1) {
+        throw new IllegalArgumentException(name + " must be positive: " + configured);
+      }
+      return Math.min(value, maximum);
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException(name + " must be an integer: " + configured, exception);
+    }
+  }
+
+  enum ExecutionMode {
+    COMMON,
+    DEDICATED,
+    PERSISTENT;
+
+    static ExecutionMode parse(String configured) {
+      if (configured == null || configured.isBlank()) {
+        return COMMON;
+      }
+      try {
+        return valueOf(configured.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException exception) {
+        throw new IllegalArgumentException(
+            "vectors.gguf.executor must be common, dedicated, or persistent: " + configured,
+            exception);
+      }
+    }
+  }
+
+  private static final class ExecutorHolder {
+    private static final GgufRowExecutor INSTANCE =
+        newExecutor(EXECUTION_MODE, PARALLELISM, CHUNKS_PER_THREAD, "vectors-gguf");
+
+    private ExecutorHolder() {}
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -16,8 +16,10 @@
 package com.integrallis.vectors.core;
 
 import java.lang.foreign.MemorySegment;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntConsumer;
-import java.util.stream.IntStream;
 
 /** Bounded row parallelism for large, thread-shareable GGUF matrices. */
 final class GgufParallelSupport {
@@ -30,7 +32,20 @@ final class GgufParallelSupport {
   private static final long MIN_ELEMENTS =
       Math.max(1L, Long.getLong("vectors.gguf.parallelThreshold", DEFAULT_MIN_ELEMENTS));
   private static final int PROCESSORS = Runtime.getRuntime().availableProcessors();
+  private static final int PARALLELISM =
+      Math.max(1, Math.min(PROCESSORS, Integer.getInteger("vectors.gguf.parallelism", PROCESSORS)));
   private static final Thread ACCESS_PROBE = Thread.ofPlatform().unstarted(() -> {});
+  private static final AtomicInteger WORKER_SEQUENCE = new AtomicInteger();
+  private static final ForkJoinPool ROW_POOL =
+      new ForkJoinPool(
+          PARALLELISM,
+          pool -> {
+            var worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+            worker.setName("vectors-gguf-" + WORKER_SEQUENCE.incrementAndGet());
+            return worker;
+          },
+          null,
+          false);
 
   private GgufParallelSupport() {}
 
@@ -42,13 +57,17 @@ final class GgufParallelSupport {
       MemorySegment weights, int rows, int cols, long formatMinElements, IntConsumer rowOperation) {
     boolean shareable = weights.isAccessibleBy(ACCESS_PROBE);
     long effectiveMinElements = Math.max(MIN_ELEMENTS, formatMinElements);
-    if (shareable && shouldParallelize(rows, cols, PROCESSORS, ENABLED, effectiveMinElements)) {
-      IntStream.range(0, rows).parallel().forEach(rowOperation);
+    if (shareable && shouldParallelize(rows, cols, PARALLELISM, ENABLED, effectiveMinElements)) {
+      forEachRowInPool(ROW_POOL, rows, rowOperation);
       return;
     }
     for (int row = 0; row < rows; row++) {
       rowOperation.accept(row);
     }
+  }
+
+  static void forEachRowInPool(ForkJoinPool pool, int rows, IntConsumer rowOperation) {
+    pool.invoke(new RowRangeAction(rows, rowOperation, pool.getParallelism()));
   }
 
   static boolean shouldParallelize(
@@ -62,5 +81,65 @@ final class GgufParallelSupport {
 
   static long minElements() {
     return MIN_ELEMENTS;
+  }
+
+  static int parallelism() {
+    return PARALLELISM;
+  }
+
+  @SuppressWarnings("serial")
+  private static final class RowRangeAction extends RecursiveAction {
+    private final int rows;
+    private final IntConsumer rowOperation;
+    private final int parallelism;
+
+    private RowRangeAction(int rows, IntConsumer rowOperation, int parallelism) {
+      this.rows = rows;
+      this.rowOperation = rowOperation;
+      this.parallelism = parallelism;
+    }
+
+    @Override
+    protected void compute() {
+      int taskCount = Math.min(rows, parallelism);
+      int rowsPerTask = (rows + taskCount - 1) / taskCount;
+      RowBatchAction[] forked = new RowBatchAction[taskCount - 1];
+      for (int task = 1; task < taskCount; task++) {
+        int start = task * rowsPerTask;
+        int end = Math.min(rows, start + rowsPerTask);
+        RowBatchAction action = new RowBatchAction(start, end, rowOperation);
+        forked[task - 1] = action;
+        action.fork();
+      }
+
+      runRows(0, Math.min(rows, rowsPerTask), rowOperation);
+      for (RowBatchAction action : forked) {
+        action.join();
+      }
+    }
+  }
+
+  @SuppressWarnings("serial")
+  private static final class RowBatchAction extends RecursiveAction {
+    private final int start;
+    private final int end;
+    private final IntConsumer rowOperation;
+
+    private RowBatchAction(int start, int end, IntConsumer rowOperation) {
+      this.start = start;
+      this.end = end;
+      this.rowOperation = rowOperation;
+    }
+
+    @Override
+    protected void compute() {
+      runRows(start, end, rowOperation);
+    }
+  }
+
+  private static void runRows(int start, int end, IntConsumer rowOperation) {
+    for (int row = start; row < end; row++) {
+      rowOperation.accept(row);
+    }
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -16,8 +16,8 @@
 package com.integrallis.vectors.core;
 
 import java.lang.foreign.MemorySegment;
-import java.util.concurrent.RecursiveAction;
 import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 
 /** Bounded row parallelism for large, thread-shareable GGUF matrices. */
 final class GgufParallelSupport {
@@ -30,8 +30,6 @@ final class GgufParallelSupport {
   private static final long MIN_ELEMENTS =
       Math.max(1L, Long.getLong("vectors.gguf.parallelThreshold", DEFAULT_MIN_ELEMENTS));
   private static final int PROCESSORS = Runtime.getRuntime().availableProcessors();
-  private static final int PARALLELISM =
-      Math.max(1, Math.min(PROCESSORS, Integer.getInteger("vectors.gguf.parallelism", PROCESSORS)));
   private static final Thread ACCESS_PROBE = Thread.ofPlatform().unstarted(() -> {});
 
   private GgufParallelSupport() {}
@@ -44,17 +42,13 @@ final class GgufParallelSupport {
       MemorySegment weights, int rows, int cols, long formatMinElements, IntConsumer rowOperation) {
     boolean shareable = weights.isAccessibleBy(ACCESS_PROBE);
     long effectiveMinElements = Math.max(MIN_ELEMENTS, formatMinElements);
-    if (shareable && shouldParallelize(rows, cols, PARALLELISM, ENABLED, effectiveMinElements)) {
-      forEachRowParallel(rows, PARALLELISM, rowOperation);
+    if (shareable && shouldParallelize(rows, cols, PROCESSORS, ENABLED, effectiveMinElements)) {
+      IntStream.range(0, rows).parallel().forEach(rowOperation);
       return;
     }
     for (int row = 0; row < rows; row++) {
       rowOperation.accept(row);
     }
-  }
-
-  static void forEachRowParallel(int rows, int parallelism, IntConsumer rowOperation) {
-    new RowRangeAction(rows, rowOperation, parallelism).invoke();
   }
 
   static boolean shouldParallelize(
@@ -68,65 +62,5 @@ final class GgufParallelSupport {
 
   static long minElements() {
     return MIN_ELEMENTS;
-  }
-
-  static int parallelism() {
-    return PARALLELISM;
-  }
-
-  @SuppressWarnings("serial")
-  private static final class RowRangeAction extends RecursiveAction {
-    private final int rows;
-    private final IntConsumer rowOperation;
-    private final int parallelism;
-
-    private RowRangeAction(int rows, IntConsumer rowOperation, int parallelism) {
-      this.rows = rows;
-      this.rowOperation = rowOperation;
-      this.parallelism = parallelism;
-    }
-
-    @Override
-    protected void compute() {
-      int taskCount = Math.min(rows, parallelism);
-      int rowsPerTask = (rows + taskCount - 1) / taskCount;
-      RowBatchAction[] forked = new RowBatchAction[taskCount - 1];
-      for (int task = 1; task < taskCount; task++) {
-        int start = task * rowsPerTask;
-        int end = Math.min(rows, start + rowsPerTask);
-        RowBatchAction action = new RowBatchAction(start, end, rowOperation);
-        forked[task - 1] = action;
-        action.fork();
-      }
-
-      runRows(0, Math.min(rows, rowsPerTask), rowOperation);
-      for (RowBatchAction action : forked) {
-        action.join();
-      }
-    }
-  }
-
-  @SuppressWarnings("serial")
-  private static final class RowBatchAction extends RecursiveAction {
-    private final int start;
-    private final int end;
-    private final IntConsumer rowOperation;
-
-    private RowBatchAction(int start, int end, IntConsumer rowOperation) {
-      this.start = start;
-      this.end = end;
-      this.rowOperation = rowOperation;
-    }
-
-    @Override
-    protected void compute() {
-      runRows(start, end, rowOperation);
-    }
-  }
-
-  private static void runRows(int start, int end, IntConsumer rowOperation) {
-    for (int row = start; row < end; row++) {
-      rowOperation.accept(row);
-    }
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -16,9 +16,7 @@
 package com.integrallis.vectors.core;
 
 import java.lang.foreign.MemorySegment;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntConsumer;
 
 /** Bounded row parallelism for large, thread-shareable GGUF matrices. */
@@ -35,17 +33,6 @@ final class GgufParallelSupport {
   private static final int PARALLELISM =
       Math.max(1, Math.min(PROCESSORS, Integer.getInteger("vectors.gguf.parallelism", PROCESSORS)));
   private static final Thread ACCESS_PROBE = Thread.ofPlatform().unstarted(() -> {});
-  private static final AtomicInteger WORKER_SEQUENCE = new AtomicInteger();
-  private static final ForkJoinPool ROW_POOL =
-      new ForkJoinPool(
-          PARALLELISM,
-          pool -> {
-            var worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-            worker.setName("vectors-gguf-" + WORKER_SEQUENCE.incrementAndGet());
-            return worker;
-          },
-          null,
-          false);
 
   private GgufParallelSupport() {}
 
@@ -58,7 +45,7 @@ final class GgufParallelSupport {
     boolean shareable = weights.isAccessibleBy(ACCESS_PROBE);
     long effectiveMinElements = Math.max(MIN_ELEMENTS, formatMinElements);
     if (shareable && shouldParallelize(rows, cols, PARALLELISM, ENABLED, effectiveMinElements)) {
-      forEachRowInPool(ROW_POOL, rows, rowOperation);
+      forEachRowParallel(rows, PARALLELISM, rowOperation);
       return;
     }
     for (int row = 0; row < rows; row++) {
@@ -66,8 +53,8 @@ final class GgufParallelSupport {
     }
   }
 
-  static void forEachRowInPool(ForkJoinPool pool, int rows, IntConsumer rowOperation) {
-    pool.invoke(new RowRangeAction(rows, rowOperation, pool.getParallelism()));
+  static void forEachRowParallel(int rows, int parallelism, IntConsumer rowOperation) {
+    new RowRangeAction(rows, rowOperation, parallelism).invoke();
   }
 
   static boolean shouldParallelize(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -48,6 +48,36 @@ final class GgufParallelSupport {
   static void forEachRow(
       MemorySegment weights, int rows, int cols, long formatMinElements, IntConsumer rowOperation) {
     boolean shareable = weights.isAccessibleBy(ACCESS_PROBE);
+    forEachRow(shareable, rows, cols, formatMinElements, rowOperation);
+  }
+
+  static void forEachRow(
+      MemorySegment firstWeights,
+      MemorySegment secondWeights,
+      int rows,
+      int cols,
+      IntConsumer rowOperation) {
+    boolean shareable =
+        firstWeights.isAccessibleBy(ACCESS_PROBE) && secondWeights.isAccessibleBy(ACCESS_PROBE);
+    forEachRow(shareable, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+  }
+
+  static void forEachRow(
+      MemorySegment firstWeights,
+      MemorySegment secondWeights,
+      MemorySegment thirdWeights,
+      int rows,
+      int cols,
+      IntConsumer rowOperation) {
+    boolean shareable =
+        firstWeights.isAccessibleBy(ACCESS_PROBE)
+            && secondWeights.isAccessibleBy(ACCESS_PROBE)
+            && thirdWeights.isAccessibleBy(ACCESS_PROBE);
+    forEachRow(shareable, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+  }
+
+  private static void forEachRow(
+      boolean shareable, int rows, int cols, long formatMinElements, IntConsumer rowOperation) {
     long effectiveMinElements = Math.max(MIN_ELEMENTS, formatMinElements);
     if (shareable && shouldParallelize(rows, cols, PARALLELISM, ENABLED, effectiveMinElements)) {
       ExecutorHolder.INSTANCE.forEach(rows, rowOperation);

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufPersistentRowExecutor.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufPersistentRowExecutor.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.Objects;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.IntConsumer;
+
+/** Persistent workers for the repeated row-parallel operations used during GGUF decoding. */
+final class GgufPersistentRowExecutor implements GgufRowExecutor {
+
+  private final int parallelism;
+  private final int chunksPerWorker;
+  private final Phaser phase;
+  private final ReentrantLock publicationLock = new ReentrantLock();
+  private final AtomicInteger nextChunk = new AtomicInteger();
+  private final AtomicReference<Throwable> failure = new AtomicReference<>();
+  private final Thread[] workers;
+
+  private IntConsumer operation;
+  private int rows;
+  private int chunkSize;
+  private boolean closed;
+
+  GgufPersistentRowExecutor(int parallelism, int chunksPerWorker, String threadNamePrefix) {
+    if (parallelism < 1) {
+      throw new IllegalArgumentException("parallelism must be positive");
+    }
+    if (chunksPerWorker < 1) {
+      throw new IllegalArgumentException("chunksPerWorker must be positive");
+    }
+    Objects.requireNonNull(threadNamePrefix, "threadNamePrefix");
+
+    this.parallelism = parallelism;
+    this.chunksPerWorker = chunksPerWorker;
+    this.phase = new Phaser(parallelism);
+    this.workers = new Thread[parallelism - 1];
+    for (int index = 0; index < workers.length; index++) {
+      workers[index] =
+          Thread.ofPlatform()
+              .daemon()
+              .name(threadNamePrefix + '-' + index)
+              .unstarted(this::workerLoop);
+      workers[index].start();
+    }
+  }
+
+  @Override
+  public void forEach(int rowCount, IntConsumer rowOperation) {
+    if (rowCount < 0) {
+      throw new IllegalArgumentException("rowCount must not be negative");
+    }
+    Objects.requireNonNull(rowOperation, "rowOperation");
+    if (rowCount == 0) {
+      return;
+    }
+
+    publicationLock.lock();
+    try {
+      ensureOpen();
+      operation = rowOperation;
+      rows = rowCount;
+      int targetChunks = (int) Math.min(rowCount, (long) parallelism * chunksPerWorker);
+      chunkSize = (rowCount + targetChunks - 1) / targetChunks;
+      nextChunk.set(0);
+      failure.set(null);
+
+      phase.arriveAndAwaitAdvance();
+      executePublishedOperation();
+      phase.arriveAndAwaitAdvance();
+
+      Throwable thrown = failure.get();
+      operation = null;
+      if (thrown != null) {
+        rethrow(thrown);
+      }
+    } finally {
+      publicationLock.unlock();
+    }
+  }
+
+  int parallelism() {
+    return parallelism;
+  }
+
+  private void workerLoop() {
+    while (true) {
+      phase.arriveAndAwaitAdvance();
+      if (closed) {
+        phase.arriveAndAwaitAdvance();
+        return;
+      }
+      executePublishedOperation();
+      phase.arriveAndAwaitAdvance();
+    }
+  }
+
+  private void executePublishedOperation() {
+    try {
+      while (failure.get() == null) {
+        int start = nextChunk.getAndIncrement() * chunkSize;
+        if (start >= rows) {
+          return;
+        }
+        int end = Math.min(start + chunkSize, rows);
+        for (int row = start; row < end; row++) {
+          operation.accept(row);
+        }
+      }
+    } catch (Throwable thrown) {
+      failure.compareAndSet(null, thrown);
+    }
+  }
+
+  private void ensureOpen() {
+    if (closed) {
+      throw new IllegalStateException("executor is closed");
+    }
+  }
+
+  private static void rethrow(Throwable thrown) {
+    if (thrown instanceof RuntimeException runtimeException) {
+      throw runtimeException;
+    }
+    if (thrown instanceof Error error) {
+      throw error;
+    }
+    throw new IllegalStateException("row operation failed", thrown);
+  }
+
+  @Override
+  public void close() {
+    publicationLock.lock();
+    try {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      phase.arriveAndAwaitAdvance();
+      phase.arriveAndAwaitAdvance();
+    } finally {
+      publicationLock.unlock();
+    }
+
+    boolean interrupted = false;
+    for (Thread worker : workers) {
+      while (worker.isAlive()) {
+        try {
+          worker.join();
+        } catch (InterruptedException exception) {
+          interrupted = true;
+        }
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
@@ -27,19 +27,31 @@ final class GgufQuantizationSupport {
   private GgufQuantizationSupport() {}
 
   static void quantizeQ8_0(float[] query, int dimensions, byte[] quants, float[] scales) {
+    quantizeQ8_0(query, 0, dimensions, quants, 0, scales, 0);
+  }
+
+  static void quantizeQ8_0(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] quants,
+      int quantOffset,
+      float[] scales,
+      int scaleOffset) {
     int blocks = dimensions / VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
     for (int block = 0; block < blocks; block++) {
       int offset = block * VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
       float absoluteMax = 0.0f;
       for (int index = 0; index < VectorUtilSupport.GGUF_Q_BLOCK_SIZE; index++) {
-        absoluteMax = Math.max(absoluteMax, Math.abs(query[offset + index]));
+        absoluteMax = Math.max(absoluteMax, Math.abs(query[queryOffset + offset + index]));
       }
 
       float scale = absoluteMax / 127.0f;
       float inverseScale = absoluteMax == 0.0f ? 0.0f : 127.0f / absoluteMax;
-      scales[block] = Float.float16ToFloat(Float.floatToFloat16(scale));
+      scales[scaleOffset + block] = Float.float16ToFloat(Float.floatToFloat16(scale));
       for (int index = 0; index < VectorUtilSupport.GGUF_Q_BLOCK_SIZE; index++) {
-        quants[offset + index] = (byte) ggmlNearestInt(query[offset + index] * inverseScale);
+        quants[quantOffset + offset + index] =
+            (byte) ggmlNearestInt(query[queryOffset + offset + index] * inverseScale);
       }
     }
   }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufRowExecutor.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufRowExecutor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.function.IntConsumer;
+
+/** Internal execution contract for independent GGUF output rows. */
+interface GgufRowExecutor extends AutoCloseable {
+
+  void forEach(int rows, IntConsumer rowOperation);
+
+  @Override
+  default void close() {}
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -674,26 +674,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         GgufParallelSupport.Q8_MIN_ELEMENTS,
         row -> {
-          if (VECTOR_BITSIZE == 256) {
-            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
-            long rowOffset = row * rowBytes;
-            for (int block = 0; block < blocks; block++) {
-              long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
-              float scale =
-                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
-              IntVector integerLanes =
-                  q8_0Q8_0IntegerLanes(
-                      qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
-              FloatVector products =
-                  (FloatVector)
-                      integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-              accumulator =
-                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
-            }
-            out[row] = accumulator.reduceLanes(VectorOperators.ADD);
-            return;
-          }
-
           float sum = 0.0f;
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
@@ -781,24 +761,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           qWeight.get(ValueLayout.JAVA_BYTE, weightOffset + index) * q8Quants[quantOffset + index];
     }
     return sum;
-  }
-
-  static IntVector q8_0Q8_0IntegerLanes(
-      MemorySegment qWeight, long weightOffset, byte[] q8Quants, int quantOffset) {
-    IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
-    for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 8) {
-      ByteVector weights =
-          ByteVector.fromMemorySegment(
-              ByteVector.SPECIES_64, qWeight, weightOffset + index, ByteOrder.LITTLE_ENDIAN);
-      ByteVector quants =
-          ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index);
-      IntVector weightInts =
-          (IntVector) weights.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
-      IntVector quantInts =
-          (IntVector) quants.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
-      accumulator = accumulator.add(weightInts.mul(quantInts));
-    }
-    return accumulator;
   }
 
   // --- Byte dot product: widening to avoid overflow ---

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -74,6 +74,9 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ShortVector.SPECIES_256, 0, 0, 0, 0, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorMask<Short> HIGH_GROUP_LANES =
       VectorMask.fromLong(ShortVector.SPECIES_256, 0xF0L);
+  private static final ByteVector Q5_HIGH_BIT_MASKS =
+      ByteVector.fromArray(
+          ByteVector.SPECIES_64, new byte[] {1, 2, 4, 8, 16, 32, 64, (byte) 0x80}, 0);
 
   // --- Conditional FMA helpers ---
 
@@ -652,6 +655,79 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
     return fourProductLanes(firstProducts, secondProducts);
+  }
+
+  /** SIMD Q5_0 by Q8_0 GEMV with one activation quantization shared by all rows. */
+  @Override
+  public void ggufQ5_0Q8_0MatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
+    long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q5_0_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+            float scale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+            int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+            IntVector integerLanes =
+                q5_0Q8_0IntegerLanes(
+                    qWeight,
+                    blockOffset + Short.BYTES + Integer.BYTES,
+                    highBits,
+                    q8Quants,
+                    block * GGUF_Q_BLOCK_SIZE);
+            sum = MathUtil.fma(scale, integerLanes.reduceLanes(VectorOperators.ADD), sum);
+          }
+          out[row] = sum;
+        });
+  }
+
+  static IntVector q5_0Q8_0IntegerLanes(
+      MemorySegment qWeight, long packedOffset, int highBits, byte[] q8Quants, int quantOffset) {
+    IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
+    for (int index = 0; index < 16; index += 8) {
+      ByteVector packed =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = q5Values(packed.and((byte) 0x0F), (byte) (highBits >>> index));
+      ByteVector high =
+          q5Values(
+              packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F),
+              (byte) (highBits >>> (index + 16)));
+      IntVector lowWeights =
+          (IntVector) low.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector highWeights =
+          (IntVector) high.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector lowQuants =
+          (IntVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector highQuants =
+          (IntVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index + 16)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      accumulator = accumulator.add(lowWeights.mul(lowQuants)).add(highWeights.mul(highQuants));
+    }
+    return accumulator;
+  }
+
+  private static ByteVector q5Values(ByteVector lowBits, byte highBits) {
+    VectorMask<Byte> highMask =
+        Q5_HIGH_BIT_MASKS.and(highBits).compare(VectorOperators.NE, (byte) 0);
+    return lowBits.add((byte) 16, highMask).sub((byte) 16);
   }
 
   /** SIMD Q6_K by Q8_K GEMV with one activation quantization shared by all rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -66,6 +66,9 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   private static final VectorShuffle<Short> SWAP_SHORT_PAIRS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
+  private static final VectorShuffle<Short> SELECT_EVEN_PAIRS =
+      VectorShuffle.fromValues(
+          ShortVector.SPECIES_256, 0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorShuffle<Short> SELECT_LOW_GROUPS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -652,6 +655,145 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
     return fourProductLanes(firstProducts, secondProducts);
+  }
+
+  /** SIMD Q6_K by Q8_K GEMV with one activation quantization shared by all rows. */
+  @Override
+  public void ggufQ6_KQ8_KMatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ6_KQ8_KMatVecDot(
+          query, qWeight, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
+
+    GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, null);
+    long rowBytes = (long) (cols / GGUF_Q6_K_BLOCK_SIZE) * GGUF_Q6_K_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+            float d =
+                Float.float16ToFloat(
+                        qWeight.get(
+                            GGUF_LE_SHORT,
+                            blockOffset
+                                + GGUF_Q6_K_QL_BYTES
+                                + GGUF_Q6_K_QH_BYTES
+                                + GGUF_Q6_K_SCALES))
+                    * q8Scales[block];
+            long qlOffset = blockOffset;
+            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+            int activationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+            IntVector blockLanes = IntVector.zero(IntVector.SPECIES_256);
+
+            for (int superBlock = 0; superBlock < 2; superBlock++) {
+              long qlBase = qlOffset + (long) superBlock * 64;
+              long qhBase = qhOffset + (long) superBlock * 32;
+              long scaleBase = scaleOffset + (long) superBlock * 8;
+              int quantBase = activationOffset + superBlock * 128;
+              for (int batch = 0; batch < 32; batch += 16) {
+                int scaleIndex = batch / 16;
+                int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+                int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+                int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+                int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+                blockLanes =
+                    blockLanes.add(
+                        q6_KQ8_KIntegerLanes(
+                            qWeight,
+                            qlBase + batch,
+                            qlBase + 32L + batch,
+                            qhBase + batch,
+                            q8Quants,
+                            quantBase + batch,
+                            s1,
+                            s2,
+                            s3,
+                            s4));
+              }
+            }
+
+            FloatVector products =
+                (FloatVector)
+                    blockLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+            accumulator =
+                fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, d), accumulator);
+          }
+          out[row] = accumulator.reduceLanes(VectorOperators.ADD);
+        });
+  }
+
+  static IntVector q6_KQ8_KIntegerLanes(
+      MemorySegment qWeight,
+      long ql1Offset,
+      long ql2Offset,
+      long qhOffset,
+      byte[] q8Quants,
+      int quantOffset,
+      int s1,
+      int s2,
+      int s3,
+      int s4) {
+    ByteVector ql1 =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, ql1Offset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector ql2 =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, ql2Offset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector qh =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, qhOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector q1 =
+        ql1.and((byte) 0x0F)
+            .or(qh.and((byte) 0x03).lanewise(VectorOperators.LSHL, 4))
+            .sub((byte) 32);
+    ByteVector q2 =
+        ql2.and((byte) 0x0F)
+            .or(qh.and((byte) 0x0C).lanewise(VectorOperators.LSHL, 2))
+            .sub((byte) 32);
+    ByteVector q3 =
+        ql1.lanewise(VectorOperators.LSHR, 4)
+            .and((byte) 0x0F)
+            .or(qh.and((byte) 0x30))
+            .sub((byte) 32);
+    ByteVector q4 =
+        ql2.lanewise(VectorOperators.LSHR, 4)
+            .and((byte) 0x0F)
+            .or(qh.and((byte) 0xC0).lanewise(VectorOperators.LSHR, 2))
+            .sub((byte) 32);
+
+    return pairProductLanes(q1, q8Quants, quantOffset)
+        .mul(s1)
+        .add(pairProductLanes(q2, q8Quants, quantOffset + 32).mul(s2))
+        .add(pairProductLanes(q3, q8Quants, quantOffset + 64).mul(s3))
+        .add(pairProductLanes(q4, q8Quants, quantOffset + 96).mul(s4));
+  }
+
+  private static IntVector pairProductLanes(ByteVector weights, byte[] q8Quants, int quantOffset) {
+    ShortVector weightShorts =
+        (ShortVector) weights.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector quantShorts =
+        (ShortVector)
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector products = weightShorts.mul(quantShorts);
+    ShortVector pairs = products.add(products.rearrange(SWAP_ADJACENT_SHORTS));
+    ShortVector selected = pairs.rearrange(SELECT_EVEN_PAIRS);
+    return (IntVector) selected.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
   }
 
   /** SIMD Q8_0 by Q8_0 GEMV with one activation quantization shared by all rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -465,15 +465,19 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
 
-    ShortVector lowGroups = sumGroupsOfFour(lowProducts).rearrange(SELECT_LOW_GROUPS);
-    ShortVector highGroups = sumGroupsOfFour(highProducts).rearrange(SELECT_HIGH_GROUPS);
-    ShortVector groups = lowGroups.blend(highGroups, HIGH_GROUP_LANES);
-    return (IntVector) groups.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    return fourProductLanes(lowProducts, highProducts);
   }
 
   private static ShortVector sumGroupsOfFour(ShortVector products) {
     ShortVector pairs = products.add(products.rearrange(SWAP_ADJACENT_SHORTS));
     return pairs.add(pairs.rearrange(SWAP_SHORT_PAIRS));
+  }
+
+  private static IntVector fourProductLanes(ShortVector first, ShortVector second) {
+    ShortVector lowGroups = sumGroupsOfFour(first).rearrange(SELECT_LOW_GROUPS);
+    ShortVector highGroups = sumGroupsOfFour(second).rearrange(SELECT_HIGH_GROUPS);
+    ShortVector groups = lowGroups.blend(highGroups, HIGH_GROUP_LANES);
+    return (IntVector) groups.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
   }
 
   /** SIMD Q4_K by Q8_K GEMV with one activation quantization shared by all rows. */
@@ -496,6 +500,48 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         rows,
         cols,
         row -> {
+          if (VECTOR_BITSIZE >= 256) {
+            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+            float minimumContribution = 0.0f;
+            long rowOffset = row * rowBytes;
+            for (int block = 0; block < blocks; block++) {
+              long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+              float q8Scale = q8Scales[block];
+              float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+              float dMin =
+                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                      * q8Scale;
+              long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+              long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+              int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+              IntVector blockLanes = IntVector.zero(IntVector.SPECIES_256);
+              int minimumSum = 0;
+
+              for (int group = 0; group < 8; group++) {
+                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+                int shift = (group & 1) * 4;
+                int groupActivationOffset = activationOffset + group * 32;
+                IntVector groupLanes =
+                    q4_KQ8_KIntegerLanes(
+                        qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+                blockLanes = blockLanes.add(groupLanes.mul(scale));
+                int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+                minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+              }
+
+              FloatVector products =
+                  (FloatVector)
+                      blockLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+              accumulator =
+                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, d), accumulator);
+              minimumContribution = MathUtil.fma(-dMin, minimumSum, minimumContribution);
+            }
+            out[row] = accumulator.reduceLanes(VectorOperators.ADD) + minimumContribution;
+            return;
+          }
+
           float sum = 0.0f;
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
@@ -575,6 +621,37 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       sum += ((packed >>> shift) & 0x0F) * q8Quants[quantOffset + index];
     }
     return sum;
+  }
+
+  static IntVector q4_KQ8_KIntegerLanes(
+      MemorySegment qWeight, long packedOffset, int shift, byte[] q8Quants, int quantOffset) {
+    ByteVector firstPacked =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, packedOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector secondPacked =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, packedOffset + 16, ByteOrder.LITTLE_ENDIAN);
+    ShortVector firstProducts =
+        ((ShortVector)
+                firstPacked
+                    .lanewise(VectorOperators.LSHR, shift)
+                    .and((byte) 0x0F)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
+            .mul(
+                (ShortVector)
+                    ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
+    ShortVector secondProducts =
+        ((ShortVector)
+                secondPacked
+                    .lanewise(VectorOperators.LSHR, shift)
+                    .and((byte) 0x0F)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
+            .mul(
+                (ShortVector)
+                    ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
+    return fourProductLanes(firstProducts, secondProducts);
   }
 
   /** SIMD Q8_0 by Q8_0 GEMV with one activation quantization shared by all rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -66,9 +66,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   private static final VectorShuffle<Short> SWAP_SHORT_PAIRS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
-  private static final VectorShuffle<Short> SELECT_EVEN_PAIRS =
-      VectorShuffle.fromValues(
-          ShortVector.SPECIES_256, 0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorShuffle<Short> SELECT_LOW_GROUPS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -743,53 +740,45 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int s2,
       int s3,
       int s4) {
-    ByteVector ql1 =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, ql1Offset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector ql2 =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, ql2Offset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector qh =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, qhOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector q1 =
-        ql1.and((byte) 0x0F)
-            .or(qh.and((byte) 0x03).lanewise(VectorOperators.LSHL, 4))
-            .sub((byte) 32);
-    ByteVector q2 =
-        ql2.and((byte) 0x0F)
-            .or(qh.and((byte) 0x0C).lanewise(VectorOperators.LSHL, 2))
-            .sub((byte) 32);
-    ByteVector q3 =
-        ql1.lanewise(VectorOperators.LSHR, 4)
-            .and((byte) 0x0F)
-            .or(qh.and((byte) 0x30))
-            .sub((byte) 32);
-    ByteVector q4 =
-        ql2.lanewise(VectorOperators.LSHR, 4)
-            .and((byte) 0x0F)
-            .or(qh.and((byte) 0xC0).lanewise(VectorOperators.LSHR, 2))
-            .sub((byte) 32);
-
-    return pairProductLanes(q1, q8Quants, quantOffset)
-        .mul(s1)
-        .add(pairProductLanes(q2, q8Quants, quantOffset + 32).mul(s2))
-        .add(pairProductLanes(q3, q8Quants, quantOffset + 64).mul(s3))
-        .add(pairProductLanes(q4, q8Quants, quantOffset + 96).mul(s4))
-        .reduceLanes(VectorOperators.ADD);
+    return s1 * q6_KQ8_KGroupDot(qWeight, ql1Offset, qhOffset, 0, 0, q8Quants, quantOffset)
+        + s2 * q6_KQ8_KGroupDot(qWeight, ql2Offset, qhOffset, 0, 2, q8Quants, quantOffset + 32)
+        + s3 * q6_KQ8_KGroupDot(qWeight, ql1Offset, qhOffset, 4, 4, q8Quants, quantOffset + 64)
+        + s4 * q6_KQ8_KGroupDot(qWeight, ql2Offset, qhOffset, 4, 6, q8Quants, quantOffset + 96);
   }
 
-  private static IntVector pairProductLanes(ByteVector weights, byte[] q8Quants, int quantOffset) {
-    ShortVector weightShorts =
-        (ShortVector) weights.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    ShortVector quantShorts =
-        (ShortVector)
-            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
-                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    ShortVector products = weightShorts.mul(quantShorts);
-    ShortVector pairs = products.add(products.rearrange(SWAP_ADJACENT_SHORTS));
-    ShortVector selected = pairs.rearrange(SELECT_EVEN_PAIRS);
-    return (IntVector) selected.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+  private static int q6_KQ8_KGroupDot(
+      MemorySegment qWeight,
+      long qlOffset,
+      long qhOffset,
+      int qlShift,
+      int qhShift,
+      byte[] q8Quants,
+      int quantOffset) {
+    int sum = 0;
+    for (int index = 0; index < 16; index += 8) {
+      ByteVector ql =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qlOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector qh =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qhOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = ql.lanewise(VectorOperators.LSHR, qlShift).and((byte) 0x0F);
+      ByteVector high =
+          qh.lanewise(VectorOperators.LSHR, qhShift)
+              .and((byte) 0x03)
+              .lanewise(VectorOperators.LSHL, 4);
+      IntVector weights =
+          (IntVector)
+              low.add(high)
+                  .sub((byte) 32)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector quants =
+          (IntVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      sum += weights.mul(quants).reduceLanes(VectorOperators.ADD);
+    }
+    return sum;
   }
 
   /** SIMD Q8_0 by Q8_0 GEMV with one activation quantization shared by all rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -399,6 +399,82 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  @Override
+  public void ggufQ4_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmul(
+          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q4_0_BLOCK_BYTES;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            ByteVector packed =
+                ByteVector.fromMemorySegment(
+                    ByteVector.SPECIES_128,
+                    qWeight,
+                    blockOffset + Short.BYTES,
+                    ByteOrder.LITTLE_ENDIAN);
+            ShortVector low =
+                (ShortVector)
+                    packed
+                        .and((byte) 0x0F)
+                        .sub((byte) 8)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+            ShortVector high =
+                (ShortVector)
+                    packed
+                        .lanewise(VectorOperators.LSHR, 4)
+                        .and((byte) 0x0F)
+                        .sub((byte) 8)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+
+            for (int batch = 0; batch < batchSize; batch++) {
+              int quantOffset = batch * cols + block * GGUF_Q_BLOCK_SIZE;
+              ShortVector lowQuants =
+                  (ShortVector)
+                      ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                          .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+              ShortVector highQuants =
+                  (ShortVector)
+                      ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                          .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+              int integerSum =
+                  fourProductLanes(low.mul(lowQuants), high.mul(highQuants))
+                      .reduceLanes(VectorOperators.ADD);
+              float scale = weightScale * q8Scales[batch * blocks + block];
+              int outputOffset = batch * rows + row;
+              out[outputOffset] = MathUtil.fma(scale, integerSum, out[outputOffset]);
+            }
+          }
+        });
+  }
+
   private static int q4_0Q8_0IntegerDot(
       MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
     if (VECTOR_BITSIZE >= 256) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -839,11 +839,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       ByteVector packed =
           ByteVector.fromMemorySegment(
               ByteVector.SPECIES_64, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
-      ByteVector low = q5Values(packed.and((byte) 0x0F), (byte) (highBits >>> index));
+      ByteVector low = q5Values(packed.and((byte) 0x0F), highBits >>> index);
       ByteVector high =
           q5Values(
-              packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F),
-              (byte) (highBits >>> (index + 16)));
+              packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F), highBits >>> (index + 16));
       IntVector lowWeights =
           (IntVector) low.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
       IntVector highWeights =
@@ -861,9 +860,9 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return accumulator;
   }
 
-  private static ByteVector q5Values(ByteVector lowBits, byte highBits) {
+  private static ByteVector q5Values(ByteVector lowBits, int highBits) {
     VectorMask<Byte> highMask =
-        Q5_HIGH_BIT_MASKS.and(highBits).compare(VectorOperators.NE, (byte) 0);
+        Q5_HIGH_BIT_MASKS.and((byte) (highBits & 0xFF)).compare(VectorOperators.NE, (byte) 0);
     return lowBits.add((byte) 16, highMask).sub((byte) 16);
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -681,7 +681,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         rows,
         cols,
         row -> {
-          FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+          float sum = 0.0f;
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
             long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
@@ -698,7 +698,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
             long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
             int activationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
-            IntVector blockLanes = IntVector.zero(IntVector.SPECIES_256);
+            int blockSum = 0;
 
             for (int superBlock = 0; superBlock < 2; superBlock++) {
               long qlBase = qlOffset + (long) superBlock * 64;
@@ -711,33 +711,28 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                 int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
                 int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
                 int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
-                blockLanes =
-                    blockLanes.add(
-                        q6_KQ8_KIntegerLanes(
-                            qWeight,
-                            qlBase + batch,
-                            qlBase + 32L + batch,
-                            qhBase + batch,
-                            q8Quants,
-                            quantBase + batch,
-                            s1,
-                            s2,
-                            s3,
-                            s4));
+                blockSum +=
+                    q6_KQ8_KIntegerDot(
+                        qWeight,
+                        qlBase + batch,
+                        qlBase + 32L + batch,
+                        qhBase + batch,
+                        q8Quants,
+                        quantBase + batch,
+                        s1,
+                        s2,
+                        s3,
+                        s4);
               }
             }
 
-            FloatVector products =
-                (FloatVector)
-                    blockLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-            accumulator =
-                fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, d), accumulator);
+            sum = MathUtil.fma(d, blockSum, sum);
           }
-          out[row] = accumulator.reduceLanes(VectorOperators.ADD);
+          out[row] = sum;
         });
   }
 
-  static IntVector q6_KQ8_KIntegerLanes(
+  static int q6_KQ8_KIntegerDot(
       MemorySegment qWeight,
       long ql1Offset,
       long ql2Offset,
@@ -780,7 +775,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         .mul(s1)
         .add(pairProductLanes(q2, q8Quants, quantOffset + 32).mul(s2))
         .add(pairProductLanes(q3, q8Quants, quantOffset + 64).mul(s3))
-        .add(pairProductLanes(q4, q8Quants, quantOffset + 96).mul(s4));
+        .add(pairProductLanes(q4, q8Quants, quantOffset + 96).mul(s4))
+        .reduceLanes(VectorOperators.ADD);
   }
 
   private static IntVector pairProductLanes(ByteVector weights, byte[] q8Quants, int quantOffset) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -157,7 +157,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     // Reduce 4 accumulators to scalar
     FloatVector res1 = acc1.add(acc2);
     FloatVector res2 = acc3.add(acc4);
-    return res1.add(res2).reduceLanes(VectorOperators.ADD);
+    return reduceAdd(res1.add(res2));
   }
 
   // --- Float square distance (L2): 4x unrolled sub+FMA ---
@@ -380,7 +380,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               accumulator =
                   fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
             }
-            out[row] = reduceQ4_0Accumulator(accumulator);
+            out[row] = reduceAdd(accumulator);
             return;
           }
 
@@ -478,8 +478,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           for (int batch = 0; batch < batchSize; batch++) {
             int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
             out[batch * rows + row] =
-                reduceQ4_0Accumulator(
-                    FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
+                reduceAdd(FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
           }
         });
   }
@@ -509,13 +508,32 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         .intoArray(laneScratch, laneOffset);
   }
 
-  /** Fixed AVX hsum tree; Vector.reduceLanes does not guarantee an evaluation order. */
-  private static float reduceQ4_0Accumulator(FloatVector accumulator) {
-    float even =
-        (accumulator.lane(4) + accumulator.lane(0)) + (accumulator.lane(6) + accumulator.lane(2));
-    float odd =
-        (accumulator.lane(5) + accumulator.lane(1)) + (accumulator.lane(7) + accumulator.lane(3));
-    return even + odd;
+  /** Fixed split-half hsum tree; Vector.reduceLanes does not guarantee an evaluation order. */
+  private static float reduceAdd(FloatVector vector) {
+    return switch (vector.length()) {
+      case 1 -> vector.lane(0);
+      case 2 -> vector.lane(1) + vector.lane(0);
+      case 4 -> (vector.lane(2) + vector.lane(0)) + (vector.lane(3) + vector.lane(1));
+      case 8 -> {
+        float even = (vector.lane(4) + vector.lane(0)) + (vector.lane(6) + vector.lane(2));
+        float odd = (vector.lane(5) + vector.lane(1)) + (vector.lane(7) + vector.lane(3));
+        yield even + odd;
+      }
+      case 16 -> {
+        float lane0 = vector.lane(8) + vector.lane(0);
+        float lane1 = vector.lane(9) + vector.lane(1);
+        float lane2 = vector.lane(10) + vector.lane(2);
+        float lane3 = vector.lane(11) + vector.lane(3);
+        float lane4 = vector.lane(12) + vector.lane(4);
+        float lane5 = vector.lane(13) + vector.lane(5);
+        float lane6 = vector.lane(14) + vector.lane(6);
+        float lane7 = vector.lane(15) + vector.lane(7);
+        float even = (lane4 + lane0) + (lane6 + lane2);
+        float odd = (lane5 + lane1) + (lane7 + lane3);
+        yield even + odd;
+      }
+      default -> throw new AssertionError("unsupported float vector length: " + vector.length());
+    };
   }
 
   private static int q4_0Q8_0IntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -380,7 +380,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               accumulator =
                   fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
             }
-            out[row] = accumulator.reduceLanes(VectorOperators.ADD);
+            out[row] = reduceQ4_0Accumulator(accumulator);
             return;
           }
 
@@ -478,8 +478,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           for (int batch = 0; batch < batchSize; batch++) {
             int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
             out[batch * rows + row] =
-                FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset)
-                    .reduceLanes(VectorOperators.ADD);
+                reduceQ4_0Accumulator(
+                    FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
           }
         });
   }
@@ -507,6 +507,15 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset);
     fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator)
         .intoArray(laneScratch, laneOffset);
+  }
+
+  /** Fixed AVX hsum tree; Vector.reduceLanes does not guarantee an evaluation order. */
+  private static float reduceQ4_0Accumulator(FloatVector accumulator) {
+    float even =
+        (accumulator.lane(4) + accumulator.lane(0)) + (accumulator.lane(6) + accumulator.lane(2));
+    float odd =
+        (accumulator.lane(5) + accumulator.lane(1)) + (accumulator.lane(7) + accumulator.lane(3));
+    return even + odd;
   }
 
   private static int q4_0Q8_0IntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -674,6 +674,26 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         GgufParallelSupport.Q8_MIN_ELEMENTS,
         row -> {
+          if (VECTOR_BITSIZE == 256) {
+            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+            long rowOffset = row * rowBytes;
+            for (int block = 0; block < blocks; block++) {
+              long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+              float scale =
+                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+              IntVector integerLanes =
+                  q8_0Q8_0IntegerLanes(
+                      qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+              FloatVector products =
+                  (FloatVector)
+                      integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+              accumulator =
+                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+            }
+            out[row] = accumulator.reduceLanes(VectorOperators.ADD);
+            return;
+          }
+
           float sum = 0.0f;
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
@@ -761,6 +781,24 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           qWeight.get(ValueLayout.JAVA_BYTE, weightOffset + index) * q8Quants[quantOffset + index];
     }
     return sum;
+  }
+
+  static IntVector q8_0Q8_0IntegerLanes(
+      MemorySegment qWeight, long weightOffset, byte[] q8Quants, int quantOffset) {
+    IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
+    for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 8) {
+      ByteVector weights =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, weightOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector quants =
+          ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index);
+      IntVector weightInts =
+          (IntVector) weights.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector quantInts =
+          (IntVector) quants.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      accumulator = accumulator.add(weightInts.mul(quantInts));
+    }
+    return accumulator;
   }
 
   // --- Byte dot product: widening to avoid overflow ---

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -23,7 +23,9 @@ import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.LongVector;
 import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorShuffle;
 import jdk.incubator.vector.VectorSpecies;
 
 /**
@@ -58,6 +60,20 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   static final VectorSpecies<Long> LONG_SPECIES =
       PanamaConstants.preferredSpecies(LongVector.SPECIES_PREFERRED);
   static final int VECTOR_BITSIZE = FLOAT_SPECIES.vectorBitSize();
+  private static final VectorShuffle<Short> SWAP_ADJACENT_SHORTS =
+      VectorShuffle.fromValues(
+          ShortVector.SPECIES_256, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+  private static final VectorShuffle<Short> SWAP_SHORT_PAIRS =
+      VectorShuffle.fromValues(
+          ShortVector.SPECIES_256, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
+  private static final VectorShuffle<Short> SELECT_LOW_GROUPS =
+      VectorShuffle.fromValues(
+          ShortVector.SPECIES_256, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  private static final VectorShuffle<Short> SELECT_HIGH_GROUPS =
+      VectorShuffle.fromValues(
+          ShortVector.SPECIES_256, 0, 0, 0, 0, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0);
+  private static final VectorMask<Short> HIGH_GROUP_LANES =
+      VectorMask.fromLong(ShortVector.SPECIES_256, 0xF0L);
 
   // --- Conditional FMA helpers ---
 
@@ -345,6 +361,26 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         rows,
         cols,
         row -> {
+          if (VECTOR_BITSIZE >= 256) {
+            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+            long rowOffset = row * rowBytes;
+            for (int block = 0; block < blocks; block++) {
+              long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+              float scale =
+                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+              IntVector integerLanes =
+                  q4_0Q8_0IntegerLanes(
+                      qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+              FloatVector products =
+                  (FloatVector)
+                      integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+              accumulator =
+                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+            }
+            out[row] = accumulator.reduceLanes(VectorOperators.ADD);
+            return;
+          }
+
           float sum = 0.0f;
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
@@ -407,6 +443,37 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       sum += high16.mul(qHigh16).reduceLanes(VectorOperators.ADD);
     }
     return sum;
+  }
+
+  static IntVector q4_0Q8_0IntegerLanes(
+      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
+    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+    ShortVector lowProducts =
+        ((ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
+            .mul(
+                (ShortVector)
+                    ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
+    ShortVector highProducts =
+        ((ShortVector) high.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
+            .mul(
+                (ShortVector)
+                    ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
+
+    ShortVector lowGroups = sumGroupsOfFour(lowProducts).rearrange(SELECT_LOW_GROUPS);
+    ShortVector highGroups = sumGroupsOfFour(highProducts).rearrange(SELECT_HIGH_GROUPS);
+    ShortVector groups = lowGroups.blend(highGroups, HIGH_GROUP_LANES);
+    return (IntVector) groups.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+  }
+
+  private static ShortVector sumGroupsOfFour(ShortVector products) {
+    ShortVector pairs = products.add(products.rearrange(SWAP_ADJACENT_SHORTS));
+    return pairs.add(pairs.rearrange(SWAP_SHORT_PAIRS));
   }
 
   /** SIMD Q4_K by Q8_K GEMV with one activation quantization shared by all rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -409,6 +409,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales) {
+    if (batchSize == 1) {
+      ggufQ4_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
     if (VECTOR_BITSIZE < 256) {
       VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmul(
           queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -363,10 +363,49 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
+        row -> out[row] = q4_0Q8_0RowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
+  }
+
+  @Override
+  public void ggufQ4_0Q8_0DualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    int totalRows = Math.addExact(firstRows, secondRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
+        // Keep the SIMD body in this lambda. Extracting it allocated about 38 MB per grouped call.
         row -> {
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          if (row < firstRows) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - firstRows;
+          }
+
+          long rowOffset = matrixRow * rowBytes;
           if (VECTOR_BITSIZE >= 256) {
             FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
-            long rowOffset = row * rowBytes;
             for (int block = 0; block < blocks; block++) {
               long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
               float scale =
@@ -380,12 +419,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               accumulator =
                   fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
             }
-            out[row] = reduceAdd(accumulator);
+            out[matrixRow] = reduceAdd(accumulator);
             return;
           }
 
           float sum = 0.0f;
-          long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
             long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
             float scale =
@@ -395,7 +433,88 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
             sum = MathUtil.fma(scale, integerSum, sum);
           }
-          out[row] = sum;
+          out[matrixRow] = sum;
+        });
+  }
+
+  @Override
+  public void ggufQ4_0Q8_0TripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        // Keep the SIMD body in this lambda. Extracting it allocated about 38 MB per grouped call.
+        row -> {
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            qWeight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+          }
+
+          long rowOffset = matrixRow * rowBytes;
+          if (VECTOR_BITSIZE >= 256) {
+            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+            for (int block = 0; block < blocks; block++) {
+              long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+              float scale =
+                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+              IntVector integerLanes =
+                  q4_0Q8_0IntegerLanes(
+                      qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+              FloatVector products =
+                  (FloatVector)
+                      integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+              accumulator =
+                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+            }
+            out[matrixRow] = reduceAdd(accumulator);
+            return;
+          }
+
+          float sum = 0.0f;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+            float scale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+            int integerSum =
+                q4_0Q8_0IntegerDot(
+                    qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+            sum = MathUtil.fma(scale, integerSum, sum);
+          }
+          out[matrixRow] = sum;
         });
   }
 
@@ -534,6 +653,38 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       }
       default -> throw new AssertionError("unsupported float vector length: " + vector.length());
     };
+  }
+
+  private static float q4_0Q8_0RowDot(
+      MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    if (VECTOR_BITSIZE >= 256) {
+      FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+        float scale =
+            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+        IntVector integerLanes =
+            q4_0Q8_0IntegerLanes(
+                qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+        FloatVector products =
+            (FloatVector)
+                integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+        accumulator =
+            fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+      }
+      return reduceAdd(accumulator);
+    }
+
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      int integerSum =
+          q4_0Q8_0IntegerDot(
+              qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+      sum = MathUtil.fma(scale, integerSum, sum);
+    }
+    return sum;
   }
 
   private static int q4_0Q8_0IntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -66,6 +66,9 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   private static final VectorShuffle<Short> SWAP_SHORT_PAIRS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
+  private static final VectorShuffle<Short> SELECT_EVEN_PAIRS =
+      VectorShuffle.fromValues(
+          ShortVector.SPECIES_256, 0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorShuffle<Short> SELECT_LOW_GROUPS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -837,17 +840,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     if (VECTOR_BITSIZE >= 256) {
       IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
-      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 8) {
-        ByteVector weights =
-            ByteVector.fromMemorySegment(
-                ByteVector.SPECIES_64, qWeight, weightOffset + index, ByteOrder.LITTLE_ENDIAN);
-        ByteVector quants =
-            ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index);
-        IntVector weightInts =
-            (IntVector) weights.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
-        IntVector quantInts =
-            (IntVector) quants.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
-        accumulator = accumulator.add(weightInts.mul(quantInts));
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 16) {
+        accumulator =
+            accumulator.add(
+                q8_0Q8_0PairLanes(qWeight, weightOffset + index, q8Quants, quantOffset + index));
       }
       return accumulator.reduceLanes(VectorOperators.ADD);
     }
@@ -888,6 +884,23 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           qWeight.get(ValueLayout.JAVA_BYTE, weightOffset + index) * q8Quants[quantOffset + index];
     }
     return sum;
+  }
+
+  static IntVector q8_0Q8_0PairLanes(
+      MemorySegment qWeight, long weightOffset, byte[] q8Quants, int quantOffset) {
+    ShortVector weights =
+        (ShortVector)
+            ByteVector.fromMemorySegment(
+                    ByteVector.SPECIES_128, qWeight, weightOffset, ByteOrder.LITTLE_ENDIAN)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector quants =
+        (ShortVector)
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector products = weights.mul(quants);
+    ShortVector pairs = products.add(products.rearrange(SWAP_ADJACENT_SHORTS));
+    ShortVector selected = pairs.rearrange(SELECT_EVEN_PAIRS);
+    return (IntVector) selected.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
   }
 
   // --- Byte dot product: widening to avoid overflow ---

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -66,9 +66,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   private static final VectorShuffle<Short> SWAP_SHORT_PAIRS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
-  private static final VectorShuffle<Short> SELECT_EVEN_PAIRS =
-      VectorShuffle.fromValues(
-          ShortVector.SPECIES_256, 0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorShuffle<Short> SELECT_LOW_GROUPS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -840,10 +837,17 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     if (VECTOR_BITSIZE >= 256) {
       IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
-      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 16) {
-        accumulator =
-            accumulator.add(
-                q8_0Q8_0PairLanes(qWeight, weightOffset + index, q8Quants, quantOffset + index));
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index += 8) {
+        ByteVector weights =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_64, qWeight, weightOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector quants =
+            ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index);
+        IntVector weightInts =
+            (IntVector) weights.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        IntVector quantInts =
+            (IntVector) quants.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        accumulator = accumulator.add(weightInts.mul(quantInts));
       }
       return accumulator.reduceLanes(VectorOperators.ADD);
     }
@@ -884,23 +888,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           qWeight.get(ValueLayout.JAVA_BYTE, weightOffset + index) * q8Quants[quantOffset + index];
     }
     return sum;
-  }
-
-  static IntVector q8_0Q8_0PairLanes(
-      MemorySegment qWeight, long weightOffset, byte[] q8Quants, int quantOffset) {
-    ShortVector weights =
-        (ShortVector)
-            ByteVector.fromMemorySegment(
-                    ByteVector.SPECIES_128, qWeight, weightOffset, ByteOrder.LITTLE_ENDIAN)
-                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    ShortVector quants =
-        (ShortVector)
-            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
-                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    ShortVector products = weights.mul(quants);
-    ShortVector pairs = products.add(products.rearrange(SWAP_ADJACENT_SHORTS));
-    ShortVector selected = pairs.rearrange(SELECT_EVEN_PAIRS);
-    return (IntVector) selected.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
   }
 
   // --- Byte dot product: widening to avoid overflow ---

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -408,14 +408,15 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      float[] laneScratch) {
     if (batchSize == 1) {
       ggufQ4_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
       return;
     }
     if (VECTOR_BITSIZE < 256) {
       VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmul(
-          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch);
       return;
     }
 
@@ -432,92 +433,60 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         row -> {
           long rowOffset = row * rowBytes;
-          for (int batchBase = 0; batchBase < batchSize; batchBase += 4) {
-            int groupSize = Math.min(4, batchSize - batchBase);
-            FloatVector accumulator0 = FloatVector.zero(FloatVector.SPECIES_256);
-            FloatVector accumulator1 = FloatVector.zero(FloatVector.SPECIES_256);
-            FloatVector accumulator2 = FloatVector.zero(FloatVector.SPECIES_256);
-            FloatVector accumulator3 = FloatVector.zero(FloatVector.SPECIES_256);
+          int rowLaneOffset = row * batchSize * FloatVector.SPECIES_256.length();
+          int rowLaneEnd = rowLaneOffset + batchSize * FloatVector.SPECIES_256.length();
+          for (int lane = rowLaneOffset; lane < rowLaneEnd; lane++) {
+            laneScratch[lane] = 0.0f;
+          }
 
-            for (int block = 0; block < blocks; block++) {
-              long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
-              float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
-              ByteVector packed =
-                  ByteVector.fromMemorySegment(
-                      ByteVector.SPECIES_128,
-                      qWeight,
-                      blockOffset + Short.BYTES,
-                      ByteOrder.LITTLE_ENDIAN);
-              ShortVector low =
-                  (ShortVector)
-                      packed
-                          .and((byte) 0x0F)
-                          .sub((byte) 8)
-                          .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-              ShortVector high =
-                  (ShortVector)
-                      packed
-                          .lanewise(VectorOperators.LSHR, 4)
-                          .and((byte) 0x0F)
-                          .sub((byte) 8)
-                          .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            ByteVector packed =
+                ByteVector.fromMemorySegment(
+                    ByteVector.SPECIES_128,
+                    qWeight,
+                    blockOffset + Short.BYTES,
+                    ByteOrder.LITTLE_ENDIAN);
+            ShortVector low =
+                (ShortVector)
+                    packed
+                        .and((byte) 0x0F)
+                        .sub((byte) 8)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+            ShortVector high =
+                (ShortVector)
+                    packed
+                        .lanewise(VectorOperators.LSHR, 4)
+                        .and((byte) 0x0F)
+                        .sub((byte) 8)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
 
-              accumulator0 =
-                  accumulateQ4_0BatchQuery(
-                      accumulator0,
-                      low,
-                      high,
-                      q8Quants,
-                      (batchBase * cols) + block * GGUF_Q_BLOCK_SIZE,
-                      weightScale * q8Scales[batchBase * blocks + block]);
-              if (groupSize > 1) {
-                accumulator1 =
-                    accumulateQ4_0BatchQuery(
-                        accumulator1,
-                        low,
-                        high,
-                        q8Quants,
-                        ((batchBase + 1) * cols) + block * GGUF_Q_BLOCK_SIZE,
-                        weightScale * q8Scales[(batchBase + 1) * blocks + block]);
-              }
-              if (groupSize > 2) {
-                accumulator2 =
-                    accumulateQ4_0BatchQuery(
-                        accumulator2,
-                        low,
-                        high,
-                        q8Quants,
-                        ((batchBase + 2) * cols) + block * GGUF_Q_BLOCK_SIZE,
-                        weightScale * q8Scales[(batchBase + 2) * blocks + block]);
-              }
-              if (groupSize > 3) {
-                accumulator3 =
-                    accumulateQ4_0BatchQuery(
-                        accumulator3,
-                        low,
-                        high,
-                        q8Quants,
-                        ((batchBase + 3) * cols) + block * GGUF_Q_BLOCK_SIZE,
-                        weightScale * q8Scales[(batchBase + 3) * blocks + block]);
-              }
+            for (int batch = 0; batch < batchSize; batch++) {
+              int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+              accumulateQ4_0BatchQuery(
+                  laneScratch,
+                  laneOffset,
+                  low,
+                  high,
+                  q8Quants,
+                  (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
+                  weightScale * q8Scales[batch * blocks + block]);
             }
+          }
 
-            out[batchBase * rows + row] = accumulator0.reduceLanes(VectorOperators.ADD);
-            if (groupSize > 1) {
-              out[(batchBase + 1) * rows + row] = accumulator1.reduceLanes(VectorOperators.ADD);
-            }
-            if (groupSize > 2) {
-              out[(batchBase + 2) * rows + row] = accumulator2.reduceLanes(VectorOperators.ADD);
-            }
-            if (groupSize > 3) {
-              out[(batchBase + 3) * rows + row] = accumulator3.reduceLanes(VectorOperators.ADD);
-            }
+          for (int batch = 0; batch < batchSize; batch++) {
+            int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+            out[batch * rows + row] =
+                FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset)
+                    .reduceLanes(VectorOperators.ADD);
           }
         });
   }
 
-  private static FloatVector accumulateQ4_0BatchQuery(
-      FloatVector accumulator,
+  private static void accumulateQ4_0BatchQuery(
+      float[] laneScratch,
+      int laneOffset,
       ShortVector low,
       ShortVector high,
       byte[] q8Quants,
@@ -534,7 +503,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     IntVector integerLanes = fourProductLanes(low.mul(lowQuants), high.mul(highQuants));
     FloatVector products =
         (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-    return fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+    FloatVector accumulator =
+        FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset);
+    fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator)
+        .intoArray(laneScratch, laneOffset);
   }
 
   private static int q4_0Q8_0IntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -431,52 +431,110 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         rows,
         cols,
         row -> {
-          for (int batch = 0; batch < batchSize; batch++) {
-            out[batch * rows + row] = 0.0f;
-          }
           long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
-            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
-            ByteVector packed =
-                ByteVector.fromMemorySegment(
-                    ByteVector.SPECIES_128,
-                    qWeight,
-                    blockOffset + Short.BYTES,
-                    ByteOrder.LITTLE_ENDIAN);
-            ShortVector low =
-                (ShortVector)
-                    packed
-                        .and((byte) 0x0F)
-                        .sub((byte) 8)
-                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-            ShortVector high =
-                (ShortVector)
-                    packed
-                        .lanewise(VectorOperators.LSHR, 4)
-                        .and((byte) 0x0F)
-                        .sub((byte) 8)
-                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          for (int batchBase = 0; batchBase < batchSize; batchBase += 4) {
+            int groupSize = Math.min(4, batchSize - batchBase);
+            FloatVector accumulator0 = FloatVector.zero(FloatVector.SPECIES_256);
+            FloatVector accumulator1 = FloatVector.zero(FloatVector.SPECIES_256);
+            FloatVector accumulator2 = FloatVector.zero(FloatVector.SPECIES_256);
+            FloatVector accumulator3 = FloatVector.zero(FloatVector.SPECIES_256);
 
-            for (int batch = 0; batch < batchSize; batch++) {
-              int quantOffset = batch * cols + block * GGUF_Q_BLOCK_SIZE;
-              ShortVector lowQuants =
+            for (int block = 0; block < blocks; block++) {
+              long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+              float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+              ByteVector packed =
+                  ByteVector.fromMemorySegment(
+                      ByteVector.SPECIES_128,
+                      qWeight,
+                      blockOffset + Short.BYTES,
+                      ByteOrder.LITTLE_ENDIAN);
+              ShortVector low =
                   (ShortVector)
-                      ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                      packed
+                          .and((byte) 0x0F)
+                          .sub((byte) 8)
                           .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-              ShortVector highQuants =
+              ShortVector high =
                   (ShortVector)
-                      ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                      packed
+                          .lanewise(VectorOperators.LSHR, 4)
+                          .and((byte) 0x0F)
+                          .sub((byte) 8)
                           .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-              int integerSum =
-                  fourProductLanes(low.mul(lowQuants), high.mul(highQuants))
-                      .reduceLanes(VectorOperators.ADD);
-              float scale = weightScale * q8Scales[batch * blocks + block];
-              int outputOffset = batch * rows + row;
-              out[outputOffset] = MathUtil.fma(scale, integerSum, out[outputOffset]);
+
+              accumulator0 =
+                  accumulateQ4_0BatchQuery(
+                      accumulator0,
+                      low,
+                      high,
+                      q8Quants,
+                      (batchBase * cols) + block * GGUF_Q_BLOCK_SIZE,
+                      weightScale * q8Scales[batchBase * blocks + block]);
+              if (groupSize > 1) {
+                accumulator1 =
+                    accumulateQ4_0BatchQuery(
+                        accumulator1,
+                        low,
+                        high,
+                        q8Quants,
+                        ((batchBase + 1) * cols) + block * GGUF_Q_BLOCK_SIZE,
+                        weightScale * q8Scales[(batchBase + 1) * blocks + block]);
+              }
+              if (groupSize > 2) {
+                accumulator2 =
+                    accumulateQ4_0BatchQuery(
+                        accumulator2,
+                        low,
+                        high,
+                        q8Quants,
+                        ((batchBase + 2) * cols) + block * GGUF_Q_BLOCK_SIZE,
+                        weightScale * q8Scales[(batchBase + 2) * blocks + block]);
+              }
+              if (groupSize > 3) {
+                accumulator3 =
+                    accumulateQ4_0BatchQuery(
+                        accumulator3,
+                        low,
+                        high,
+                        q8Quants,
+                        ((batchBase + 3) * cols) + block * GGUF_Q_BLOCK_SIZE,
+                        weightScale * q8Scales[(batchBase + 3) * blocks + block]);
+              }
+            }
+
+            out[batchBase * rows + row] = accumulator0.reduceLanes(VectorOperators.ADD);
+            if (groupSize > 1) {
+              out[(batchBase + 1) * rows + row] = accumulator1.reduceLanes(VectorOperators.ADD);
+            }
+            if (groupSize > 2) {
+              out[(batchBase + 2) * rows + row] = accumulator2.reduceLanes(VectorOperators.ADD);
+            }
+            if (groupSize > 3) {
+              out[(batchBase + 3) * rows + row] = accumulator3.reduceLanes(VectorOperators.ADD);
             }
           }
         });
+  }
+
+  private static FloatVector accumulateQ4_0BatchQuery(
+      FloatVector accumulator,
+      ShortVector low,
+      ShortVector high,
+      byte[] q8Quants,
+      int quantOffset,
+      float scale) {
+    ShortVector lowQuants =
+        (ShortVector)
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector highQuants =
+        (ShortVector)
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    IntVector integerLanes = fourProductLanes(low.mul(lowQuants), high.mul(highQuants));
+    FloatVector products =
+        (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+    return fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
   }
 
   private static int q4_0Q8_0IntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -426,6 +426,85 @@ public final class VectorUtil {
   }
 
   /**
+   * Multiplies two Q4_0 matrices by the same activation with one Q8_0 quantization and one row
+   * dispatch.
+   *
+   * <p>This is intended for transformer projections such as SwiGLU gate/up matrices that consume
+   * the same normalized activation.
+   */
+  public static void ggufQ4_0Q8_0DualBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query, secondWeight, secondRows, cols, secondOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ4_0Q8_0DualMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  /**
+   * Multiplies three Q4_0 matrices by the same activation with one Q8_0 quantization and one row
+   * dispatch.
+   *
+   * <p>This is intended for grouped query/key/value transformer projections.
+   */
+  public static void ggufQ4_0Q8_0TripleBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query, secondWeight, secondRows, cols, secondOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query, thirdWeight, thirdRows, cols, thirdOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ4_0Q8_0TripleMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  /**
    * Multiplies one Q4_0 matrix by a batch-major collection of activation vectors.
    *
    * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -425,6 +425,62 @@ public final class VectorUtil {
     IMPL.ggufQ4_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
   }
 
+  /**
+   * Multiplies one Q4_0 matrix by a batch-major collection of activation vectors.
+   *
+   * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code
+   * [batchSize][rows]}. Activation quantization scratch is caller-owned so repeated prefill calls
+   * do not allocate in the hot path.
+   *
+   * @param q8Quants scratch space with at least {@code batchSize * cols} entries
+   * @param q8Scales scratch space with at least {@code batchSize * (cols / 32)} entries
+   */
+  public static void ggufQ4_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int scaleEntries =
+        checkedProduct(batchSize, cols / VectorUtilSupport.GGUF_Q_BLOCK_SIZE, "batch scales");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    if (q8Quants.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= batchSize * cols: " + q8Quants.length + " < " + queryEntries);
+    }
+    if (q8Scales.length < scaleEntries) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= batch scales: " + q8Scales.length + " < " + scaleEntries);
+    }
+    IMPL.ggufQ4_0Q8_0BatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+  }
+
   /** Batched row-major GEMV over GGUF Q4_K rows. */
   public static void ggufQ4_KBatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
@@ -921,15 +977,27 @@ public final class VectorUtil {
       int blockSize,
       int blockBytes) {
     Objects.requireNonNull(query, "query");
-    Objects.requireNonNull(qWeight, "qWeight");
     Objects.requireNonNull(out, "out");
-    if (rows < 0) {
-      throw new IllegalArgumentException("rows must be >= 0: " + rows);
-    }
-    checkGgufQuantizedDimensions(query, cols, blockSize);
+    checkDimensions(query.length, cols);
+    checkGgufQuantizedMatrixArguments(qWeight, rows, cols, blockSize, blockBytes);
     if (out.length < rows) {
       throw new IllegalArgumentException(
           "out.length must be >= rows: " + out.length + " < " + rows);
+    }
+  }
+
+  private static void checkGgufQuantizedMatrixArguments(
+      MemorySegment qWeight, int rows, int cols, int blockSize, int blockBytes) {
+    Objects.requireNonNull(qWeight, "qWeight");
+    if (rows < 0) {
+      throw new IllegalArgumentException("rows must be >= 0: " + rows);
+    }
+    if (cols < 0) {
+      throw new IllegalArgumentException("cols must be >= 0: " + cols);
+    }
+    if (cols % blockSize != 0) {
+      throw new IllegalArgumentException(
+          "GGUF quantized dimensions must be a multiple of " + blockSize + ": " + cols);
     }
     long rowBytes = ggufQuantizedRowBytes(cols, blockSize, blockBytes);
     long required = rowBytes * rows;
@@ -986,5 +1054,13 @@ public final class VectorUtil {
 
   private static long ggufQuantizedRowBytes(int dimensions, int blockSize, int blockBytes) {
     return (long) (dimensions / blockSize) * blockBytes;
+  }
+
+  private static int checkedProduct(int left, int right, String label) {
+    long product = (long) left * right;
+    if (product > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(label + " exceeds maximum Java array length: " + product);
+    }
+    return (int) product;
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -447,10 +447,45 @@ public final class VectorUtil {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
     }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        new float[checkedProduct(outputEntries, 8, "Q4 lane scratch")]);
+  }
+
+  /**
+   * Allocation-free Q4_0 batched matrix multiplication with caller-owned reduction lanes.
+   *
+   * @param laneScratch scratch space with at least {@code batchSize * rows * 8} entries
+   */
+  public static void ggufQ4_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
     Objects.requireNonNull(queries, "queries");
     Objects.requireNonNull(out, "out");
     Objects.requireNonNull(q8Quants, "q8Quants");
     Objects.requireNonNull(q8Scales, "q8Scales");
+    Objects.requireNonNull(laneScratch, "laneScratch");
     checkGgufQuantizedMatrixArguments(
         qWeight,
         rows,
@@ -459,6 +494,7 @@ public final class VectorUtil {
         VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
     int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int laneEntries = checkedProduct(outputEntries, 8, "Q4 lane scratch");
     int scaleEntries =
         checkedProduct(batchSize, cols / VectorUtilSupport.GGUF_Q_BLOCK_SIZE, "batch scales");
     if (queries.length < queryEntries) {
@@ -477,8 +513,15 @@ public final class VectorUtil {
       throw new IllegalArgumentException(
           "q8Scales.length must be >= batch scales: " + q8Scales.length + " < " + scaleEntries);
     }
+    if (laneScratch.length < laneEntries) {
+      throw new IllegalArgumentException(
+          "lane scratch length must be >= batchSize * rows * 8: "
+              + laneScratch.length
+              + " < "
+              + laneEntries);
+    }
     IMPL.ggufQ4_0Q8_0BatchedMatmul(
-        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch);
   }
 
   /** Batched row-major GEMV over GGUF Q4_K rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -566,6 +566,51 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Q4_0 matrix multiplication over batch-major Q8_0-quantized activation rows. */
+  default void ggufQ4_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    for (int batch = 0; batch < batchSize; batch++) {
+      int quantBatchOffset = batch * cols;
+      int scaleBatchOffset = batch * blocks;
+      for (int row = 0; row < rows; row++) {
+        float sum = 0.0f;
+        long rowOffset = row * rowBytes;
+        for (int block = 0; block < blocks; block++) {
+          long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+          float scale =
+              Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset))
+                  * q8Scales[scaleBatchOffset + block];
+          long nibbleOffset = blockOffset + Short.BYTES;
+          int quantOffset = quantBatchOffset + block * GGUF_Q_BLOCK_SIZE;
+          int integerSum = 0;
+          for (int index = 0; index < 16; index++) {
+            int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + index) & 0xFF;
+            int lo = (packed & 0x0F) - 8;
+            int hi = ((packed >>> 4) & 0x0F) - 8;
+            integerSum += lo * q8Quants[quantOffset + index];
+            integerSum += hi * q8Quants[quantOffset + index + 16];
+          }
+          sum = MathUtil.fma(scale, integerSum, sum);
+        }
+        out[batch * rows + row] = sum;
+      }
+    }
+  }
+
   /** Batched row-major GEMV over GGUF Q4_K rows. */
   default void ggufQ4_KMatVecDot(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -544,26 +544,88 @@ public interface VectorUtilSupport {
     long rowBytes = ggufQ4_0RowBytes(cols);
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     for (int row = 0; row < rows; row++) {
-      float sum = 0.0f;
-      long rowOffset = row * rowBytes;
-      for (int block = 0; block < blocks; block++) {
-        long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
-        float scale =
-            Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
-        long nibbleOffset = blockOffset + Short.BYTES;
-        int quantOffset = block * GGUF_Q_BLOCK_SIZE;
-        int integerSum = 0;
-        for (int index = 0; index < 16; index++) {
-          int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + index) & 0xFF;
-          int lo = (packed & 0x0F) - 8;
-          int hi = ((packed >>> 4) & 0x0F) - 8;
-          integerSum += lo * q8Quants[quantOffset + index];
-          integerSum += hi * q8Quants[quantOffset + index + 16];
-        }
-        sum = MathUtil.fma(scale, integerSum, sum);
-      }
-      out[row] = sum;
+      out[row] = ggufQ4_0Q8_0ScalarRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales);
     }
+  }
+
+  /** Two Q4_0 projections sharing one Q8_0 activation quantization. */
+  default void ggufQ4_0Q8_0DualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int row = 0; row < firstRows; row++) {
+      firstOut[row] =
+          ggufQ4_0Q8_0ScalarRowDot(firstWeight, row * rowBytes, blocks, q8Quants, q8Scales);
+    }
+    for (int row = 0; row < secondRows; row++) {
+      secondOut[row] =
+          ggufQ4_0Q8_0ScalarRowDot(secondWeight, row * rowBytes, blocks, q8Quants, q8Scales);
+    }
+  }
+
+  /** Three Q4_0 projections sharing one Q8_0 activation quantization. */
+  default void ggufQ4_0Q8_0TripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int row = 0; row < firstRows; row++) {
+      firstOut[row] =
+          ggufQ4_0Q8_0ScalarRowDot(firstWeight, row * rowBytes, blocks, q8Quants, q8Scales);
+    }
+    for (int row = 0; row < secondRows; row++) {
+      secondOut[row] =
+          ggufQ4_0Q8_0ScalarRowDot(secondWeight, row * rowBytes, blocks, q8Quants, q8Scales);
+    }
+    for (int row = 0; row < thirdRows; row++) {
+      thirdOut[row] =
+          ggufQ4_0Q8_0ScalarRowDot(thirdWeight, row * rowBytes, blocks, q8Quants, q8Scales);
+    }
+  }
+
+  private static float ggufQ4_0Q8_0ScalarRowDot(
+      MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      long nibbleOffset = blockOffset + Short.BYTES;
+      int quantOffset = block * GGUF_Q_BLOCK_SIZE;
+      int integerSum = 0;
+      for (int index = 0; index < 16; index++) {
+        int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + index) & 0xFF;
+        int lo = (packed & 0x0F) - 8;
+        int hi = ((packed >>> 4) & 0x0F) - 8;
+        integerSum += lo * q8Quants[quantOffset + index];
+        integerSum += hi * q8Quants[quantOffset + index + 16];
+      }
+      sum = MathUtil.fma(scale, integerSum, sum);
+    }
+    return sum;
   }
 
   /** Q4_0 matrix multiplication over batch-major Q8_0-quantized activation rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -575,7 +575,8 @@ public interface VectorUtilSupport {
       int cols,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      float[] laneScratch) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -18,6 +18,7 @@ package com.integrallis.vectors.core;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -99,6 +100,9 @@ public final class VectorizationProvider {
     String useScalarFMA = System.getProperty("vectors.useScalarFMA");
     String ggufParallel = System.getProperty("vectors.gguf.parallel");
     String ggufParallelThreshold = System.getProperty("vectors.gguf.parallelThreshold");
+    String ggufExecutor = System.getProperty("vectors.gguf.executor");
+    String ggufThreads = System.getProperty("vectors.gguf.threads");
+    String ggufChunksPerThread = System.getProperty("vectors.gguf.chunksPerThread");
 
     StringBuilder sb = new StringBuilder("vectors-core: provider=");
     sb.append(impl.getClass().getSimpleName());
@@ -110,6 +114,10 @@ public final class VectorizationProvider {
     sb.append(" sve=").append(PanamaConstants.HAS_SVE);
     sb.append(" ggufParallel=").append(GgufParallelSupport.enabled());
     sb.append(" ggufParallelThreshold=").append(GgufParallelSupport.minElements());
+    sb.append(" ggufExecutor=")
+        .append(GgufParallelSupport.executionMode().name().toLowerCase(Locale.ROOT));
+    sb.append(" ggufThreads=").append(GgufParallelSupport.parallelism());
+    sb.append(" ggufChunksPerThread=").append(GgufParallelSupport.chunksPerThread());
     sb.append(" toggles=[");
     boolean first = true;
     if (forceScalar != null) {
@@ -139,6 +147,21 @@ public final class VectorizationProvider {
     if (ggufParallelThreshold != null) {
       if (!first) sb.append(", ");
       sb.append("vectors.gguf.parallelThreshold=").append(ggufParallelThreshold);
+      first = false;
+    }
+    if (ggufExecutor != null) {
+      if (!first) sb.append(", ");
+      sb.append("vectors.gguf.executor=").append(ggufExecutor);
+      first = false;
+    }
+    if (ggufThreads != null) {
+      if (!first) sb.append(", ");
+      sb.append("vectors.gguf.threads=").append(ggufThreads);
+      first = false;
+    }
+    if (ggufChunksPerThread != null) {
+      if (!first) sb.append(", ");
+      sb.append("vectors.gguf.chunksPerThread=").append(ggufChunksPerThread);
       first = false;
     }
     if (first) sb.append("(defaults — no -Dvectors.* overrides)");

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -16,11 +16,20 @@
 package com.integrallis.vectors.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.lang.foreign.Arena;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +65,35 @@ class GgufParallelSupportTest {
   }
 
   @Test
+  void executionModePropertyIsValidated() {
+    assertThat(GgufParallelSupport.ExecutionMode.parse(null))
+        .isEqualTo(GgufParallelSupport.ExecutionMode.COMMON);
+    assertThat(GgufParallelSupport.ExecutionMode.parse("common"))
+        .isEqualTo(GgufParallelSupport.ExecutionMode.COMMON);
+    assertThat(GgufParallelSupport.ExecutionMode.parse("dedicated"))
+        .isEqualTo(GgufParallelSupport.ExecutionMode.DEDICATED);
+    assertThat(GgufParallelSupport.ExecutionMode.parse("persistent"))
+        .isEqualTo(GgufParallelSupport.ExecutionMode.PERSISTENT);
+    assertThatThrownBy(() -> GgufParallelSupport.ExecutionMode.parse("unknown"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("vectors.gguf.executor");
+  }
+
+  @Test
+  void everyExecutionModeRunsEachRowExactlyOnce() {
+    for (GgufParallelSupport.ExecutionMode mode : GgufParallelSupport.ExecutionMode.values()) {
+      try (GgufRowExecutor executor = GgufParallelSupport.newExecutor(mode, 4, 4, "vectors-test")) {
+        AtomicIntegerArray visits = new AtomicIntegerArray(257);
+        executor.forEach(257, row -> visits.incrementAndGet(row));
+
+        for (int row = 0; row < visits.length(); row++) {
+          assertThat(visits.get(row)).as("%s row %s", mode, row).isOne();
+        }
+      }
+    }
+  }
+
+  @Test
   void confinedSegmentsRemainOnTheirOwnerThread() {
     AtomicInteger rowsVisited = new AtomicInteger();
     Set<Thread> threads = ConcurrentHashMap.newKeySet();
@@ -74,5 +112,96 @@ class GgufParallelSupportTest {
 
     assertThat(rowsVisited).hasValue(1024);
     assertThat(threads).containsExactly(owner);
+  }
+
+  @Test
+  void persistentExecutorRunsEveryRowExactlyOnceAcrossRepeatedDispatches() {
+    try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test")) {
+      for (int round = 0; round < 100; round++) {
+        int rows = 1 + round % 61;
+        AtomicIntegerArray visits = new AtomicIntegerArray(rows);
+
+        executor.forEach(rows, row -> visits.incrementAndGet(row));
+
+        for (int row = 0; row < rows; row++) {
+          assertThat(visits.get(row)).as("round %s row %s", round, row).isOne();
+        }
+      }
+    }
+  }
+
+  @Test
+  void persistentExecutorSerializesConcurrentPublishersWithoutLosingRows() throws Exception {
+    try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test");
+        ExecutorService publishers = Executors.newFixedThreadPool(4)) {
+      List<Future<AtomicIntegerArray>> results = new ArrayList<>();
+      for (int publisher = 0; publisher < 4; publisher++) {
+        results.add(
+            publishers.submit(
+                () -> {
+                  AtomicIntegerArray visits = new AtomicIntegerArray(97);
+                  for (int round = 0; round < 20; round++) {
+                    executor.forEach(97, row -> visits.incrementAndGet(row));
+                  }
+                  return visits;
+                }));
+      }
+
+      for (Future<AtomicIntegerArray> result : results) {
+        AtomicIntegerArray visits = result.get();
+        for (int row = 0; row < visits.length(); row++) {
+          assertThat(visits.get(row)).as("row %s", row).isEqualTo(20);
+        }
+      }
+    }
+  }
+
+  @Test
+  void persistentExecutorPropagatesWorkerFailureAndRemainsReusable() {
+    try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test")) {
+      assertThatThrownBy(
+              () ->
+                  executor.forEach(
+                      64,
+                      row -> {
+                        if (row == 17) {
+                          throw new IllegalStateException("boom");
+                        }
+                      }))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("boom");
+
+      AtomicInteger rowsVisited = new AtomicInteger();
+      executor.forEach(64, ignored -> rowsVisited.incrementAndGet());
+      assertThat(rowsVisited).hasValue(64);
+    }
+  }
+
+  @Test
+  void persistentExecutorClosesImmediatelyAfterACompletedDispatch() {
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () -> {
+          for (int attempt = 0; attempt < 100; attempt++) {
+            try (GgufPersistentRowExecutor executor =
+                new GgufPersistentRowExecutor(12, 4, "vectors-test")) {
+              executor.forEach(257, ignored -> Thread.onSpinWait());
+            }
+          }
+        });
+  }
+
+  @Test
+  void persistentExecutorHandlesMaximumChunkConfigurationWithoutOverflow() {
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () -> {
+          try (GgufPersistentRowExecutor executor =
+              new GgufPersistentRowExecutor(4, Integer.MAX_VALUE, "vectors-test")) {
+            AtomicInteger rowsVisited = new AtomicInteger();
+            executor.forEach(257, ignored -> rowsVisited.incrementAndGet());
+            assertThat(rowsVisited).hasValue(257);
+          }
+        });
   }
 }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.foreign.Arena;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -74,5 +76,27 @@ class GgufParallelSupportTest {
 
     assertThat(rowsVisited).hasValue(1024);
     assertThat(threads).containsExactly(owner);
+  }
+
+  @Test
+  void boundedPoolVisitsEveryRowExactlyOnce() {
+    int rows = 257;
+    AtomicIntegerArray visits = new AtomicIntegerArray(rows);
+    Set<Thread> threads = ConcurrentHashMap.newKeySet();
+
+    try (ForkJoinPool pool = new ForkJoinPool(3)) {
+      GgufParallelSupport.forEachRowInPool(
+          pool,
+          rows,
+          row -> {
+            visits.incrementAndGet(row);
+            threads.add(Thread.currentThread());
+          });
+    }
+
+    for (int row = 0; row < rows; row++) {
+      assertThat(visits.get(row)).isOne();
+    }
+    assertThat(threads).hasSizeBetween(1, 3);
   }
 }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.foreign.Arena;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.junit.jupiter.api.Tag;
@@ -79,20 +78,18 @@ class GgufParallelSupportTest {
   }
 
   @Test
-  void boundedPoolVisitsEveryRowExactlyOnce() {
+  void boundedParallelExecutionVisitsEveryRowExactlyOnce() {
     int rows = 257;
     AtomicIntegerArray visits = new AtomicIntegerArray(rows);
     Set<Thread> threads = ConcurrentHashMap.newKeySet();
 
-    try (ForkJoinPool pool = new ForkJoinPool(3)) {
-      GgufParallelSupport.forEachRowInPool(
-          pool,
-          rows,
-          row -> {
-            visits.incrementAndGet(row);
-            threads.add(Thread.currentThread());
-          });
-    }
+    GgufParallelSupport.forEachRowParallel(
+        rows,
+        3,
+        row -> {
+          visits.incrementAndGet(row);
+          threads.add(Thread.currentThread());
+        });
 
     for (int row = 0; row < rows; row++) {
       assertThat(visits.get(row)).isOne();

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -101,6 +102,29 @@ class GgufParallelSupportTest {
 
     try (Arena arena = Arena.ofConfined()) {
       GgufParallelSupport.forEachRow(
+          arena.allocate(1),
+          1024,
+          2048,
+          ignored -> {
+            rowsVisited.incrementAndGet();
+            threads.add(Thread.currentThread());
+          });
+    }
+
+    assertThat(rowsVisited).hasValue(1024);
+    assertThat(threads).containsExactly(owner);
+  }
+
+  @Test
+  void groupedRowsRemainOnOwnerWhenAnySegmentIsConfined() {
+    AtomicInteger rowsVisited = new AtomicInteger();
+    Set<Thread> threads = ConcurrentHashMap.newKeySet();
+    Thread owner = Thread.currentThread();
+
+    try (Arena arena = Arena.ofConfined()) {
+      GgufParallelSupport.forEachRow(
+          MemorySegment.ofArray(new byte[1]),
+          MemorySegment.ofArray(new byte[1]),
           arena.allocate(1),
           1024,
           2048,

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -67,7 +67,7 @@ class GgufParallelSupportTest {
   @Test
   void executionModePropertyIsValidated() {
     assertThat(GgufParallelSupport.ExecutionMode.parse(null))
-        .isEqualTo(GgufParallelSupport.ExecutionMode.COMMON);
+        .isEqualTo(GgufParallelSupport.ExecutionMode.PERSISTENT);
     assertThat(GgufParallelSupport.ExecutionMode.parse("common"))
         .isEqualTo(GgufParallelSupport.ExecutionMode.COMMON);
     assertThat(GgufParallelSupport.ExecutionMode.parse("dedicated"))

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -21,7 +21,6 @@ import java.lang.foreign.Arena;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -75,25 +74,5 @@ class GgufParallelSupportTest {
 
     assertThat(rowsVisited).hasValue(1024);
     assertThat(threads).containsExactly(owner);
-  }
-
-  @Test
-  void boundedParallelExecutionVisitsEveryRowExactlyOnce() {
-    int rows = 257;
-    AtomicIntegerArray visits = new AtomicIntegerArray(rows);
-    Set<Thread> threads = ConcurrentHashMap.newKeySet();
-
-    GgufParallelSupport.forEachRowParallel(
-        rows,
-        3,
-        row -> {
-          visits.incrementAndGet(row);
-          threads.add(Thread.currentThread());
-        });
-
-    for (int row = 0; row < rows; row++) {
-      assertThat(visits.get(row)).isOne();
-    }
-    assertThat(threads).hasSizeBetween(1, 3);
   }
 }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -417,9 +417,32 @@ class GgufQuantizedDotTest {
           cols,
           actual,
           new byte[batchSize * cols],
-          new float[batchSize * (cols / 32)]);
+          new float[batchSize * (cols / 32)],
+          new float[batchSize * rows * 8]);
 
       assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
+  void q4_0Q8_0BatchedMatmulRejectsUndersizedLaneScratch() {
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, repeat(q4Block(0.1f, ones(32), null), 2));
+
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+                      patternedQuery(64),
+                      segment,
+                      2,
+                      1,
+                      32,
+                      new float[2],
+                      new byte[64],
+                      new float[2],
+                      new float[15]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("lane scratch");
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -24,6 +24,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Random;
 import java.util.function.IntUnaryOperator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -422,6 +423,50 @@ class GgufQuantizedDotTest {
 
       assertThat(actual).containsExactly(expected);
     }
+  }
+
+  @Test
+  void q4_0Q8_0BatchedMatmulMatchesGemvAtQwenProjectionScaleAfterWarmup() {
+    int batchSize = 4;
+    int rows = 1024;
+    int cols = 1024;
+    int blocks = cols / 32;
+    Random random = new Random(42L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 8.0f - 4.0f;
+    }
+    byte[] matrix = new byte[rows * blocks * 18];
+    random.nextBytes(matrix);
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += 18) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.001f + random.nextFloat() * 0.1f));
+    }
+
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] gemvOut = new float[rows];
+    byte[] gemvQuants = new byte[cols];
+    float[] gemvScales = new float[blocks];
+    byte[] batchQuants = new byte[batchSize * cols];
+    float[] batchScales = new float[batchSize * blocks];
+    float[] batchLanes = new float[batchSize * rows * 8];
+
+    for (int iteration = 0; iteration < 12; iteration++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales);
+        System.arraycopy(gemvOut, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+          queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales, batchLanes);
+    }
+
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -360,6 +360,28 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0SingleQueryBatchMatchesGemvExactly() {
+    int rows = 2;
+    int cols = 32;
+    float[] query = patternedQuery(cols);
+    byte[] row0 = q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF);
+    byte[] row1 = q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF);
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+      VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+          query, segment, rows, cols, expected, new byte[cols], new float[cols / 32]);
+
+      VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+          query, segment, 1, rows, cols, actual, new byte[cols], new float[cols / 32]);
+
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
   void q8_0BatchDotProduct_respectsRowOffsets() {
     float[] query = ones(32);
     byte[] row0 = q8Block(1.0f);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -464,9 +464,8 @@ class GgufQuantizedDotTest {
 
       VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
           queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales, batchLanes);
+      assertThat(actual).containsExactly(expected);
     }
-
-    assertThat(actual).containsExactly(expected);
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -324,6 +324,115 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0DualBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 64;
+    int firstRows = 2;
+    int secondRows = 3;
+    float[] query = patternedQuery(cols);
+    byte[] firstWeights =
+        concat(
+            repeat(q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), 2),
+            repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), 2));
+    byte[] secondWeights =
+        concat(
+            concat(
+                repeat(q4Block(0.5f, ones(cols), (lo, hi) -> (lo + hi * 11) & 0xFF), 2),
+                repeat(q4Block(-0.0625f, ones(cols), (lo, hi) -> (lo * 13 + hi) & 0xFF), 2)),
+            repeat(q4Block(0.03125f, ones(cols), (lo, hi) -> (lo * 3 + hi * 7) & 0xFF), 2));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+
+    MemorySegment firstSegment = MemorySegment.ofArray(firstWeights);
+    MemorySegment secondSegment = MemorySegment.ofArray(secondWeights);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, firstSegment, firstRows, cols, expectedFirst, new byte[cols], new float[cols / 32]);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        secondSegment,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 32]);
+
+    VectorUtil.ggufQ4_0Q8_0DualBatchDotProduct(
+        query,
+        firstSegment,
+        firstRows,
+        actualFirst,
+        secondSegment,
+        secondRows,
+        actualSecond,
+        cols,
+        new byte[cols],
+        new float[cols / 32]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
+  void q4_0Q8_0TripleBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 64;
+    int firstRows = 4;
+    int secondRows = 2;
+    int thirdRows = 3;
+    float[] query = patternedQuery(cols);
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(
+                q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), firstRows * 2));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), secondRows * 2));
+    MemorySegment thirdWeight =
+        MemorySegment.ofArray(
+            repeat(
+                q4Block(0.03125f, ones(cols), (lo, hi) -> (lo * 3 + hi * 7) & 0xFF),
+                thirdRows * 2));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] expectedThird = new float[thirdRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+    float[] actualThird = new float[thirdRows];
+
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, firstWeight, firstRows, cols, expectedFirst, new byte[cols], new float[cols / 32]);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 32]);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, thirdWeight, thirdRows, cols, expectedThird, new byte[cols], new float[cols / 32]);
+
+    VectorUtil.ggufQ4_0Q8_0TripleBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        cols,
+        new byte[cols],
+        new float[cols / 32]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q4_0Q8_0BatchedMatmulMatchesIndependentQueries() {
     int batchSize = 3;
     int rows = 2;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -503,7 +503,9 @@ class GgufQuantizedDotTest {
 
     assertThat(q8Quants).containsExactly(expectedQuants);
     assertThat(q8Scales).containsExactly(expectedScales);
-    assertThat(out).containsOnly(expected[0]);
+    for (float value : out) {
+      assertThat(value).isCloseTo(expected[0], within(1e-4f));
+    }
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -382,6 +382,48 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0BatchedMatmulMatchesGemvReductionAcrossBlocks() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 256;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] =
+            (float) Math.sin((batch + 1.0) * (col + 0.5)) * (batch + 0.25f);
+      }
+    }
+    byte[] row0 = repeat(q4Block(0.13f, ones(32), (lo, hi) -> (lo * 11 + hi * 7 + 3) & 0xFF), 8);
+    byte[] row1 = repeat(q4Block(-0.07f, ones(32), (lo, hi) -> (lo * 5 + hi * 13 + 9) & 0xFF), 8);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+      for (int batch = 0; batch < batchSize; batch++) {
+        float[] query = new float[cols];
+        float[] result = new float[rows];
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+            query, segment, rows, cols, result, new byte[cols], new float[cols / 32]);
+        System.arraycopy(result, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+          queries,
+          segment,
+          batchSize,
+          rows,
+          cols,
+          actual,
+          new byte[batchSize * cols],
+          new float[batchSize * (cols / 32)]);
+
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
   void q8_0BatchDotProduct_respectsRowOffsets() {
     float[] query = ones(32);
     byte[] row0 = q8Block(1.0f);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -323,6 +323,43 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0BatchedMatmulMatchesIndependentQueries() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 32;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] = ((batch + 1) * (col - 13)) / 17.0f;
+      }
+    }
+    byte[] row0 = q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF);
+    byte[] row1 = q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    byte[] q8Quants = new byte[batchSize * cols];
+    float[] q8Scales = new float[batchSize * (cols / 32)];
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, concat(row0, row1));
+      for (int batch = 0; batch < batchSize; batch++) {
+        float[] query = new float[cols];
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        float[] result = new float[rows];
+        VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+            query, segment, rows, cols, result, new byte[cols], new float[cols / 32]);
+        System.arraycopy(result, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+          queries, segment, batchSize, rows, cols, actual, q8Quants, q8Scales);
+
+      assertThat(actual).containsExactly(expected);
+      assertThat(q8Quants[0]).isNotZero();
+    }
+  }
+
+  @Test
   void q8_0BatchDotProduct_respectsRowOffsets() {
     float[] query = ones(32);
     byte[] row0 = q8Block(1.0f);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -83,6 +83,25 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0IntegerLanesAccumulateFourChunks() {
+    byte[] weights = new byte[32];
+    byte[] q8 = new byte[32];
+    for (int index = 0; index < weights.length; index++) {
+      weights[index] = (byte) (index - 17);
+      q8[index] = (byte) (15 - index);
+    }
+
+    IntVector actual =
+        PanamaVectorUtilSupport.q8_0Q8_0IntegerLanes(MemorySegment.ofArray(weights), 0, q8, 0);
+
+    int[] expected = new int[8];
+    for (int index = 0; index < weights.length; index++) {
+      expected[index % 8] += weights[index] * q8[index];
+    }
+    assertThat(actual.toArray()).containsExactly(expected);
+  }
+
+  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
@@ -179,7 +198,10 @@ class PanamaGgufQuantizedDotTest {
 
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
-    assertThat(actual).containsExactly(expected);
+    assertThat(actual).hasSameSizeAs(expected);
+    for (int row = 0; row < rows; row++) {
+      assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
+    }
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -117,6 +117,29 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0PairLanesSumAdjacentProductsWithoutOverflow() {
+    byte[] weights = {127, 127, -128, 127, 64, -64, 31, -31, 1, -1, 100, -100, 12, 13, -14, -15};
+    byte[] q8 = new byte[21];
+    int quantOffset = 5;
+    for (int index = 0; index < weights.length; index++) {
+      q8[quantOffset + index] = (byte) (127 - index * 9);
+    }
+
+    IntVector actual =
+        PanamaVectorUtilSupport.q8_0Q8_0PairLanes(
+            MemorySegment.ofArray(weights), 0, q8, quantOffset);
+
+    int[] expected = new int[8];
+    for (int lane = 0; lane < expected.length; lane++) {
+      int index = lane * 2;
+      expected[lane] =
+          weights[index] * q8[quantOffset + index]
+              + weights[index + 1] * q8[quantOffset + index + 1];
+    }
+    assertThat(actual.toArray()).containsExactly(expected);
+  }
+
+  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -117,29 +117,6 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q8_0Q8_0PairLanesSumAdjacentProductsWithoutOverflow() {
-    byte[] weights = {127, 127, -128, 127, 64, -64, 31, -31, 1, -1, 100, -100, 12, 13, -14, -15};
-    byte[] q8 = new byte[21];
-    int quantOffset = 5;
-    for (int index = 0; index < weights.length; index++) {
-      q8[quantOffset + index] = (byte) (127 - index * 9);
-    }
-
-    IntVector actual =
-        PanamaVectorUtilSupport.q8_0Q8_0PairLanes(
-            MemorySegment.ofArray(weights), 0, q8, quantOffset);
-
-    int[] expected = new int[8];
-    for (int lane = 0; lane < expected.length; lane++) {
-      int index = lane * 2;
-      expected[lane] =
-          weights[index] * q8[quantOffset + index]
-              + weights[index + 1] * q8[quantOffset + index + 1];
-    }
-    assertThat(actual.toArray()).containsExactly(expected);
-  }
-
-  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -59,6 +59,30 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KQ8_KIntegerLanesSumFourProductsPerLane() {
+    byte[] packed = new byte[32];
+    byte[] q8 = new byte[32];
+    int[] q4 = new int[32];
+    for (int index = 0; index < packed.length; index++) {
+      int value = (index * 3) % 16;
+      packed[index] = (byte) ((value << 4) | (15 - value));
+      q4[index] = value;
+      q8[index] = (byte) (index - 16);
+    }
+
+    IntVector actual =
+        PanamaVectorUtilSupport.q4_KQ8_KIntegerLanes(MemorySegment.ofArray(packed), 0, 4, q8, 0);
+
+    int[] expected = new int[8];
+    for (int lane = 0; lane < expected.length; lane++) {
+      for (int index = lane * 4; index < lane * 4 + 4; index++) {
+        expected[lane] += q4[index] * q8[index];
+      }
+    }
+    assertThat(actual.toArray()).containsExactly(expected);
+  }
+
+  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
@@ -205,6 +229,9 @@ class PanamaGgufQuantizedDotTest {
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
     assertThat(actualSums).containsExactly(expectedSums);
-    assertThat(actual).containsExactly(expected);
+    assertThat(actual).hasSameSizeAs(expected);
+    for (int row = 0; row < rows; row++) {
+      assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
+    }
   }
 }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -83,7 +83,7 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q6_KQ8_KIntegerLanesDecodePackedWeightsAndSignedScales() {
+  void q6_KQ8_KIntegerDotDecodesPackedWeightsAndSignedScales() {
     byte[] weights = new byte[80];
     byte[] q8 = new byte[128];
     Random random = new Random(0x516B48L);
@@ -95,11 +95,11 @@ class PanamaGgufQuantizedDotTest {
     int s3 = -3;
     int s4 = 13;
 
-    IntVector actual =
-        PanamaVectorUtilSupport.q6_KQ8_KIntegerLanes(
+    int actual =
+        PanamaVectorUtilSupport.q6_KQ8_KIntegerDot(
             MemorySegment.ofArray(weights), 0, 32, 64, q8, quantOffset, s1, s2, s3, s4);
 
-    int[] expected = new int[8];
+    int expected = 0;
     for (int index = 0; index < 16; index++) {
       int ql1 = weights[index] & 0xFF;
       int ql2 = weights[32 + index] & 0xFF;
@@ -108,13 +108,12 @@ class PanamaGgufQuantizedDotTest {
       int q2 = ((ql2 & 0x0F) | (((high >>> 2) & 0x03) << 4)) - 32;
       int q3 = ((ql1 >>> 4) | (((high >>> 4) & 0x03) << 4)) - 32;
       int q4 = ((ql2 >>> 4) | (((high >>> 6) & 0x03) << 4)) - 32;
-      int lane = index / 2;
-      expected[lane] += s1 * q1 * q8[quantOffset + index];
-      expected[lane] += s2 * q2 * q8[quantOffset + index + 32];
-      expected[lane] += s3 * q3 * q8[quantOffset + index + 64];
-      expected[lane] += s4 * q4 * q8[quantOffset + index + 96];
+      expected += s1 * q1 * q8[quantOffset + index];
+      expected += s2 * q2 * q8[quantOffset + index + 32];
+      expected += s3 * q3 * q8[quantOffset + index + 64];
+      expected += s4 * q4 * q8[quantOffset + index + 96];
     }
-    assertThat(actual.toArray()).containsExactly(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -83,25 +83,6 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q8_0Q8_0IntegerLanesAccumulateFourChunks() {
-    byte[] weights = new byte[32];
-    byte[] q8 = new byte[32];
-    for (int index = 0; index < weights.length; index++) {
-      weights[index] = (byte) (index - 17);
-      q8[index] = (byte) (15 - index);
-    }
-
-    IntVector actual =
-        PanamaVectorUtilSupport.q8_0Q8_0IntegerLanes(MemorySegment.ofArray(weights), 0, q8, 0);
-
-    int[] expected = new int[8];
-    for (int index = 0; index < weights.length; index++) {
-      expected[index % 8] += weights[index] * q8[index];
-    }
-    assertThat(actual.toArray()).containsExactly(expected);
-  }
-
-  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
@@ -198,10 +179,7 @@ class PanamaGgufQuantizedDotTest {
 
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
-    assertThat(actual).hasSameSizeAs(expected);
-    for (int row = 0; row < rows; row++) {
-      assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
-    }
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -16,17 +16,47 @@
 package com.integrallis.vectors.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
+import jdk.incubator.vector.IntVector;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("unit")
 class PanamaGgufQuantizedDotTest {
+
+  @Test
+  void q4_0Q8_0IntegerLanesSumFourProductsPerLane() {
+    byte[] packed = new byte[16];
+    byte[] q8 = new byte[32];
+    int[] q4 = new int[32];
+    for (int index = 0; index < 16; index++) {
+      int low = index % 16;
+      int high = 15 - index;
+      packed[index] = (byte) (low | (high << 4));
+      q4[index] = low - 8;
+      q4[index + 16] = high - 8;
+    }
+    for (int index = 0; index < q8.length; index++) {
+      q8[index] = (byte) (index - 16);
+    }
+
+    IntVector actual =
+        PanamaVectorUtilSupport.q4_0Q8_0IntegerLanes(MemorySegment.ofArray(packed), 0, q8, 0);
+
+    int[] expected = new int[8];
+    for (int lane = 0; lane < expected.length; lane++) {
+      for (int index = lane * 4; index < lane * 4 + 4; index++) {
+        expected[lane] += q4[index] * q8[index];
+      }
+    }
+    assertThat(actual.toArray()).containsExactly(expected);
+  }
 
   @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
@@ -84,7 +114,10 @@ class PanamaGgufQuantizedDotTest {
 
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
-    assertThat(actual).containsExactly(expected);
+    assertThat(actual).hasSameSizeAs(expected);
+    for (int row = 0; row < rows; row++) {
+      assertThat(actual[row]).isCloseTo(expected[row], offset(1e-4f));
+    }
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -83,6 +83,41 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q6_KQ8_KIntegerLanesDecodePackedWeightsAndSignedScales() {
+    byte[] weights = new byte[80];
+    byte[] q8 = new byte[128];
+    Random random = new Random(0x516B48L);
+    random.nextBytes(weights);
+    random.nextBytes(q8);
+    int quantOffset = 7;
+    int s1 = -11;
+    int s2 = 7;
+    int s3 = -3;
+    int s4 = 13;
+
+    IntVector actual =
+        PanamaVectorUtilSupport.q6_KQ8_KIntegerLanes(
+            MemorySegment.ofArray(weights), 0, 32, 64, q8, quantOffset, s1, s2, s3, s4);
+
+    int[] expected = new int[8];
+    for (int index = 0; index < 16; index++) {
+      int ql1 = weights[index] & 0xFF;
+      int ql2 = weights[32 + index] & 0xFF;
+      int high = weights[64 + index] & 0xFF;
+      int q1 = ((ql1 & 0x0F) | ((high & 0x03) << 4)) - 32;
+      int q2 = ((ql2 & 0x0F) | (((high >>> 2) & 0x03) << 4)) - 32;
+      int q3 = ((ql1 >>> 4) | (((high >>> 4) & 0x03) << 4)) - 32;
+      int q4 = ((ql2 >>> 4) | (((high >>> 6) & 0x03) << 4)) - 32;
+      int lane = index / 2;
+      expected[lane] += s1 * q1 * q8[quantOffset + index];
+      expected[lane] += s2 * q2 * q8[quantOffset + index + 32];
+      expected[lane] += s3 * q3 * q8[quantOffset + index + 64];
+      expected[lane] += s4 * q4 * q8[quantOffset + index + 96];
+    }
+    assertThat(actual.toArray()).containsExactly(expected);
+  }
+
+  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
@@ -101,6 +136,13 @@ class PanamaGgufQuantizedDotTest {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
         .contains("ggufQ4_KQ8_KMatVecDot");
+  }
+
+  @Test
+  void panamaProviderOwnsQ6_KQ8_KKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ6_KQ8_KMatVecDot");
   }
 
   @Test
@@ -229,6 +271,47 @@ class PanamaGgufQuantizedDotTest {
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
     assertThat(actualSums).containsExactly(expectedSums);
+    assertThat(actual).hasSameSizeAs(expected);
+    for (int row = 0; row < rows; row++) {
+      assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
+    }
+  }
+
+  @Test
+  void q6_KQ8_KKernelMatchesScalarReferenceAcrossRowsAndBlocks() {
+    int rows = 512;
+    int cols = 2048;
+    Random random = new Random(0x516B48L);
+    float[] query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 256) * 210];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 210) {
+      float scale = random.nextFloat() * 0.05f + 0.001f;
+      buffer.putShort(offset + 208, Float.floatToFloat16(scale));
+    }
+
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+    byte[] expectedQuants = new byte[cols];
+    byte[] actualQuants = new byte[cols];
+    float[] expectedScales = new float[cols / 256];
+    float[] actualScales = new float[cols / 256];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ6_KQ8_KMatVecDot(
+            query, weightSegment, rows, cols, expected, expectedQuants, expectedScales);
+    new PanamaVectorUtilSupport()
+        .ggufQ6_KQ8_KMatVecDot(
+            query, weightSegment, rows, cols, actual, actualQuants, actualScales);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
     assertThat(actual).hasSameSizeAs(expected);
     for (int row = 0; row < rows; row++) {
       assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -117,6 +117,31 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q5_0Q8_0IntegerLanesDecodeHighBits() {
+    byte[] packed = new byte[16];
+    byte[] q8 = new byte[32];
+    Random random = new Random(0x515048L);
+    random.nextBytes(packed);
+    random.nextBytes(q8);
+    int highBits = 0xA5C33C5A;
+
+    IntVector actual =
+        PanamaVectorUtilSupport.q5_0Q8_0IntegerLanes(
+            MemorySegment.ofArray(packed), 0, highBits, q8, 0);
+
+    int[] expected = new int[8];
+    for (int index = 0; index < packed.length; index++) {
+      int value = packed[index] & 0xFF;
+      int low = (value & 0x0F) | (((highBits >>> index) & 1) << 4);
+      int high = (value >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
+      int lane = index & 7;
+      expected[lane] += (low - 16) * q8[index];
+      expected[lane] += (high - 16) * q8[index + 16];
+    }
+    assertThat(actual.toArray()).containsExactly(expected);
+  }
+
+  @Test
   void panamaProviderOwnsQ4_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
@@ -142,6 +167,13 @@ class PanamaGgufQuantizedDotTest {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
         .contains("ggufQ6_KQ8_KMatVecDot");
+  }
+
+  @Test
+  void panamaProviderOwnsQ5_0Q8_0Kernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ5_0Q8_0MatVecDot");
   }
 
   @Test
@@ -315,5 +347,43 @@ class PanamaGgufQuantizedDotTest {
     for (int row = 0; row < rows; row++) {
       assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
     }
+  }
+
+  @Test
+  void q5_0Q8_0KernelMatchesScalarReferenceAcrossRowsAndBlocks() {
+    int rows = 512;
+    int cols = 2048;
+    Random random = new Random(0x515048L);
+    float[] query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 22];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 22) {
+      float scale = random.nextFloat() * 0.05f + 0.001f;
+      buffer.putShort(offset, Float.floatToFloat16(scale));
+    }
+
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+    byte[] expectedQuants = new byte[cols];
+    byte[] actualQuants = new byte[cols];
+    float[] expectedScales = new float[cols / 32];
+    float[] actualScales = new float[cols / 32];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ5_0Q8_0MatVecDot(
+            query, weightSegment, rows, cols, expected, expectedQuants, expectedScales);
+    new PanamaVectorUtilSupport()
+        .ggufQ5_0Q8_0MatVecDot(
+            query, weightSegment, rows, cols, actual, actualQuants, actualScales);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actual).containsExactly(expected);
   }
 }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
@@ -186,6 +186,19 @@ class VectorUtilSupportTest {
     }
 
     @Test
+    void dotProductRemainsBitExactAfterJitWarmup() {
+      float[] values = randomFloats(1024, new Random(SEED));
+      float cold = panama.dotProduct(values, values);
+      float hot = cold;
+
+      for (int iteration = 0; iteration < 20_000; iteration++) {
+        hot = panama.dotProduct(values, values);
+      }
+
+      assertThat(Float.floatToRawIntBits(hot)).isEqualTo(Float.floatToRawIntBits(cold));
+    }
+
+    @Test
     void emptyVectors() {
       float[] a = {};
       float[] b = {};

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -45,6 +45,9 @@ class VectorizationProviderTest {
     assertThat(summary).contains("fastVectorFMA=");
     assertThat(summary).contains("fastScalarFMA=");
     assertThat(summary).contains("sve=");
+    assertThat(summary).contains("ggufExecutor=persistent");
+    assertThat(summary).contains("ggufThreads=" + GgufParallelSupport.parallelism());
+    assertThat(summary).contains("ggufChunksPerThread=2");
     assertThat(summary).contains("toggles=[");
     assertThat(summary).endsWith("]");
   }


### PR DESCRIPTION
## Summary

- add Q4_0 batched prompt kernels and quantized-activation SIMD paths for supported GGUF formats
- make floating and quantized reductions deterministic across JIT tiers
- add reusable common, dedicated, and persistent row executors, with caller-participating persistent workers as the default
- add allocation-free dual/triple Q4_0 projection operations that share activation quantization and row dispatch
- add exactness, lifecycle, concurrency, model-scale stress, and JMH coverage

## Measured results

- persistent row execution improved controlled Qwen3 0.6B decode from 21.13 to 24.26 tok/s versus the common pool
- grouped Q/K/V is 45.8% faster in isolation and cuts normalized allocation by about 84.7%
- grouped projections improve controlled end-to-end decode from 25.96 to 27.21 tok/s and p50 TTFT from 1418 to 1164 ms
- all paired output hashes and strict Qwen/llama.cpp token checks remain exact

## Verification

- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`
- isolated `VectorDbVamanaPersistenceTest$ConcurrencyVamana.concurrentReadersNeverBlockedByVamanaCommit`
- repository-wide `spotlessApply check` progressed through the changed modules and about 800 `vectors-db` tests; an unrelated 10-second concurrency timeout passed immediately in isolation, and the already-failed run was stopped while executing the pre-existing 262,144-vector/1,024-centroid IVF footprint test
- controlled JMH, decode-only JFR, and real-model Qwen benchmarks on OpenJDK 25.0.3 / AMD EPYC Milan