### PR TITLE
bench: cover speculative verification batch sizes

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
@@ -46,7 +46,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1)
 public class GgufBatchedMatmulBenchmark {
 
-  @Param({"1", "8", "32"})
+  @Param({"1", "2", "4", "8", "32"})
   int batchSize;
 
   @Param("1024")


### PR DESCRIPTION
## Summary
- add batch sizes 2 and 4 to the Q4_0 batched-matmul JMH matrix
- cover the verifier break-even region alongside existing 1, 8, and 32-token cases

## Verification
- ./gradlew :vectors-bench:check
- controlled JDK 25 allocation/throughput runs at batches 2, 4, and 8