### PR TITLE
perf(core): group Q4_K transformer projections

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -57,6 +57,8 @@ public class GgufQuantizedMatVecBenchmark {
   private MemorySegment secondQ4Weights;
   private MemorySegment thirdQ4Weights;
   private MemorySegment q4KWeights;
+  private MemorySegment secondQ4KWeights;
+  private MemorySegment thirdQ4KWeights;
   private MemorySegment q5Weights;
   private MemorySegment q8Weights;
   private MemorySegment q6Weights;
@@ -86,6 +88,9 @@ public class GgufQuantizedMatVecBenchmark {
     thirdQ4Weights =
         MemorySegment.ofArray(randomBlocks(random, auxiliaryRows * (cols / 32) * 18, 18, 0));
     q4KWeights = MemorySegment.ofArray(q4K);
+    secondQ4KWeights = MemorySegment.ofArray(randomQ4KBlocks(random, rows * (cols / 256) * 144));
+    thirdQ4KWeights =
+        MemorySegment.ofArray(randomQ4KBlocks(random, auxiliaryRows * (cols / 256) * 144));
     q5Weights = MemorySegment.ofArray(q5);
     q8Weights = MemorySegment.ofArray(q8);
     q6Weights = MemorySegment.ofArray(q6);
@@ -172,6 +177,71 @@ public class GgufQuantizedMatVecBenchmark {
     VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
         query, q4KWeights, rows, cols, out, q8Quants, q8Scales, q8Sums);
     blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q4_KSeparateDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, q4KWeights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, secondQ4KWeights, rows, cols, secondOut, q8Quants, q8Scales, q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q4_KGroupedDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KQ8_KDualBatchDotProduct(
+        query,
+        q4KWeights,
+        rows,
+        out,
+        secondQ4KWeights,
+        rows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q4_KSeparateQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = thirdOut.length;
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, q4KWeights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, secondQ4KWeights, auxiliaryRows, cols, secondOut, q8Quants, q8Scales, q8Sums);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, thirdQ4KWeights, auxiliaryRows, cols, thirdOut, q8Quants, q8Scales, q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
+  }
+
+  @Benchmark
+  public void q4_KGroupedQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = thirdOut.length;
+    VectorUtil.ggufQ4_KQ8_KTripleBatchDotProduct(
+        query,
+        q4KWeights,
+        rows,
+        out,
+        secondQ4KWeights,
+        auxiliaryRows,
+        secondOut,
+        thirdQ4KWeights,
+        auxiliaryRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
   }
 
   @Benchmark

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -868,6 +868,193 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  @Override
+  public void ggufQ4_KQ8_KDualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    ggufQ4_KQ8_KGroupedMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        secondWeight,
+        0,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  @Override
+  public void ggufQ4_KQ8_KTripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    ggufQ4_KQ8_KGroupedMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  private static void ggufQ4_KQ8_KGroupedMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = (long) (cols / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            qWeight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+          }
+
+          // Keep the SIMD body in this lambda. Extracting Vector values defeats C2 scalarization.
+          if (VECTOR_BITSIZE >= 256) {
+            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+            float minimumContribution = 0.0f;
+            long rowOffset = matrixRow * rowBytes;
+            for (int block = 0; block < blocks; block++) {
+              long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+              float q8Scale = q8Scales[block];
+              float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+              float dMin =
+                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                      * q8Scale;
+              long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+              long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+              int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+              IntVector blockLanes = IntVector.zero(IntVector.SPECIES_256);
+              int minimumSum = 0;
+
+              for (int group = 0; group < 8; group++) {
+                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+                int shift = (group & 1) * 4;
+                int groupActivationOffset = activationOffset + group * 32;
+                IntVector groupLanes =
+                    q4_KQ8_KIntegerLanes(
+                        qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+                blockLanes = blockLanes.add(groupLanes.mul(scale));
+                int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+                minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+              }
+
+              FloatVector products =
+                  (FloatVector)
+                      blockLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+              accumulator =
+                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, d), accumulator);
+              minimumContribution = MathUtil.fma(-dMin, minimumSum, minimumContribution);
+            }
+            out[matrixRow] = accumulator.reduceLanes(VectorOperators.ADD) + minimumContribution;
+            return;
+          }
+
+          float sum = 0.0f;
+          long rowOffset = matrixRow * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+            float q8Scale = q8Scales[block];
+            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+            float dMin =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                    * q8Scale;
+            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+            int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+            int quantizedSum = 0;
+            int minimumSum = 0;
+
+            for (int group = 0; group < 8; group++) {
+              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+              int shift = (group & 1) * 4;
+              int groupActivationOffset = activationOffset + group * 32;
+              int groupDot =
+                  q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+              quantizedSum += scale * groupDot;
+              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+            }
+
+            sum = MathUtil.fma(d, quantizedSum, sum);
+            sum = MathUtil.fma(-dMin, minimumSum, sum);
+          }
+          out[matrixRow] = sum;
+        });
+  }
+
   private static int q4_KQ8_KIntegerDot(
       MemorySegment qWeight, long packedOffset, int shift, byte[] q8Quants, int quantOffset) {
     if (VECTOR_BITSIZE >= 256) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -649,6 +649,110 @@ public final class VectorUtil {
     IMPL.ggufQ4_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
   }
 
+  /** Multiplies two Q4_K matrices by one shared Q8_K activation quantization and row dispatch. */
+  public static void ggufQ4_KQ8_KDualBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, cols);
+    IMPL.ggufQ4_KQ8_KDualMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  /** Multiplies three Q4_K matrices by one shared Q8_K activation quantization and row dispatch. */
+  public static void ggufQ4_KQ8_KTripleBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        thirdWeight,
+        thirdRows,
+        cols,
+        thirdOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, cols);
+    IMPL.ggufQ4_KQ8_KTripleMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
   /** Batched row-major GEMV over GGUF Q5_K rows. */
   public static void ggufQ5_KBatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -701,46 +701,139 @@ public interface VectorUtilSupport {
         qWeight,
         rows,
         cols,
+        row ->
+            out[row] =
+                ggufQ4_KQ8_KScalarRowDot(
+                    qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8Sums));
+  }
+
+  /** Two Q4_K projections sharing one Q8_K activation quantization and row dispatch. */
+  default void ggufQ4_KQ8_KDualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = ggufQ4_KRowBytes(cols);
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int totalRows = Math.addExact(firstRows, secondRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
         row -> {
-          float sum = 0.0f;
-          long rowOffset = row * rowBytes;
-
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-            float q8Scale = q8Scales[block];
-            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-            float dMin =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
-                    * q8Scale;
-            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-            int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-            int quantizedSum = 0;
-            int minimumSum = 0;
-
-            for (int group = 0; group < 8; group++) {
-              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-              int shift = (group & 1) * 4;
-              int groupActivationOffset = activationOffset + group * 32;
-              int groupDot = 0;
-
-              for (int index = 0; index < 32; index++) {
-                int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
-                int quant = (packed >>> shift) & 0x0F;
-                groupDot += quant * q8Quants[groupActivationOffset + index];
-              }
-              quantizedSum += scale * groupDot;
-              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-            }
-
-            sum = MathUtil.fma(d, quantizedSum, sum);
-            sum = MathUtil.fma(-dMin, minimumSum, sum);
-          }
-          out[row] = sum;
+          boolean first = row < firstRows;
+          MemorySegment weight = first ? firstWeight : secondWeight;
+          int matrixRow = first ? row : row - firstRows;
+          float[] out = first ? firstOut : secondOut;
+          out[matrixRow] =
+              ggufQ4_KQ8_KScalarRowDot(
+                  weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
         });
+  }
+
+  /** Three Q4_K projections sharing one Q8_K activation quantization and row dispatch. */
+  default void ggufQ4_KQ8_KTripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = ggufQ4_KRowBytes(cols);
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          MemorySegment weight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            weight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            weight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            weight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+          }
+          out[matrixRow] =
+              ggufQ4_KQ8_KScalarRowDot(
+                  weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+        });
+  }
+
+  private static float ggufQ4_KQ8_KScalarRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+      float q8Scale = q8Scales[block];
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+      float dMin =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+      int quantizedSum = 0;
+      int minimumSum = 0;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int groupActivationOffset = activationOffset + group * 32;
+        int groupDot = 0;
+        for (int index = 0; index < 32; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+          int quant = (packed >>> shift) & 0x0F;
+          groupDot += quant * q8Quants[groupActivationOffset + index];
+        }
+        quantizedSum += scale * groupDot;
+        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+      }
+
+      sum = MathUtil.fma(d, quantizedSum, sum);
+      sum = MathUtil.fma(-dMin, minimumSum, sum);
+    }
+    return sum;
   }
 
   /** Batched row-major GEMV over GGUF Q5_K rows. */

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -840,6 +840,135 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KQ8_KDualBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 256;
+    int firstRows = 3;
+    int secondRows = 2;
+    float[] query = patternedQuery(cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins), firstRows));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(-0.25f, 0.03125f, i -> 15 - i % 16, scales, mins), secondRows));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    VectorUtil.ggufQ4_KQ8_KDualBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        cols,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
+  void q4_KQ8_KTripleBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 256;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 1;
+    float[] query = patternedQuery(cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins), firstRows));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(-0.25f, 0.03125f, i -> 15 - i % 16, scales, mins), secondRows));
+    MemorySegment thirdWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(0.5f, -0.015625f, i -> i * 3 % 16, scales, mins), thirdRows));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] expectedThird = new float[thirdRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+    float[] actualThird = new float[thirdRows];
+
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        thirdWeight,
+        thirdRows,
+        cols,
+        expectedThird,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    VectorUtil.ggufQ4_KQ8_KTripleBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        cols,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q5_KBatchDotProduct_respectsRowOffsets() {
     float[] query = patternedQuery(256);
     int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};


### PR DESCRIPTION
## Summary

- add allocation-free dual and triple Q4_K/Q8_K projection APIs
- share activation quantization and persistent row dispatch across transformer projections
- retain scalar fallback, SIMD kernels, exact-equivalence tests, and transformer-shaped JMH controls

## Impact

Q4_K models can eliminate repeated Q8_K activation quantization and executor publication for QKV and gate/up groups. Local JDK 25 measurements showed grouped QKV at 0.534 ms/op versus 0.852 ms/op separate, with exact outputs.

## Verification

- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`
- JMH: 3 warmups, 5 measurements, 1024x2048, persistent 12-thread executor
- exact dual/triple Q4_K results against independent matmuls