### PR TITLE
perf(core): vectorize and group Q5_K projections

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -59,6 +59,9 @@ public class GgufQuantizedMatVecBenchmark {
   private MemorySegment q4KWeights;
   private MemorySegment secondQ4KWeights;
   private MemorySegment thirdQ4KWeights;
+  private MemorySegment q5KWeights;
+  private MemorySegment secondQ5KWeights;
+  private MemorySegment thirdQ5KWeights;
   private MemorySegment q5Weights;
   private MemorySegment q8Weights;
   private MemorySegment q6Weights;
@@ -79,6 +82,7 @@ public class GgufQuantizedMatVecBenchmark {
 
     byte[] q4 = randomBlocks(random, rows * (cols / 32) * 18, 18, 0);
     byte[] q4K = randomQ4KBlocks(random, rows * (cols / 256) * 144);
+    byte[] q5K = randomQ5KBlocks(random, rows * (cols / 256) * 176);
     byte[] q5 = randomBlocks(random, rows * (cols / 32) * 22, 22, 0);
     byte[] q8 = randomBlocks(random, rows * (cols / 32) * 34, 34, 0);
     byte[] q6 = randomBlocks(random, rows * (cols / 256) * 210, 210, 208);
@@ -91,6 +95,10 @@ public class GgufQuantizedMatVecBenchmark {
     secondQ4KWeights = MemorySegment.ofArray(randomQ4KBlocks(random, rows * (cols / 256) * 144));
     thirdQ4KWeights =
         MemorySegment.ofArray(randomQ4KBlocks(random, auxiliaryRows * (cols / 256) * 144));
+    q5KWeights = MemorySegment.ofArray(q5K);
+    secondQ5KWeights = MemorySegment.ofArray(randomQ5KBlocks(random, rows * (cols / 256) * 176));
+    thirdQ5KWeights =
+        MemorySegment.ofArray(randomQ5KBlocks(random, auxiliaryRows * (cols / 256) * 176));
     q5Weights = MemorySegment.ofArray(q5);
     q8Weights = MemorySegment.ofArray(q8);
     q6Weights = MemorySegment.ofArray(q6);
@@ -245,6 +253,71 @@ public class GgufQuantizedMatVecBenchmark {
   }
 
   @Benchmark
+  public void q5_KSeparateDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query, q5KWeights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query, secondQ5KWeights, rows, cols, secondOut, q8Quants, q8Scales, q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q5_KGroupedDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ5_KQ8_KDualBatchDotProduct(
+        query,
+        q5KWeights,
+        rows,
+        out,
+        secondQ5KWeights,
+        rows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q5_KSeparateQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = thirdOut.length;
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query, q5KWeights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query, secondQ5KWeights, auxiliaryRows, cols, secondOut, q8Quants, q8Scales, q8Sums);
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query, thirdQ5KWeights, auxiliaryRows, cols, thirdOut, q8Quants, q8Scales, q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
+  }
+
+  @Benchmark
+  public void q5_KGroupedQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = thirdOut.length;
+    VectorUtil.ggufQ5_KQ8_KTripleBatchDotProduct(
+        query,
+        q5KWeights,
+        rows,
+        out,
+        secondQ5KWeights,
+        auxiliaryRows,
+        secondOut,
+        thirdQ5KWeights,
+        auxiliaryRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
+  }
+
+  @Benchmark
   public void q5_0WithF32Activation(Blackhole blackhole) {
     VectorUtil.ggufQ5_0BatchDotProduct(query, q5Weights, rows, cols, out);
     blackhole.consume(out);
@@ -297,6 +370,16 @@ public class GgufQuantizedMatVecBenchmark {
     ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
     short minScale = Float.floatToFloat16(0.005f);
     for (int offset = 0; offset < byteCount; offset += 144) {
+      buffer.putShort(offset + Short.BYTES, minScale);
+    }
+    return blocks;
+  }
+
+  private static byte[] randomQ5KBlocks(Random random, int byteCount) {
+    byte[] blocks = randomBlocks(random, byteCount, 176, 0);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short minScale = Float.floatToFloat16(0.005f);
+    for (int offset = 0; offset < byteCount; offset += 176) {
       buffer.putShort(offset + Short.BYTES, minScale);
     }
     return blocks;

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1132,6 +1132,278 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return fourProductLanes(firstProducts, secondProducts);
   }
 
+  /** SIMD Q5_K by Q8_K GEMV with one activation quantization shared by all rows. */
+  @Override
+  public void ggufQ5_KQ8_KMatVecDot(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ5_KQ8_KMatVecDot(
+          query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
+      return;
+    }
+
+    GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+    long rowBytes = (long) (cols / GGUF_Q5_K_BLOCK_SIZE) * GGUF_Q5_K_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row ->
+            out[row] = q5_KQ8_KRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8Sums));
+  }
+
+  @Override
+  public void ggufQ5_KQ8_KDualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ5_KQ8_KDualMatVecDot(
+          query,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          cols,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      return;
+    }
+    ggufQ5_KQ8_KGroupedMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        secondWeight,
+        0,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  @Override
+  public void ggufQ5_KQ8_KTripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ5_KQ8_KTripleMatVecDot(
+          query,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          thirdWeight,
+          thirdRows,
+          thirdOut,
+          cols,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      return;
+    }
+    ggufQ5_KQ8_KGroupedMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  private static void ggufQ5_KQ8_KGroupedMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = (long) (cols / GGUF_Q5_K_BLOCK_SIZE) * GGUF_Q5_K_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            qWeight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+          }
+
+          out[matrixRow] =
+              q5_KQ8_KRowDot(qWeight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+        });
+  }
+
+  private static float q5_KQ8_KRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      float q8Scale = q8Scales[block];
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+      float dMin =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+      int quantizedSum = 0;
+      int minimumSum = 0;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int highBit = 1 << group;
+        int groupActivationOffset = activationOffset + group * 32;
+        int groupDot =
+            q5_KQ8_KIntegerDot(
+                qWeight,
+                packedOffset,
+                shift,
+                highBitsOffset,
+                highBit,
+                q8Quants,
+                groupActivationOffset);
+        quantizedSum += scale * groupDot;
+        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+      }
+
+      sum = MathUtil.fma(d, quantizedSum, sum);
+      sum = MathUtil.fma(-dMin, minimumSum, sum);
+    }
+    return sum;
+  }
+
+  static int q5_KQ8_KIntegerDot(
+      MemorySegment qWeight,
+      long packedOffset,
+      int shift,
+      long highBitsOffset,
+      int highBit,
+      byte[] q8Quants,
+      int quantOffset) {
+    int sum = q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, quantOffset);
+    int highShift = Integer.numberOfTrailingZeros(highBit);
+    if (VECTOR_BITSIZE >= 256) {
+      for (int index = 0; index < 32; index += 16) {
+        ByteVector highBits =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_128, qWeight, highBitsOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ShortVector bits =
+            (ShortVector)
+                highBits
+                    .lanewise(VectorOperators.LSHR, highShift)
+                    .and((byte) 1)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+        ShortVector quants =
+            (ShortVector)
+                ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + index)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+        sum += 16 * bits.mul(quants).reduceLanes(VectorOperators.ADD);
+      }
+      return sum;
+    }
+
+    for (int index = 0; index < 32; index += 8) {
+      ByteVector highBits =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, highBitsOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ShortVector bits =
+          (ShortVector)
+              highBits
+                  .lanewise(VectorOperators.LSHR, highShift)
+                  .and((byte) 1)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+      ShortVector quants =
+          (ShortVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+      sum += 16 * bits.mul(quants).reduceLanes(VectorOperators.ADD);
+    }
+    return sum;
+  }
+
   /** SIMD Q5_0 by Q8_0 GEMV with one activation quantization shared by all rows. */
   @Override
   public void ggufQ5_0Q8_0MatVecDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -796,6 +796,110 @@ public final class VectorUtil {
     IMPL.ggufQ5_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
   }
 
+  /** Multiplies two Q5_K matrices by one shared Q8_K activation quantization and row dispatch. */
+  public static void ggufQ5_KQ8_KDualBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, cols);
+    IMPL.ggufQ5_KQ8_KDualMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  /** Multiplies three Q5_K matrices by one shared Q8_K activation quantization and row dispatch. */
+  public static void ggufQ5_KQ8_KTripleBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        thirdWeight,
+        thirdRows,
+        cols,
+        thirdOut,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, cols);
+    IMPL.ggufQ5_KQ8_KTripleMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
   /** Batched row-major GEMV over GGUF Q5_0 rows. */
   public static void ggufQ5_0BatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -863,49 +863,143 @@ public interface VectorUtilSupport {
         qWeight,
         rows,
         cols,
+        row ->
+            out[row] =
+                ggufQ5_KQ8_KScalarRowDot(
+                    qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8Sums));
+  }
+
+  /** Two Q5_K projections sharing one Q8_K activation quantization and row dispatch. */
+  default void ggufQ5_KQ8_KDualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = ggufQ5_KRowBytes(cols);
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    int totalRows = Math.addExact(firstRows, secondRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
         row -> {
-          float sum = 0.0f;
-          long rowOffset = row * rowBytes;
-
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
-            float q8Scale = q8Scales[block];
-            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-            float dMin =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
-                    * q8Scale;
-            long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
-            long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
-            long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
-            int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
-            int quantizedSum = 0;
-            int minimumSum = 0;
-
-            for (int group = 0; group < 8; group++) {
-              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-              int shift = (group & 1) * 4;
-              int highBit = 1 << group;
-              int groupActivationOffset = activationOffset + group * 32;
-              int groupDot = 0;
-
-              for (int index = 0; index < 32; index++) {
-                int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
-                int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
-                int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
-                groupDot += quant * q8Quants[groupActivationOffset + index];
-              }
-              quantizedSum += scale * groupDot;
-              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-            }
-
-            sum = MathUtil.fma(d, quantizedSum, sum);
-            sum = MathUtil.fma(-dMin, minimumSum, sum);
-          }
-          out[row] = sum;
+          boolean first = row < firstRows;
+          MemorySegment weight = first ? firstWeight : secondWeight;
+          int matrixRow = first ? row : row - firstRows;
+          float[] out = first ? firstOut : secondOut;
+          out[matrixRow] =
+              ggufQ5_KQ8_KScalarRowDot(
+                  weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
         });
+  }
+
+  /** Three Q5_K projections sharing one Q8_K activation quantization and row dispatch. */
+  default void ggufQ5_KQ8_KTripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long rowBytes = ggufQ5_KRowBytes(cols);
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          MemorySegment weight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            weight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            weight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            weight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+          }
+          out[matrixRow] =
+              ggufQ5_KQ8_KScalarRowDot(
+                  weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+        });
+  }
+
+  private static float ggufQ5_KQ8_KScalarRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      float q8Scale = q8Scales[block];
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+      float dMin =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+      int quantizedSum = 0;
+      int minimumSum = 0;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int highBit = 1 << group;
+        int groupActivationOffset = activationOffset + group * 32;
+        int groupDot = 0;
+
+        for (int index = 0; index < 32; index++) {
+          int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+          int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
+          int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
+          groupDot += quant * q8Quants[groupActivationOffset + index];
+        }
+        quantizedSum += scale * groupDot;
+        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+      }
+
+      sum = MathUtil.fma(d, quantizedSum, sum);
+      sum = MathUtil.fma(-dMin, minimumSum, sum);
+    }
+    return sum;
   }
 
   /** Batched row-major GEMV over GGUF Q5_0 rows. */

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -969,6 +969,135 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_KQ8_KDualBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 256;
+    int firstRows = 3;
+    int secondRows = 2;
+    float[] query = patternedQuery(cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins), firstRows));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q5KBlock(-0.25f, 0.03125f, i -> 31 - i % 32, scales, mins), secondRows));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    VectorUtil.ggufQ5_KQ8_KDualBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        cols,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
+  void q5_KQ8_KTripleBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 256;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 1;
+    float[] query = patternedQuery(cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins), firstRows));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q5KBlock(-0.25f, 0.03125f, i -> 31 - i % 32, scales, mins), secondRows));
+    MemorySegment thirdWeight =
+        MemorySegment.ofArray(
+            repeat(q5KBlock(0.5f, -0.015625f, i -> i * 11 % 32, scales, mins), thirdRows));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] expectedThird = new float[thirdRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+    float[] actualThird = new float[thirdRows];
+
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query,
+        thirdWeight,
+        thirdRows,
+        cols,
+        expectedThird,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    VectorUtil.ggufQ5_KQ8_KTripleBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        cols,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q5_KBatchDotProduct_respectsRowOffsets() {
     float[] query = patternedQuery(256);
     int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -83,6 +83,37 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q5_KQ8_KIntegerDotDecodesPerElementHighBits() {
+    byte[] weights = new byte[64];
+    byte[] q8 = new byte[32];
+    int highBit = 1 << 3;
+    for (int index = 0; index < 32; index++) {
+      int low = index * 3 % 16;
+      int high = index * 5 % 16;
+      weights[32 + index] = (byte) (low | (high << 4));
+      if ((index & 1) != 0) {
+        weights[index] = (byte) highBit;
+      }
+      q8[index] = (byte) (index - 16);
+    }
+
+    int actual =
+        PanamaVectorUtilSupport.q5_KQ8_KIntegerDot(
+            MemorySegment.ofArray(weights), 32, 4, 0, highBit, q8, 0);
+
+    int expected = 0;
+    for (int index = 0; index < 32; index++) {
+      int packed = weights[32 + index] & 0xFF;
+      int quant = (packed >>> 4) & 0x0F;
+      if ((weights[index] & highBit) != 0) {
+        quant += 16;
+      }
+      expected += quant * q8[index];
+    }
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
   void q6_KQ8_KIntegerDotDecodesPackedWeightsAndSignedScales() {
     byte[] weights = new byte[80];
     byte[] q8 = new byte[128];
@@ -160,6 +191,13 @@ class PanamaGgufQuantizedDotTest {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
         .contains("ggufQ4_KQ8_KMatVecDot");
+  }
+
+  @Test
+  void panamaProviderOwnsQ5_KQ8_KKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ5_KQ8_KMatVecDot");
   }
 
   @Test
@@ -306,6 +344,56 @@ class PanamaGgufQuantizedDotTest {
     for (int row = 0; row < rows; row++) {
       assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
     }
+  }
+
+  @Test
+  void q5_KQ8_KKernelMatchesScalarReferenceAcrossRowsAndBlocks() {
+    int rows = 512;
+    int cols = 2048;
+    Random random = new Random(0x515B48L);
+    float[] query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 256) * 176];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 176) {
+      float scale = random.nextFloat() * 0.05f + 0.001f;
+      float minScale = random.nextFloat() * 0.05f;
+      buffer.putShort(offset, Float.floatToFloat16(scale));
+      buffer.putShort(offset + Short.BYTES, Float.floatToFloat16(minScale));
+    }
+
+    float[] expected = new float[rows];
+    float[] actual = new float[rows];
+    byte[] expectedQuants = new byte[cols];
+    byte[] actualQuants = new byte[cols];
+    float[] expectedScales = new float[cols / 256];
+    float[] actualScales = new float[cols / 256];
+    short[] expectedSums = new short[cols / 16];
+    short[] actualSums = new short[cols / 16];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ5_KQ8_KMatVecDot(
+            query,
+            weightSegment,
+            rows,
+            cols,
+            expected,
+            expectedQuants,
+            expectedScales,
+            expectedSums);
+    new PanamaVectorUtilSupport()
+        .ggufQ5_KQ8_KMatVecDot(
+            query, weightSegment, rows, cols, actual, actualQuants, actualScales, actualSums);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actualSums).containsExactly(expectedSums);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add allocation-free dual and triple Q5_K/Q8_K projection APIs with one shared activation quantization
- add a Panama Q5_K row kernel using exact low4 plus high-bit integer decomposition
- cover scalar, grouped, provider ownership, high-bit decoding, randomized bit-exactness, and JMH paths

## Correctness
- randomized 512x2048 Panama output is bit-identical to the scalar provider
- grouped and separate operations preserve exact floating accumulation order
- real SQLCoder-7B-2 validation in the dependent models branch matches llama.cpp tokens `[13, 917, 29901, 274]`

## Performance
Controlled 8-vCPU AMD EPYC Milan, OpenJDK 25.0.3, SQLCoder-7B-2 Q5_K_M, 2 warmups and 10 trials:
- p50 decode: 0.590 to 1.183 tok/s (`+100.4%`)
- p50 TPOT: 1693.81 to 845.03 ms (`-50.1%`)
- p95 TTFT: 40185.9 to 19799.0 ms (`-50.7%`)
- every corresponding output SHA-256 matched

A direct full-Q5 Vector formulation was rejected after allocating about 12.53 MB/op. The retained primitive-return decomposition measures about 167 B/op with zero collections.

## Verification
- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`
- allocation-profiled JMH on JDK 25
- controlled real-model A/B from isolated worktrees