### PR TITLE
fix(core): stabilize Q4_K SIMD reduction

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -792,8 +792,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         row -> {
           if (VECTOR_BITSIZE >= 256) {
-            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
-            float minimumContribution = 0.0f;
+            float sum = 0.0f;
             long rowOffset = row * rowBytes;
             for (int block = 0; block < blocks; block++) {
               long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
@@ -822,14 +821,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                 minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
               }
 
-              FloatVector products =
-                  (FloatVector)
-                      blockLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-              accumulator =
-                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, d), accumulator);
-              minimumContribution = MathUtil.fma(-dMin, minimumSum, minimumContribution);
+              int quantizedSum = blockLanes.reduceLanes(VectorOperators.ADD);
+              sum = MathUtil.fma(d, quantizedSum, sum);
+              sum = MathUtil.fma(-dMin, minimumSum, sum);
             }
-            out[row] = accumulator.reduceLanes(VectorOperators.ADD) + minimumContribution;
+            out[row] = sum;
             return;
           }
 
@@ -979,8 +975,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
           // Keep the SIMD body in this lambda. Extracting Vector values defeats C2 scalarization.
           if (VECTOR_BITSIZE >= 256) {
-            FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
-            float minimumContribution = 0.0f;
+            float sum = 0.0f;
             long rowOffset = matrixRow * rowBytes;
             for (int block = 0; block < blocks; block++) {
               long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
@@ -1009,14 +1004,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                 minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
               }
 
-              FloatVector products =
-                  (FloatVector)
-                      blockLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-              accumulator =
-                  fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, d), accumulator);
-              minimumContribution = MathUtil.fma(-dMin, minimumSum, minimumContribution);
+              int quantizedSum = blockLanes.reduceLanes(VectorOperators.ADD);
+              sum = MathUtil.fma(d, quantizedSum, sum);
+              sum = MathUtil.fma(-dMin, minimumSum, sum);
             }
-            out[matrixRow] = accumulator.reduceLanes(VectorOperators.ADD) + minimumContribution;
+            out[matrixRow] = sum;
             return;
           }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -340,10 +340,7 @@ class PanamaGgufQuantizedDotTest {
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);
     assertThat(actualSums).containsExactly(expectedSums);
-    assertThat(actual).hasSameSizeAs(expected);
-    for (int row = 0; row < rows; row++) {
-      assertThat(actual[row]).isCloseTo(expected[row], offset(1e-3f));
-    }
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismProbe.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismProbe.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Random;
+
+/** Fresh-JVM probe used by {@link Q4KColdHotDeterminismTest}. */
+final class Q4KColdHotDeterminismProbe {
+
+  private static final int ROWS = 4_096;
+  private static final int COLS = 3_584;
+  private static final int Q4_K_BLOCK_BYTES = 144;
+
+  private Q4KColdHotDeterminismProbe() {}
+
+  public static void main(String[] args) {
+    Random random = new Random(0xD37E_4B48L);
+    float[] query = new float[COLS];
+    for (int index = 0; index < query.length; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[ROWS * (COLS / 256) * Q4_K_BLOCK_BYTES];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += Q4_K_BLOCK_BYTES) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+      buffer.putShort(offset + Short.BYTES, Float.floatToFloat16(random.nextFloat() * 0.05f));
+    }
+
+    PanamaVectorUtilSupport provider = new PanamaVectorUtilSupport();
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    byte[] quants = new byte[COLS];
+    float[] scales = new float[COLS / 256];
+    short[] sums = new short[COLS / 16];
+    float[] first = new float[ROWS];
+    float[] current = new float[ROWS];
+
+    provider.ggufQ4_KQ8_KMatVecDot(query, weightSegment, ROWS, COLS, first, quants, scales, sums);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ4_KQ8_KMatVecDot(
+          query, weightSegment, ROWS, COLS, current, quants, scales, sums);
+    }
+
+    if (!Arrays.equals(first, current)) {
+      for (int row = 0; row < ROWS; row++) {
+        if (Float.floatToRawIntBits(first[row]) != Float.floatToRawIntBits(current[row])) {
+          throw new AssertionError(
+              "Q4_K cold/hot mismatch at row "
+                  + row
+                  + ": first="
+                  + first[row]
+                  + ", hot="
+                  + current[row]);
+        }
+      }
+    }
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class Q4KColdHotDeterminismTest {
+
+  @Test
+  void q4_K256BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    Process process =
+        new ProcessBuilder(
+                javaExecutable(),
+                "--add-modules",
+                "jdk.incubator.vector",
+                "-Dvectors.maxBits=256",
+                "-Dvectors.gguf.parallel=false",
+                "-cp",
+                System.getProperty("java.class.path"),
+                Q4KColdHotDeterminismProbe.class.getName())
+            .redirectErrorStream(true)
+            .start();
+
+    boolean completed = process.waitFor(60, TimeUnit.SECONDS);
+    String output = readOutput(process);
+
+    assertThat(completed).as("probe timed out; output:%n%s", output).isTrue();
+    assertThat(process.exitValue()).as("probe output:%n%s", output).isZero();
+  }
+
+  private static String javaExecutable() {
+    return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+  }
+
+  private static String readOutput(Process process) throws IOException {
+    return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
## Summary
- keep Q4_K/Q8_K integer dot products vectorized while reducing each block before scalar accumulation
- eliminate 256-bit cold-versus-hot JIT drift
- require exact SIMD parity with the scalar Q4_K reference

## Verification
- ./gradlew :vectors-core:check
- fresh-JVM Q4KColdHotDeterminismTest on Intel macOS and AMD EPYC Linux
- HuatuoGPT-o1 7B exact-logit audit across 256-bit parallel/serial, no-FMA, 128-bit, and scalar modes
- AMD JMH Q4_K kernel: 0.150 ms/op before, 0.141 ms/op after