### PR TITLE
feat(core): add batched Q4_K matmul

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ4KBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ4KBatchedMatmulBenchmark.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares row-local Q4_K batched matmul with independent GEMV calls. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ4KBatchedMatmulBenchmark {
+
+  @Param({"1", "2", "4", "8", "32"})
+  int batchSize;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] queries;
+  private float[][] independentQueries;
+  private MemorySegment weights;
+  private float[] batchedOut;
+  private float[] independentOut;
+  private byte[] batchedQuants;
+  private float[] batchedScales;
+  private short[] batchedSums;
+  private byte[] independentQuants;
+  private float[] independentScales;
+  private short[] independentSums;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(42L);
+    queries = new float[batchSize * cols];
+    independentQueries = new float[batchSize][cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        float value = random.nextFloat() * 2.0f - 1.0f;
+        queries[batch * cols + col] = value;
+        independentQueries[batch][col] = value;
+      }
+    }
+
+    byte[] blocks = new byte[rows * (cols / 256) * 144];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    short minScale = Float.floatToFloat16(0.005f);
+    for (int offset = 0; offset < blocks.length; offset += 144) {
+      buffer.putShort(offset, scale);
+      buffer.putShort(offset + Short.BYTES, minScale);
+    }
+    weights = MemorySegment.ofArray(blocks);
+    batchedOut = new float[batchSize * rows];
+    independentOut = new float[rows];
+    batchedQuants = new byte[batchSize * cols];
+    batchedScales = new float[batchSize * (cols / 256)];
+    batchedSums = new short[batchSize * (cols / 16)];
+    independentQuants = new byte[cols];
+    independentScales = new float[cols / 256];
+    independentSums = new short[cols / 16];
+  }
+
+  @Benchmark
+  public void batched(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQuants,
+        batchedScales,
+        batchedSums);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void independent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+          query,
+          weights,
+          rows,
+          cols,
+          independentOut,
+          independentQuants,
+          independentScales,
+          independentSums);
+      blackhole.consume(independentOut);
+    }
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ4KBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ4KBatchedMatmulBenchmark.java
@@ -80,15 +80,7 @@ public class GgufQ4KBatchedMatmulBenchmark {
       }
     }
 
-    byte[] blocks = new byte[rows * (cols / 256) * 144];
-    random.nextBytes(blocks);
-    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
-    short scale = Float.floatToFloat16(0.01f);
-    short minScale = Float.floatToFloat16(0.005f);
-    for (int offset = 0; offset < blocks.length; offset += 144) {
-      buffer.putShort(offset, scale);
-      buffer.putShort(offset + Short.BYTES, minScale);
-    }
+    byte[] blocks = randomQ4KBlocks(random, rows * (cols / 256) * 144);
     weights = MemorySegment.ofArray(blocks);
     batchedOut = new float[batchSize * rows];
     independentOut = new float[rows];
@@ -98,6 +90,19 @@ public class GgufQ4KBatchedMatmulBenchmark {
     independentQuants = new byte[cols];
     independentScales = new float[cols / 256];
     independentSums = new short[cols / 16];
+  }
+
+  private static byte[] randomQ4KBlocks(Random random, int byteCount) {
+    byte[] blocks = new byte[byteCount];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    short minScale = Float.floatToFloat16(0.005f);
+    for (int offset = 0; offset < blocks.length; offset += 144) {
+      buffer.putShort(offset, scale);
+      buffer.putShort(offset + Short.BYTES, minScale);
+    }
+    return blocks;
   }
 
   @Benchmark

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
@@ -58,6 +58,19 @@ final class GgufQuantizationSupport {
 
   static void quantizeQ8_K(
       float[] query, int dimensions, byte[] quants, float[] scales, short[] sums) {
+    quantizeQ8_K(query, 0, dimensions, quants, 0, scales, 0, sums, 0);
+  }
+
+  static void quantizeQ8_K(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] quants,
+      int quantOffset,
+      float[] scales,
+      int scaleOffset,
+      short[] sums,
+      int sumOffset) {
     int blockSize = VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE;
     int sumBlockSize = VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE;
     int blocks = dimensions / blockSize;
@@ -66,7 +79,7 @@ final class GgufQuantizationSupport {
       float max = 0.0f;
       float absoluteMax = 0.0f;
       for (int index = 0; index < blockSize; index++) {
-        float value = query[offset + index];
+        float value = query[queryOffset + offset + index];
         float absolute = Math.abs(value);
         if (absolute > absoluteMax) {
           absoluteMax = absolute;
@@ -75,29 +88,33 @@ final class GgufQuantizationSupport {
       }
 
       if (absoluteMax == 0.0f) {
-        Arrays.fill(quants, offset, offset + blockSize, (byte) 0);
+        Arrays.fill(quants, quantOffset + offset, quantOffset + offset + blockSize, (byte) 0);
         if (sums != null) {
-          Arrays.fill(sums, offset / sumBlockSize, (offset + blockSize) / sumBlockSize, (short) 0);
+          Arrays.fill(
+              sums,
+              sumOffset + offset / sumBlockSize,
+              sumOffset + (offset + blockSize) / sumBlockSize,
+              (short) 0);
         }
-        scales[block] = 0.0f;
+        scales[scaleOffset + block] = 0.0f;
         continue;
       }
 
       float inverseScale = -127.0f / max;
       int sum = 0;
       for (int index = 0; index < blockSize; index++) {
-        int quant = ggmlNearestInt(inverseScale * query[offset + index]);
+        int quant = ggmlNearestInt(inverseScale * query[queryOffset + offset + index]);
         byte stored = (byte) Math.min(127, quant);
-        quants[offset + index] = stored;
+        quants[quantOffset + offset + index] = stored;
         if (sums != null) {
           sum += stored;
           if ((index + 1) % sumBlockSize == 0) {
-            sums[(offset + index) / sumBlockSize] = (short) sum;
+            sums[sumOffset + (offset + index) / sumBlockSize] = (short) sum;
             sum = 0;
           }
         }
       }
-      scales[block] = 1.0f / inverseScale;
+      scales[scaleOffset + block] = 1.0f / inverseScale;
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -864,6 +864,109 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  /** SIMD Q4_K by a batch of Q8_K activations with row-local weight reuse. */
+  @Override
+  public void ggufQ4_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (batchSize == 1) {
+      ggufQ4_KQ8_KMatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            float weightMinScale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+            int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+
+            for (int batch = 0; batch < batchSize; batch++) {
+              int quantBatchOffset = batch * cols;
+              int scaleBatchOffset = batch * blocks;
+              int sumBatchOffset = batch * sumsPerBatch;
+              float q8Scale = q8Scales[scaleBatchOffset + block];
+              float d = weightScale * q8Scale;
+              float dMin = weightMinScale * q8Scale;
+              int quantizedSum = 0;
+              int minimumSum = 0;
+
+              for (int group = 0; group < 8; group++) {
+                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+                int shift = (group & 1) * 4;
+                int groupActivationOffset = blockActivationOffset + group * 32;
+                int groupDot;
+                if (VECTOR_BITSIZE >= 256) {
+                  IntVector groupLanes =
+                      q4_KQ8_KIntegerLanes(
+                          qWeight,
+                          packedOffset,
+                          shift,
+                          q8Quants,
+                          quantBatchOffset + groupActivationOffset);
+                  groupDot = groupLanes.reduceLanes(VectorOperators.ADD);
+                } else {
+                  groupDot =
+                      q4_KQ8_KIntegerDot(
+                          qWeight,
+                          packedOffset,
+                          shift,
+                          q8Quants,
+                          quantBatchOffset + groupActivationOffset);
+                }
+                quantizedSum += scale * groupDot;
+                int activationSumOffset =
+                    sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+                minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
+              }
+
+              int outputOffset = batch * rows + row;
+              float sum = out[outputOffset];
+              sum = MathUtil.fma(d, quantizedSum, sum);
+              sum = MathUtil.fma(-dMin, minimumSum, sum);
+              out[outputOffset] = sum;
+            }
+          }
+        });
+  }
+
   @Override
   public void ggufQ4_KQ8_KDualMatVecDot(
       float[] query,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -649,6 +649,79 @@ public final class VectorUtil {
     IMPL.ggufQ4_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
   }
 
+  /**
+   * Multiplies one Q4_K matrix by a batch-major collection of activation vectors.
+   *
+   * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code
+   * [batchSize][rows]}. Each activation row is quantized independently to Q8_K in caller-owned
+   * scratch before the matrix rows are evaluated.
+   *
+   * @param q8Quants scratch space with at least {@code batchSize * cols} entries
+   * @param q8Scales scratch space with at least {@code batchSize * (cols / 256)} entries
+   * @param q8Sums scratch space with at least {@code batchSize * (cols / 16)} entries
+   */
+  public static void ggufQ4_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    Objects.requireNonNull(q8Sums, "q8Sums");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int scaleEntries =
+        checkedProduct(
+            batchSize, cols / VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE, "batch Q8_K scales");
+    int sumEntries =
+        checkedProduct(
+            batchSize, cols / VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE, "batch Q8_K sums");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    if (q8Quants.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= batchSize * cols: " + q8Quants.length + " < " + queryEntries);
+    }
+    if (q8Scales.length < scaleEntries) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= batch Q8_K scales: "
+              + q8Scales.length
+              + " < "
+              + scaleEntries);
+    }
+    if (q8Sums.length < sumEntries) {
+      throw new IllegalArgumentException(
+          "q8Sums.length must be >= batch Q8_K sums: " + q8Sums.length + " < " + sumEntries);
+    }
+    IMPL.ggufQ4_KQ8_KBatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
+  }
+
   /** Multiplies two Q4_K matrices by one shared Q8_K activation quantization and row dispatch. */
   public static void ggufQ4_KQ8_KDualBatchDotProduct(
       float[] query,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -707,6 +707,54 @@ public interface VectorUtilSupport {
                     qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8Sums));
   }
 
+  /** Q4_K matrix multiplication over batch-major Q8_K-quantized activation rows. */
+  default void ggufQ4_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+
+    long rowBytes = ggufQ4_KRowBytes(cols);
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] =
+                ggufQ4_KQ8_KScalarRowDot(
+                    qWeight,
+                    row * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks,
+                    q8Sums,
+                    batch * sumsPerBatch);
+          }
+        });
+  }
+
   /** Two Q4_K projections sharing one Q8_K activation quantization and row dispatch. */
   default void ggufQ4_KQ8_KDualMatVecDot(
       float[] query,
@@ -800,16 +848,30 @@ public interface VectorUtilSupport {
       byte[] q8Quants,
       float[] q8Scales,
       short[] q8Sums) {
+    return ggufQ4_KQ8_KScalarRowDot(
+        qWeight, rowOffset, blocks, q8Quants, 0, q8Scales, 0, q8Sums, 0);
+  }
+
+  private static float ggufQ4_KQ8_KScalarRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      int quantBatchOffset,
+      float[] q8Scales,
+      int scaleBatchOffset,
+      short[] q8Sums,
+      int sumBatchOffset) {
     float sum = 0.0f;
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-      float q8Scale = q8Scales[block];
+      float q8Scale = q8Scales[scaleBatchOffset + block];
       float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
       float dMin =
           Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
       long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
       long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-      int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+      int activationOffset = quantBatchOffset + block * GGUF_Q4_K_BLOCK_SIZE;
       int quantizedSum = 0;
       int minimumSum = 0;
 
@@ -826,7 +888,8 @@ public interface VectorUtilSupport {
           groupDot += quant * q8Quants[groupActivationOffset + index];
         }
         quantizedSum += scale * groupDot;
-        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int sumOffset =
+            sumBatchOffset + (groupActivationOffset - quantBatchOffset) / GGUF_Q8_K_SUM_BLOCK_SIZE;
         minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
       }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -935,6 +935,127 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KQ8_KBatchedMatmulMatchesIndependentQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] =
+            (float) Math.sin((batch + 1.0) * (col + 0.25)) * (batch + 0.5f);
+      }
+    }
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstBlock = q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins);
+    byte[] secondBlock = q4KBlock(-0.25f, 0.03125f, i -> 15 - i % 16, scales, mins);
+    MemorySegment weights =
+        MemorySegment.ofArray(
+            concat(concat(firstBlock, secondBlock), concat(secondBlock, firstBlock)));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+          query,
+          weights,
+          rows,
+          cols,
+          result,
+          new byte[cols],
+          new float[cols / 256],
+          new short[cols / 16]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q4_KQ8_KBatchedMatmulMatchesGemvAtProjectionScaleAfterWarmup() {
+    int batchSize = 4;
+    int rows = 512;
+    int cols = 2_048;
+    int blocks = cols / 256;
+    Random random = new Random(0xB47C_4B48L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 8.0f - 4.0f;
+    }
+    byte[] matrix = new byte[rows * blocks * 144];
+    random.nextBytes(matrix);
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += 144) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.001f + random.nextFloat() * 0.1f));
+      matrixBuffer.putShort(offset + Short.BYTES, Float.floatToFloat16(random.nextFloat() * 0.05f));
+    }
+
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] gemvOut = new float[rows];
+    byte[] gemvQuants = new byte[cols];
+    float[] gemvScales = new float[blocks];
+    short[] gemvSums = new short[cols / 16];
+    byte[] batchQuants = new byte[batchSize * cols];
+    float[] batchScales = new float[batchSize * blocks];
+    short[] batchSums = new short[batchSize * (cols / 16)];
+
+    for (int iteration = 0; iteration < 12; iteration++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales, gemvSums);
+        System.arraycopy(gemvOut, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+          queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales, batchSums);
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
+  void q4_KQ8_KBatchedMatmulRejectsUndersizedSumScratch() {
+    int batchSize = 2;
+    int cols = 256;
+    int[] unitScales = {1, 1, 1, 1, 1, 1, 1, 1};
+    MemorySegment weights =
+        MemorySegment.ofArray(q4KBlock(1.0f, 0.0f, ignored -> 1, unitScales, new int[8]));
+
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+                    new float[batchSize * cols],
+                    weights,
+                    batchSize,
+                    1,
+                    cols,
+                    new float[batchSize],
+                    new byte[batchSize * cols],
+                    new float[batchSize],
+                    new short[batchSize * (cols / 16) - 1]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("q8Sums");
+  }
+
+  @Test
   void q4_KQ8_KDualBatchDotProductMatchesSeparateMatmulsExactly() {
     int cols = 256;
     int firstRows = 3;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -194,6 +194,13 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ4_KQ8_KBatchedKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ4_KQ8_KBatchedMatmul");
+  }
+
+  @Test
   void panamaProviderOwnsQ5_KQ8_KKernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismProbe.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismProbe.java
@@ -26,6 +26,7 @@ final class Q4KColdHotDeterminismProbe {
 
   private static final int ROWS = 4_096;
   private static final int COLS = 3_584;
+  private static final int BATCH_SIZE = 4;
   private static final int Q4_K_BLOCK_BYTES = 144;
 
   private Q4KColdHotDeterminismProbe() {}
@@ -59,17 +60,59 @@ final class Q4KColdHotDeterminismProbe {
           query, weightSegment, ROWS, COLS, current, quants, scales, sums);
     }
 
-    if (!Arrays.equals(first, current)) {
-      for (int row = 0; row < ROWS; row++) {
-        if (Float.floatToRawIntBits(first[row]) != Float.floatToRawIntBits(current[row])) {
-          throw new AssertionError(
-              "Q4_K cold/hot mismatch at row "
-                  + row
-                  + ": first="
-                  + first[row]
-                  + ", hot="
-                  + current[row]);
-        }
+    assertBitIdentical("Q4_K GEMV", first, current);
+
+    float[] queries = new float[BATCH_SIZE * COLS];
+    for (int batch = 0; batch < BATCH_SIZE; batch++) {
+      for (int col = 0; col < COLS; col++) {
+        queries[batch * COLS + col] = random.nextFloat() * (batch + 1.0f) - batch * 0.5f;
+      }
+    }
+    byte[] batchQuants = new byte[BATCH_SIZE * COLS];
+    float[] batchScales = new float[BATCH_SIZE * (COLS / 256)];
+    short[] batchSums = new short[BATCH_SIZE * (COLS / 16)];
+    float[] firstBatch = new float[BATCH_SIZE * ROWS];
+    float[] currentBatch = new float[BATCH_SIZE * ROWS];
+
+    provider.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        weightSegment,
+        BATCH_SIZE,
+        ROWS,
+        COLS,
+        firstBatch,
+        batchQuants,
+        batchScales,
+        batchSums);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ4_KQ8_KBatchedMatmul(
+          queries,
+          weightSegment,
+          BATCH_SIZE,
+          ROWS,
+          COLS,
+          currentBatch,
+          batchQuants,
+          batchScales,
+          batchSums);
+    }
+    assertBitIdentical("Q4_K batched matmul", firstBatch, currentBatch);
+  }
+
+  private static void assertBitIdentical(String operation, float[] first, float[] current) {
+    if (Arrays.equals(first, current)) {
+      return;
+    }
+    for (int index = 0; index < first.length; index++) {
+      if (Float.floatToRawIntBits(first[index]) != Float.floatToRawIntBits(current[index])) {
+        throw new AssertionError(
+            operation
+                + " cold/hot mismatch at index "
+                + index
+                + ": first="
+                + first[index]
+                + ", hot="
+                + current[index]);
       }
     }
   }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q4KColdHotDeterminismTest.java
@@ -29,12 +29,21 @@ class Q4KColdHotDeterminismTest {
 
   @Test
   void q4_K256BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(256);
+  }
+
+  @Test
+  void q4_K128BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(128);
+  }
+
+  private static void runProbe(int maxBits) throws Exception {
     Process process =
         new ProcessBuilder(
                 javaExecutable(),
                 "--add-modules",
                 "jdk.incubator.vector",
-                "-Dvectors.maxBits=256",
+                "-Dvectors.maxBits=" + maxBits,
                 "-Dvectors.gguf.parallel=false",
                 "-cp",
                 System.getProperty("java.class.path"),

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -129,6 +129,60 @@ class ScalarVectorUtilSupportTest {
     assertThat(out).containsExactly(-2f, 8.5f);
   }
 
+  @Test
+  void q4_KBatchedMatmulMatchesIndependentScalarQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] =
+            (float) Math.sin((batch + 1.0) * (col + 0.5)) * (batch + 0.25f);
+      }
+    }
+    byte[] matrix = new byte[rows * (cols / 256) * 144];
+    for (int index = 0; index < matrix.length; index++) {
+      matrix[index] = (byte) (index * 31 + 7);
+    }
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += 144) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.01f));
+      matrixBuffer.putShort(offset + Short.BYTES, Float.floatToFloat16(0.005f));
+    }
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      scalar.ggufQ4_KQ8_KMatVecDot(
+          query,
+          weights,
+          rows,
+          cols,
+          result,
+          new byte[cols],
+          new float[cols / 256],
+          new short[cols / 16]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    scalar.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
   private static float referenceDot(float[] a, int ao, float[] b, int bo, int length) {
     float result = 0f;
     for (int i = 0; i < length; i++) result = Math.fma(a[ao + i], b[bo + i], result);


### PR DESCRIPTION
## Summary

- add a generic batch-major Q4_K/Q8_K matrix multiplication API with caller-owned activation scratch
- implement scalar, 128-bit, and 256-bit Panama paths while preserving the existing per-block reduction order
- add fresh-JVM cold/hot determinism, scalar fallback, projection-scale parity, validation, and JMH coverage

## Performance

On the 2019 Intel Mac with JDK 25.0.3, AVX2, 1024x2048 matrices, three warmups, five measurements, and `-prof gc`:

| Batch | Batched | Independent | Change |
| ---: | ---: | ---: | ---: |
| 2 | 0.698 ms | 0.778 ms | 10.3% faster |
| 4 | 1.233 ms | 1.451 ms | 15.0% faster |
| 8 | 2.378 ms | 3.124 ms | 23.9% faster |

No measured case triggered a collection. Batched allocation remained 640-848 B/op.

## Validation

- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`
- exact batched-versus-independent GEMV output at small and 512x2048 warm projection sizes
- fresh-JVM cold/hot equality with `vectors.maxBits=128` and `256`
- direct scalar-provider equality
