### PR TITLE
feat(core): add batched Q6_K matmul

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ6KBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ6KBatchedMatmulBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares row-local Q6_K batched matmul with independent GEMV calls. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ6KBatchedMatmulBenchmark {
+
+  @Param({"1", "2", "4", "8", "32"})
+  int batchSize;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] queries;
+  private float[][] independentQueries;
+  private MemorySegment weights;
+  private float[] batchedOut;
+  private float[] independentOut;
+  private byte[] batchedQuants;
+  private float[] batchedScales;
+  private byte[] independentQuants;
+  private float[] independentScales;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(46L);
+    queries = new float[batchSize * cols];
+    independentQueries = new float[batchSize][cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        float value = random.nextFloat() * 2.0f - 1.0f;
+        queries[batch * cols + col] = value;
+        independentQueries[batch][col] = value;
+      }
+    }
+
+    byte[] blocks = randomQ6KBlocks(random, rows * (cols / 256) * 210);
+    weights = MemorySegment.ofArray(blocks);
+    batchedOut = new float[batchSize * rows];
+    independentOut = new float[rows];
+    batchedQuants = new byte[batchSize * cols];
+    batchedScales = new float[batchSize * (cols / 256)];
+    independentQuants = new byte[cols];
+    independentScales = new float[cols / 256];
+  }
+
+  private static byte[] randomQ6KBlocks(Random random, int byteCount) {
+    byte[] blocks = new byte[byteCount];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    for (int offset = 0; offset < blocks.length; offset += 210) {
+      buffer.putShort(offset + 208, scale);
+    }
+    return blocks;
+  }
+
+  @Benchmark
+  public void batched(Blackhole blackhole) {
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries, weights, batchSize, rows, cols, batchedOut, batchedQuants, batchedScales);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void independent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+          query, weights, rows, cols, independentOut, independentQuants, independentScales);
+      blackhole.consume(independentOut);
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1646,6 +1646,95 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  /** SIMD Q6_K by a batch of Q8_K activations with row-local weight reuse. */
+  @Override
+  public void ggufQ6_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize == 1) {
+      ggufQ6_KQ8_KMatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ6_KQ8_KBatchedMatmul(
+          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks, null, 0);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q6_K_BLOCK_BYTES;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+            float weightScale =
+                Float.float16ToFloat(
+                    qWeight.get(
+                        GGUF_LE_SHORT,
+                        blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES));
+            long qlOffset = blockOffset;
+            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+            int blockActivationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+
+            for (int batch = 0; batch < batchSize; batch++) {
+              int quantBatchOffset = batch * cols;
+              int scaleBatchOffset = batch * blocks;
+              int blockSum = 0;
+
+              for (int superBlock = 0; superBlock < 2; superBlock++) {
+                long qlBase = qlOffset + (long) superBlock * 64;
+                long qhBase = qhOffset + (long) superBlock * 32;
+                long scaleBase = scaleOffset + (long) superBlock * 8;
+                int quantBase = quantBatchOffset + blockActivationOffset + superBlock * 128;
+                for (int chunk = 0; chunk < 32; chunk += 16) {
+                  int scaleIndex = chunk / 16;
+                  int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+                  int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+                  int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+                  int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+                  blockSum +=
+                      q6_KQ8_KIntegerDot(
+                          qWeight,
+                          qlBase + chunk,
+                          qlBase + 32L + chunk,
+                          qhBase + chunk,
+                          q8Quants,
+                          quantBase + chunk,
+                          s1,
+                          s2,
+                          s3,
+                          s4);
+                }
+              }
+
+              int outputOffset = batch * rows + row;
+              float d = weightScale * q8Scales[scaleBatchOffset + block];
+              out[outputOffset] = MathUtil.fma(d, blockSum, out[outputOffset]);
+            }
+          }
+        });
+  }
+
   static int q6_KQ8_KIntegerDot(
       MemorySegment qWeight,
       long ql1Offset,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1151,6 +1151,69 @@ public final class VectorUtil {
   }
 
   /**
+   * Multiplies one Q6_K matrix by a batch-major collection of activation vectors.
+   *
+   * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code
+   * [batchSize][rows]}. Each activation row is quantized independently to Q8_K in caller-owned
+   * scratch before the matrix rows are evaluated.
+   *
+   * @param q8Quants scratch space with at least {@code batchSize * cols} entries
+   * @param q8Scales scratch space with at least {@code batchSize * (cols / 256)} entries
+   */
+  public static void ggufQ6_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_BYTES);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int scaleEntries =
+        checkedProduct(
+            batchSize, cols / VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE, "batch Q8_K scales");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    if (q8Quants.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= batchSize * cols: " + q8Quants.length + " < " + queryEntries);
+    }
+    if (q8Scales.length < scaleEntries) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= batch Q8_K scales: "
+              + q8Scales.length
+              + " < "
+              + scaleEntries);
+    }
+    IMPL.ggufQ6_KQ8_KBatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+  }
+
+  /**
    * Fills {@code out[i]} with the squared L2 distance from {@code query} to {@code matrix[i]} for
    * all rows {@code i} in {@code [0, matrix.length)}. {@code out.length} must be &ge; {@code
    * matrix.length}.

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1141,69 +1141,113 @@ public interface VectorUtilSupport {
         qWeight,
         rows,
         cols,
+        row ->
+            out[row] =
+                ggufQ6_KQ8_KScalarRowDot(
+                    qWeight, row * rowBytes, blocks, q8Quants, 0, q8Scales, 0));
+  }
+
+  /** Q6_K matrix multiplication over batch-major Q8_K-quantized activation rows. */
+  default void ggufQ6_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks, null, 0);
+    }
+
+    long rowBytes = ggufQ6_KRowBytes(cols);
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
         row -> {
-          GgufQuantizationSupport.Q6Scratch scratch = GgufQuantizationSupport.q6Scratch();
-          int[] integerSums = scratch.integerSums;
-          float[] laneSums = scratch.laneSums;
-          java.util.Arrays.fill(laneSums, 0.0f);
-          long rowOffset = row * rowBytes;
-
-          for (int block = 0; block < blocks; block++) {
-            java.util.Arrays.fill(integerSums, 0);
-            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
-            float d =
-                Float.float16ToFloat(
-                        qWeight.get(
-                            GGUF_LE_SHORT,
-                            blockOffset
-                                + GGUF_Q6_K_QL_BYTES
-                                + GGUF_Q6_K_QH_BYTES
-                                + GGUF_Q6_K_SCALES))
-                    * q8Scales[block];
-            long qlOffset = blockOffset;
-            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
-            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
-            int queryOffset = block * GGUF_Q6_K_BLOCK_SIZE;
-
-            for (int superBlock = 0; superBlock < 2; superBlock++) {
-              long qlBase = qlOffset + (long) superBlock * 64;
-              long qhBase = qhOffset + (long) superBlock * 32;
-              long scaleBase = scaleOffset + (long) superBlock * 8;
-              int quantBase = queryOffset + superBlock * 128;
-
-              for (int index = 0; index < 32; index++) {
-                int scaleIndex = index / 16;
-                int ql1 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + index) & 0xFF;
-                int ql2 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + 32L + index) & 0xFF;
-                int qh = qWeight.get(ValueLayout.JAVA_BYTE, qhBase + index) & 0xFF;
-                int q1 = ((ql1 & 0x0F) | ((qh & 0x03) << 4)) - 32;
-                int q2 = ((ql2 & 0x0F) | (((qh >>> 2) & 0x03) << 4)) - 32;
-                int q3 = ((ql1 >>> 4) | (((qh >>> 4) & 0x03) << 4)) - 32;
-                int q4 = ((ql2 >>> 4) | (((qh >>> 6) & 0x03) << 4)) - 32;
-                int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
-                int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
-                int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
-                int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
-                int lane = index & 7;
-
-                integerSums[lane] += s1 * q1 * q8Quants[quantBase + index];
-                integerSums[lane] += s2 * q2 * q8Quants[quantBase + index + 32];
-                integerSums[lane] += s3 * q3 * q8Quants[quantBase + index + 64];
-                integerSums[lane] += s4 * q4 * q8Quants[quantBase + index + 96];
-              }
-            }
-
-            for (int lane = 0; lane < laneSums.length; lane++) {
-              laneSums[lane] = MathUtil.fma(d, integerSums[lane], laneSums[lane]);
-            }
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] =
+                ggufQ6_KQ8_KScalarRowDot(
+                    qWeight,
+                    row * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks);
           }
-
-          float sum = 0.0f;
-          for (float laneSum : laneSums) {
-            sum += laneSum;
-          }
-          out[row] = sum;
         });
+  }
+
+  private static float ggufQ6_KQ8_KScalarRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      int quantBatchOffset,
+      float[] q8Scales,
+      int scaleBatchOffset) {
+    GgufQuantizationSupport.Q6Scratch scratch = GgufQuantizationSupport.q6Scratch();
+    int[] integerSums = scratch.integerSums;
+    float[] laneSums = scratch.laneSums;
+    java.util.Arrays.fill(laneSums, 0.0f);
+
+    for (int block = 0; block < blocks; block++) {
+      java.util.Arrays.fill(integerSums, 0);
+      long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float d =
+          Float.float16ToFloat(
+                  qWeight.get(
+                      GGUF_LE_SHORT,
+                      blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES))
+              * q8Scales[scaleBatchOffset + block];
+      long qlOffset = blockOffset;
+      long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+      long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+      int queryOffset = quantBatchOffset + block * GGUF_Q6_K_BLOCK_SIZE;
+
+      for (int superBlock = 0; superBlock < 2; superBlock++) {
+        long qlBase = qlOffset + (long) superBlock * 64;
+        long qhBase = qhOffset + (long) superBlock * 32;
+        long scaleBase = scaleOffset + (long) superBlock * 8;
+        int quantBase = queryOffset + superBlock * 128;
+
+        for (int index = 0; index < 32; index++) {
+          int scaleIndex = index / 16;
+          int ql1 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + index) & 0xFF;
+          int ql2 = qWeight.get(ValueLayout.JAVA_BYTE, qlBase + 32L + index) & 0xFF;
+          int qh = qWeight.get(ValueLayout.JAVA_BYTE, qhBase + index) & 0xFF;
+          int q1 = ((ql1 & 0x0F) | ((qh & 0x03) << 4)) - 32;
+          int q2 = ((ql2 & 0x0F) | (((qh >>> 2) & 0x03) << 4)) - 32;
+          int q3 = ((ql1 >>> 4) | (((qh >>> 4) & 0x03) << 4)) - 32;
+          int q4 = ((ql2 >>> 4) | (((qh >>> 6) & 0x03) << 4)) - 32;
+          int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+          int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+          int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+          int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+          int lane = index & 7;
+
+          integerSums[lane] += s1 * q1 * q8Quants[quantBase + index];
+          integerSums[lane] += s2 * q2 * q8Quants[quantBase + index + 32];
+          integerSums[lane] += s3 * q3 * q8Quants[quantBase + index + 64];
+          integerSums[lane] += s4 * q4 * q8Quants[quantBase + index + 96];
+        }
+      }
+
+      for (int lane = 0; lane < laneSums.length; lane++) {
+        laneSums[lane] = MathUtil.fma(d, integerSums[lane], laneSums[lane]);
+      }
+    }
+
+    float sum = 0.0f;
+    for (float laneSum : laneSums) {
+      sum += laneSum;
+    }
+    return sum;
   }
 
   /** Batched row-major GEMV over GGUF Q8_0 rows. */

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -881,6 +881,112 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q6_KQ8_KBatchedMatmulMatchesIndependentQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] =
+            (float) Math.cos((batch + 0.75) * (col + 0.5)) * (batch + 0.25f);
+      }
+    }
+    byte[] firstBlock = q6KBlock(0.125f, index -> (index * 5 + 3) % 64 - 32, index -> index - 8);
+    byte[] secondBlock = q6KBlock(-0.25f, index -> 31 - (index % 64), index -> 7 - index);
+    MemorySegment weights =
+        MemorySegment.ofArray(
+            concat(concat(firstBlock, secondBlock), concat(secondBlock, firstBlock)));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+          query, weights, rows, cols, result, new byte[cols], new float[cols / 256]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q6_KQ8_KBatchedMatmulMatchesGemvAtProjectionScaleAfterWarmup() {
+    int batchSize = 4;
+    int rows = 512;
+    int cols = 2_048;
+    int blocks = cols / 256;
+    int blockBytes = 210;
+    Random random = new Random(0xB47C_6B48L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 8.0f - 4.0f;
+    }
+    byte[] matrix = new byte[rows * blocks * blockBytes];
+    random.nextBytes(matrix);
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      matrixBuffer.putShort(offset + 208, Float.floatToFloat16(0.001f + random.nextFloat() * 0.1f));
+    }
+
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] gemvOut = new float[rows];
+    byte[] gemvQuants = new byte[cols];
+    float[] gemvScales = new float[blocks];
+    byte[] batchQuants = new byte[batchSize * cols];
+    float[] batchScales = new float[batchSize * blocks];
+
+    for (int iteration = 0; iteration < 12; iteration++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales);
+        System.arraycopy(gemvOut, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+          queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales);
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
+  void q6_KQ8_KBatchedMatmulRejectsUndersizedScaleScratch() {
+    int batchSize = 2;
+    int cols = 256;
+    MemorySegment weights = MemorySegment.ofArray(q6KBlock(1.0f, ignored -> 1, ignored -> 1));
+
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+                    new float[batchSize * cols],
+                    weights,
+                    batchSize,
+                    1,
+                    cols,
+                    new float[batchSize],
+                    new byte[batchSize * cols],
+                    new float[batchSize - 1]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("q8Scales");
+  }
+
+  @Test
   void q4_KQ8_KBatchDotProduct_quantizesTheQueryOnceUsingGgmlSemantics() {
     float[] query = new float[256];
     query[0] = 1.0f;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -215,6 +215,13 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ6_KQ8_KBatchedKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ6_KQ8_KBatchedMatmul");
+  }
+
+  @Test
   void panamaProviderOwnsQ5_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q6KColdHotDeterminismProbe.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q6KColdHotDeterminismProbe.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Random;
+
+/** Fresh-JVM probe used by {@link Q6KColdHotDeterminismTest}. */
+final class Q6KColdHotDeterminismProbe {
+
+  private static final int ROWS = 4_096;
+  private static final int COLS = 3_584;
+  private static final int BATCH_SIZE = 4;
+  private static final int Q6_K_BLOCK_BYTES = 210;
+
+  private Q6KColdHotDeterminismProbe() {}
+
+  public static void main(String[] args) {
+    Random random = new Random(0xD37E_6B48L);
+    float[] query = new float[COLS];
+    for (int index = 0; index < query.length; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[ROWS * (COLS / 256) * Q6_K_BLOCK_BYTES];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += Q6_K_BLOCK_BYTES) {
+      buffer.putShort(offset + 208, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    PanamaVectorUtilSupport provider = new PanamaVectorUtilSupport();
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    byte[] quants = new byte[COLS];
+    float[] scales = new float[COLS / 256];
+    float[] first = new float[ROWS];
+    float[] current = new float[ROWS];
+
+    provider.ggufQ6_KQ8_KMatVecDot(query, weightSegment, ROWS, COLS, first, quants, scales);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ6_KQ8_KMatVecDot(query, weightSegment, ROWS, COLS, current, quants, scales);
+    }
+    assertBitIdentical("Q6_K GEMV", first, current);
+
+    float[] queries = new float[BATCH_SIZE * COLS];
+    for (int batch = 0; batch < BATCH_SIZE; batch++) {
+      for (int col = 0; col < COLS; col++) {
+        queries[batch * COLS + col] = random.nextFloat() * (batch + 1.0f) - batch * 0.5f;
+      }
+    }
+    byte[] batchQuants = new byte[BATCH_SIZE * COLS];
+    float[] batchScales = new float[BATCH_SIZE * (COLS / 256)];
+    float[] firstBatch = new float[BATCH_SIZE * ROWS];
+    float[] currentBatch = new float[BATCH_SIZE * ROWS];
+
+    provider.ggufQ6_KQ8_KBatchedMatmul(
+        queries, weightSegment, BATCH_SIZE, ROWS, COLS, firstBatch, batchQuants, batchScales);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ6_KQ8_KBatchedMatmul(
+          queries, weightSegment, BATCH_SIZE, ROWS, COLS, currentBatch, batchQuants, batchScales);
+    }
+    assertBitIdentical("Q6_K batched matmul", firstBatch, currentBatch);
+  }
+
+  private static void assertBitIdentical(String operation, float[] first, float[] current) {
+    if (Arrays.equals(first, current)) {
+      return;
+    }
+    for (int index = 0; index < first.length; index++) {
+      if (Float.floatToRawIntBits(first[index]) != Float.floatToRawIntBits(current[index])) {
+        throw new AssertionError(
+            operation
+                + " cold/hot mismatch at index "
+                + index
+                + ": first="
+                + first[index]
+                + ", hot="
+                + current[index]);
+      }
+    }
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q6KColdHotDeterminismTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q6KColdHotDeterminismTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class Q6KColdHotDeterminismTest {
+
+  @Test
+  void q6_K256BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(256);
+  }
+
+  @Test
+  void q6_K128BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(128);
+  }
+
+  private static void runProbe(int maxBits) throws Exception {
+    Process process =
+        new ProcessBuilder(
+                javaExecutable(),
+                "--add-modules",
+                "jdk.incubator.vector",
+                "-Dvectors.maxBits=" + maxBits,
+                "-Dvectors.gguf.parallel=false",
+                "-cp",
+                System.getProperty("java.class.path"),
+                Q6KColdHotDeterminismProbe.class.getName())
+            .redirectErrorStream(true)
+            .start();
+
+    boolean completed = process.waitFor(60, TimeUnit.SECONDS);
+    String output = readOutput(process);
+
+    assertThat(completed).as("probe timed out; output:%n%s", output).isTrue();
+    assertThat(process.exitValue()).as("probe output:%n%s", output).isZero();
+  }
+
+  private static String javaExecutable() {
+    return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+  }
+
+  private static String readOutput(Process process) throws IOException {
+    return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -183,6 +183,49 @@ class ScalarVectorUtilSupportTest {
     assertThat(actual).containsExactly(expected);
   }
 
+  @Test
+  void q6_KBatchedMatmulMatchesIndependentScalarQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    int blockBytes = 210;
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = (float) Math.cos((index + 0.5) * 0.03125);
+    }
+    byte[] matrix = new byte[rows * (cols / 256) * blockBytes];
+    for (int index = 0; index < matrix.length; index++) {
+      matrix[index] = (byte) (index * 17 + 5);
+    }
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      matrixBuffer.putShort(offset + 208, Float.floatToFloat16(0.01f));
+    }
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      scalar.ggufQ6_KQ8_KMatVecDot(
+          query, weights, rows, cols, result, new byte[cols], new float[cols / 256]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    scalar.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
   private static float referenceDot(float[] a, int ao, float[] b, int bo, int length) {
     float result = 0f;
     for (int i = 0; i < length; i++) result = Math.fma(a[ao + i], b[bo + i], result);


### PR DESCRIPTION
## Summary
- add caller-scratch Q6_K x batched Q8_K matmul to the format-level vectors API
- retain dedicated scalar and Panama implementations with exact GEMV reduction order
- add projection-scale, fresh-JVM determinism, provider ownership, validation, and JMH coverage

## Verification
- ./gradlew :vectors-core:check
- ./gradlew :vectors-bench:jmh -Pjmh.includes=GgufQ6KBatchedMatmulBenchmark
- Java 25 JMH GC profile at batches 4, 8, and 32

## Local JMH evidence
At 1024x2048, batched vs independent GEMV: 1.845 vs 1.920 ms (batch 4), 3.511 vs 3.876 ms (batch 8), and 13.271 vs 18.985 ms (batch 32). Normalized allocation was 672 vs 1375 B/op, 876 vs 3211 B/op, and 1189 vs 15164 B/op respectively.