### PR TITLE
perf(core): group Q8 transformer projections

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -64,6 +64,8 @@ public class GgufQuantizedMatVecBenchmark {
   private MemorySegment thirdQ5KWeights;
   private MemorySegment q5Weights;
   private MemorySegment q8Weights;
+  private MemorySegment secondQ8Weights;
+  private MemorySegment thirdQ8Weights;
   private MemorySegment q6Weights;
   private float[] out;
   private float[] secondOut;
@@ -101,6 +103,9 @@ public class GgufQuantizedMatVecBenchmark {
         MemorySegment.ofArray(randomQ5KBlocks(random, auxiliaryRows * (cols / 256) * 176));
     q5Weights = MemorySegment.ofArray(q5);
     q8Weights = MemorySegment.ofArray(q8);
+    secondQ8Weights = MemorySegment.ofArray(randomBlocks(random, rows * (cols / 32) * 34, 34, 0));
+    thirdQ8Weights =
+        MemorySegment.ofArray(randomBlocks(random, auxiliaryRows * (cols / 32) * 34, 34, 0));
     q6Weights = MemorySegment.ofArray(q6);
     out = new float[rows];
     secondOut = new float[rows];
@@ -339,6 +344,58 @@ public class GgufQuantizedMatVecBenchmark {
   public void q8_0WithQ8_0Activation(Blackhole blackhole) {
     VectorUtil.ggufQ8_0Q8_0BatchDotProduct(query, q8Weights, rows, cols, out, q8Quants, q8Scales);
     blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void q8_0SeparateDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(query, q8Weights, rows, cols, out, q8Quants, q8Scales);
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query, secondQ8Weights, rows, cols, secondOut, q8Quants, q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q8_0GroupedDualProjection(Blackhole blackhole) {
+    VectorUtil.ggufQ8_0Q8_0DualBatchDotProduct(
+        query, q8Weights, rows, out, secondQ8Weights, rows, secondOut, cols, q8Quants, q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q8_0SeparateQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = thirdOut.length;
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(query, q8Weights, rows, cols, out, q8Quants, q8Scales);
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query, secondQ8Weights, auxiliaryRows, cols, secondOut, q8Quants, q8Scales);
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query, thirdQ8Weights, auxiliaryRows, cols, thirdOut, q8Quants, q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
+  }
+
+  @Benchmark
+  public void q8_0GroupedQkvProjection(Blackhole blackhole) {
+    int auxiliaryRows = thirdOut.length;
+    VectorUtil.ggufQ8_0Q8_0TripleBatchDotProduct(
+        query,
+        q8Weights,
+        rows,
+        out,
+        secondQ8Weights,
+        auxiliaryRows,
+        secondOut,
+        thirdQ8Weights,
+        auxiliaryRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
   }
 
   @Benchmark

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -57,9 +57,19 @@ final class GgufParallelSupport {
       int rows,
       int cols,
       IntConsumer rowOperation) {
+    forEachRow(firstWeights, secondWeights, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+  }
+
+  static void forEachRow(
+      MemorySegment firstWeights,
+      MemorySegment secondWeights,
+      int rows,
+      int cols,
+      long formatMinElements,
+      IntConsumer rowOperation) {
     boolean shareable =
         firstWeights.isAccessibleBy(ACCESS_PROBE) && secondWeights.isAccessibleBy(ACCESS_PROBE);
-    forEachRow(shareable, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+    forEachRow(shareable, rows, cols, formatMinElements, rowOperation);
   }
 
   static void forEachRow(
@@ -69,11 +79,23 @@ final class GgufParallelSupport {
       int rows,
       int cols,
       IntConsumer rowOperation) {
+    forEachRow(
+        firstWeights, secondWeights, thirdWeights, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+  }
+
+  static void forEachRow(
+      MemorySegment firstWeights,
+      MemorySegment secondWeights,
+      MemorySegment thirdWeights,
+      int rows,
+      int cols,
+      long formatMinElements,
+      IntConsumer rowOperation) {
     boolean shareable =
         firstWeights.isAccessibleBy(ACCESS_PROBE)
             && secondWeights.isAccessibleBy(ACCESS_PROBE)
             && thirdWeights.isAccessibleBy(ACCESS_PROBE);
-    forEachRow(shareable, rows, cols, DEFAULT_MIN_ELEMENTS, rowOperation);
+    forEachRow(shareable, rows, cols, formatMinElements, rowOperation);
   }
 
   private static void forEachRow(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1622,20 +1622,130 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         rows,
         cols,
         GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> out[row] = q8_0Q8_0RowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
+  }
+
+  @Override
+  public void ggufQ8_0Q8_0DualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    ggufQ8_0Q8_0GroupedMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        secondWeight,
+        0,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  @Override
+  public void ggufQ8_0Q8_0TripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    ggufQ8_0Q8_0GroupedMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  private static void ggufQ8_0Q8_0GroupedMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q8_0_BLOCK_BYTES;
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
         row -> {
-          float sum = 0.0f;
-          long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
-            float scale =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
-            int integerSum =
-                q8_0Q8_0IntegerDot(
-                    qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
-            sum = MathUtil.fma(scale, integerSum, sum);
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            qWeight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
           }
-          out[row] = sum;
+          out[matrixRow] =
+              q8_0Q8_0RowDot(qWeight, matrixRow * rowBytes, blocks, q8Quants, q8Scales);
         });
+  }
+
+  private static float q8_0Q8_0RowDot(
+      MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      int integerSum =
+          q8_0Q8_0IntegerDot(
+              qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+      sum = MathUtil.fma(scale, integerSum, sum);
+    }
+    return sum;
   }
 
   private static int q8_0Q8_0IntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -959,6 +959,80 @@ public final class VectorUtil {
     IMPL.ggufQ8_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
   }
 
+  /**
+   * Multiplies two Q8_0 matrices by the same activation with one Q8_0 quantization and one row
+   * dispatch.
+   */
+  public static void ggufQ8_0Q8_0DualBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query, secondWeight, secondRows, cols, secondOut, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ8_0Q8_0DualMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  /**
+   * Multiplies three Q8_0 matrices by the same activation with one Q8_0 quantization and one row
+   * dispatch.
+   */
+  public static void ggufQ8_0Q8_0TripleBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchArguments(
+        query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query, secondWeight, secondRows, cols, secondOut, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query, thirdWeight, thirdRows, cols, thirdOut, VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ8_0Q8_0TripleMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
   /** Batched row-major GEMV over GGUF Q6_K rows. */
   public static void ggufQ6_KBatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1170,25 +1170,111 @@ public interface VectorUtilSupport {
         rows,
         cols,
         GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row ->
+            out[row] =
+                ggufQ8_0Q8_0ScalarRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
+  }
+
+  /** Two Q8_0 projections sharing one Q8_0 activation quantization and row dispatch. */
+  default void ggufQ8_0Q8_0DualMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ8_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    int totalRows = Math.addExact(firstRows, secondRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
         row -> {
-          float sum = 0.0f;
-          long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
-            float scale =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
-            long quantOffset = blockOffset + Short.BYTES;
-            int queryOffset = block * GGUF_Q_BLOCK_SIZE;
-            int integerSum = 0;
-            for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
-              integerSum +=
-                  qWeight.get(ValueLayout.JAVA_BYTE, quantOffset + index)
-                      * q8Quants[queryOffset + index];
-            }
-            sum = MathUtil.fma(scale, integerSum, sum);
-          }
-          out[row] = sum;
+          boolean first = row < firstRows;
+          MemorySegment weight = first ? firstWeight : secondWeight;
+          int matrixRow = first ? row : row - firstRows;
+          float[] out = first ? firstOut : secondOut;
+          out[matrixRow] =
+              ggufQ8_0Q8_0ScalarRowDot(weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales);
         });
+  }
+
+  /** Three Q8_0 projections sharing one Q8_0 activation quantization and row dispatch. */
+  default void ggufQ8_0Q8_0TripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    quantizeQ8_0(query, cols, q8Quants, q8Scales);
+
+    long rowBytes = ggufQ8_0RowBytes(cols);
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> {
+          MemorySegment weight;
+          float[] out;
+          int matrixRow;
+          if (row < secondStart) {
+            weight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+          } else if (row < thirdStart) {
+            weight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+          } else {
+            weight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+          }
+          out[matrixRow] =
+              ggufQ8_0Q8_0ScalarRowDot(weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales);
+        });
+  }
+
+  private static float ggufQ8_0Q8_0ScalarRowDot(
+      MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      long quantOffset = blockOffset + Short.BYTES;
+      int queryOffset = block * GGUF_Q_BLOCK_SIZE;
+      int integerSum = 0;
+      for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
+        integerSum +=
+            qWeight.get(ValueLayout.JAVA_BYTE, quantOffset + index) * q8Quants[queryOffset + index];
+      }
+      sum = MathUtil.fma(scale, integerSum, sum);
+    }
+    return sum;
   }
 
   /**

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -644,6 +644,101 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0DualBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 64;
+    int firstRows = 2;
+    int secondRows = 3;
+    float[] query = patternedQuery(cols);
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(repeat(q8Block(0.125f, i -> i * 7 - 53), firstRows * 2));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(repeat(q8Block(-0.25f, i -> 61 - i * 5), secondRows * 2));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query, firstWeight, firstRows, cols, expectedFirst, new byte[cols], new float[cols / 32]);
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 32]);
+
+    VectorUtil.ggufQ8_0Q8_0DualBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        cols,
+        new byte[cols],
+        new float[cols / 32]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
+  void q8_0Q8_0TripleBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 64;
+    int firstRows = 4;
+    int secondRows = 2;
+    int thirdRows = 3;
+    float[] query = patternedQuery(cols);
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(repeat(q8Block(0.125f, i -> i * 7 - 53), firstRows * 2));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(repeat(q8Block(-0.25f, i -> 61 - i * 5), secondRows * 2));
+    MemorySegment thirdWeight =
+        MemorySegment.ofArray(repeat(q8Block(0.03125f, i -> i * 3 - 41), thirdRows * 2));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] expectedThird = new float[thirdRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+    float[] actualThird = new float[thirdRows];
+
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query, firstWeight, firstRows, cols, expectedFirst, new byte[cols], new float[cols / 32]);
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 32]);
+    VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+        query, thirdWeight, thirdRows, cols, expectedThird, new byte[cols], new float[cols / 32]);
+
+    VectorUtil.ggufQ8_0Q8_0TripleBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        cols,
+        new byte[cols],
+        new float[cols / 32]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void activationQuantizedBatchDotProducts_rejectUndersizedScratch() {
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment q4 = copy(arena, q4Block(1.0f, ones(32), null));


### PR DESCRIPTION
## Summary
- add exact dual and triple Q8_0/Q8_0 grouped matvec operations
- share activation quantization and row dispatch across grouped projections
- add scalar/Panama correctness coverage and grouped/separate JMH cases

## Validation
- ./gradlew :vectors-core:check :vectors-bench:check
- JMH with GC profiling
- consumed by the matching Models Q8 gate/up integration