### PR TITLE
feat(core): add batched Q5_K matmul

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ5KBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ5KBatchedMatmulBenchmark.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares row-local Q5_K batched matmul with independent GEMV calls. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ5KBatchedMatmulBenchmark {
+
+  @Param({"1", "2", "4", "8", "32"})
+  int batchSize;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] queries;
+  private float[][] independentQueries;
+  private MemorySegment weights;
+  private float[] batchedOut;
+  private float[] independentOut;
+  private byte[] batchedQuants;
+  private float[] batchedScales;
+  private short[] batchedSums;
+  private byte[] independentQuants;
+  private float[] independentScales;
+  private short[] independentSums;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(44L);
+    queries = new float[batchSize * cols];
+    independentQueries = new float[batchSize][cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        float value = random.nextFloat() * 2.0f - 1.0f;
+        queries[batch * cols + col] = value;
+        independentQueries[batch][col] = value;
+      }
+    }
+
+    byte[] blocks = randomQ5KBlocks(random, rows * (cols / 256) * 176);
+    weights = MemorySegment.ofArray(blocks);
+    batchedOut = new float[batchSize * rows];
+    independentOut = new float[rows];
+    batchedQuants = new byte[batchSize * cols];
+    batchedScales = new float[batchSize * (cols / 256)];
+    batchedSums = new short[batchSize * (cols / 16)];
+    independentQuants = new byte[cols];
+    independentScales = new float[cols / 256];
+    independentSums = new short[cols / 16];
+  }
+
+  private static byte[] randomQ5KBlocks(Random random, int byteCount) {
+    byte[] blocks = new byte[byteCount];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    short minScale = Float.floatToFloat16(0.005f);
+    for (int offset = 0; offset < blocks.length; offset += 176) {
+      buffer.putShort(offset, scale);
+      buffer.putShort(offset + Short.BYTES, minScale);
+    }
+    return blocks;
+  }
+
+  @Benchmark
+  public void batched(Blackhole blackhole) {
+    VectorUtil.ggufQ5_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQuants,
+        batchedScales,
+        batchedSums);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void independent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+          query,
+          weights,
+          rows,
+          cols,
+          independentOut,
+          independentQuants,
+          independentScales,
+          independentSums);
+      blackhole.consume(independentOut);
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1255,6 +1255,106 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             out[row] = q5_KQ8_KRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8Sums));
   }
 
+  /** SIMD Q5_K by a batch of Q8_K activations with row-local weight reuse. */
+  @Override
+  public void ggufQ5_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (batchSize == 1) {
+      ggufQ5_KQ8_KMatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
+      return;
+    }
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ5_KQ8_KBatchedMatmul(
+          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q5_K_BLOCK_BYTES;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            float weightMinScale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+            long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+            long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+            int blockActivationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+
+            for (int batch = 0; batch < batchSize; batch++) {
+              int quantBatchOffset = batch * cols;
+              int scaleBatchOffset = batch * blocks;
+              int sumBatchOffset = batch * sumsPerBatch;
+              float q8Scale = q8Scales[scaleBatchOffset + block];
+              float d = weightScale * q8Scale;
+              float dMin = weightMinScale * q8Scale;
+              int quantizedSum = 0;
+              int minimumSum = 0;
+
+              for (int group = 0; group < 8; group++) {
+                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+                int shift = (group & 1) * 4;
+                int highBit = 1 << group;
+                int groupActivationOffset = blockActivationOffset + group * 32;
+                int groupDot =
+                    q5_KQ8_KIntegerDot(
+                        qWeight,
+                        packedOffset,
+                        shift,
+                        highBitsOffset,
+                        highBit,
+                        q8Quants,
+                        quantBatchOffset + groupActivationOffset);
+                quantizedSum += scale * groupDot;
+                int activationSumOffset =
+                    sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+                minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
+              }
+
+              int outputOffset = batch * rows + row;
+              float sum = out[outputOffset];
+              sum = MathUtil.fma(d, quantizedSum, sum);
+              sum = MathUtil.fma(-dMin, minimumSum, sum);
+              out[outputOffset] = sum;
+            }
+          }
+        });
+  }
+
   @Override
   public void ggufQ5_KQ8_KDualMatVecDot(
       float[] query,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -869,6 +869,79 @@ public final class VectorUtil {
     IMPL.ggufQ5_KQ8_KMatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales, q8Sums);
   }
 
+  /**
+   * Multiplies one Q5_K matrix by a batch-major collection of activation vectors.
+   *
+   * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code
+   * [batchSize][rows]}. Each activation row is quantized independently to Q8_K in caller-owned
+   * scratch before the matrix rows are evaluated.
+   *
+   * @param q8Quants scratch space with at least {@code batchSize * cols} entries
+   * @param q8Scales scratch space with at least {@code batchSize * (cols / 256)} entries
+   * @param q8Sums scratch space with at least {@code batchSize * (cols / 16)} entries
+   */
+  public static void ggufQ5_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    Objects.requireNonNull(q8Sums, "q8Sums");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_K_BLOCK_BYTES);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int scaleEntries =
+        checkedProduct(
+            batchSize, cols / VectorUtilSupport.GGUF_Q5_K_BLOCK_SIZE, "batch Q8_K scales");
+    int sumEntries =
+        checkedProduct(
+            batchSize, cols / VectorUtilSupport.GGUF_Q8_K_SUM_BLOCK_SIZE, "batch Q8_K sums");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    if (q8Quants.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= batchSize * cols: " + q8Quants.length + " < " + queryEntries);
+    }
+    if (q8Scales.length < scaleEntries) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= batch Q8_K scales: "
+              + q8Scales.length
+              + " < "
+              + scaleEntries);
+    }
+    if (q8Sums.length < sumEntries) {
+      throw new IllegalArgumentException(
+          "q8Sums.length must be >= batch Q8_K sums: " + q8Sums.length + " < " + sumEntries);
+    }
+    IMPL.ggufQ5_KQ8_KBatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
+  }
+
   /** Multiplies two Q5_K matrices by one shared Q8_K activation quantization and row dispatch. */
   public static void ggufQ5_KQ8_KDualBatchDotProduct(
       float[] query,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -929,7 +929,55 @@ public interface VectorUtilSupport {
         row ->
             out[row] =
                 ggufQ5_KQ8_KScalarRowDot(
-                    qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8Sums));
+                    qWeight, row * rowBytes, blocks, q8Quants, 0, q8Scales, 0, q8Sums, 0));
+  }
+
+  /** Q5_K matrix multiplication over batch-major Q8_K-quantized activation rows. */
+  default void ggufQ5_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+
+    long rowBytes = ggufQ5_KRowBytes(cols);
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] =
+                ggufQ5_KQ8_KScalarRowDot(
+                    qWeight,
+                    row * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks,
+                    q8Sums,
+                    batch * sumsPerBatch);
+          }
+        });
   }
 
   /** Two Q5_K projections sharing one Q8_K activation quantization and row dispatch. */
@@ -962,7 +1010,7 @@ public interface VectorUtilSupport {
           float[] out = first ? firstOut : secondOut;
           out[matrixRow] =
               ggufQ5_KQ8_KScalarRowDot(
-                  weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+                  weight, matrixRow * rowBytes, blocks, q8Quants, 0, q8Scales, 0, q8Sums, 0);
         });
   }
 
@@ -1014,7 +1062,7 @@ public interface VectorUtilSupport {
           }
           out[matrixRow] =
               ggufQ5_KQ8_KScalarRowDot(
-                  weight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+                  weight, matrixRow * rowBytes, blocks, q8Quants, 0, q8Scales, 0, q8Sums, 0);
         });
   }
 
@@ -1023,12 +1071,15 @@ public interface VectorUtilSupport {
       long rowOffset,
       int blocks,
       byte[] q8Quants,
+      int quantBatchOffset,
       float[] q8Scales,
-      short[] q8Sums) {
+      int scaleBatchOffset,
+      short[] q8Sums,
+      int sumBatchOffset) {
     float sum = 0.0f;
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
-      float q8Scale = q8Scales[block];
+      float q8Scale = q8Scales[scaleBatchOffset + block];
       float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
       float dMin =
           Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
@@ -1052,10 +1103,10 @@ public interface VectorUtilSupport {
           int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
           int highBits = qWeight.get(ValueLayout.JAVA_BYTE, highBitsOffset + index) & 0xFF;
           int quant = ((packed >>> shift) & 0x0F) | ((highBits & highBit) == 0 ? 0 : 16);
-          groupDot += quant * q8Quants[groupActivationOffset + index];
+          groupDot += quant * q8Quants[quantBatchOffset + groupActivationOffset + index];
         }
         quantizedSum += scale * groupDot;
-        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int sumOffset = sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
         minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
       }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1420,6 +1420,128 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_KQ8_KBatchedMatmulMatchesIndependentQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] =
+            (float) Math.sin((batch + 0.5) * (col + 0.75)) * (batch + 0.625f);
+      }
+    }
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstBlock = q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) % 32, scales, mins);
+    byte[] secondBlock = q5KBlock(-0.25f, 0.03125f, i -> 31 - i % 32, scales, mins);
+    MemorySegment weights =
+        MemorySegment.ofArray(
+            concat(concat(firstBlock, secondBlock), concat(secondBlock, firstBlock)));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+          query,
+          weights,
+          rows,
+          cols,
+          result,
+          new byte[cols],
+          new float[cols / 256],
+          new short[cols / 16]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    VectorUtil.ggufQ5_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q5_KQ8_KBatchedMatmulMatchesGemvAtProjectionScaleAfterWarmup() {
+    int batchSize = 4;
+    int rows = 512;
+    int cols = 2_048;
+    int blocks = cols / 256;
+    int blockBytes = 176;
+    Random random = new Random(0xB47C_5B48L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 8.0f - 4.0f;
+    }
+    byte[] matrix = new byte[rows * blocks * blockBytes];
+    random.nextBytes(matrix);
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.001f + random.nextFloat() * 0.1f));
+      matrixBuffer.putShort(offset + Short.BYTES, Float.floatToFloat16(random.nextFloat() * 0.05f));
+    }
+
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] gemvOut = new float[rows];
+    byte[] gemvQuants = new byte[cols];
+    float[] gemvScales = new float[blocks];
+    short[] gemvSums = new short[cols / 16];
+    byte[] batchQuants = new byte[batchSize * cols];
+    float[] batchScales = new float[batchSize * blocks];
+    short[] batchSums = new short[batchSize * (cols / 16)];
+
+    for (int iteration = 0; iteration < 12; iteration++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales, gemvSums);
+        System.arraycopy(gemvOut, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ5_KQ8_KBatchedMatmul(
+          queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales, batchSums);
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
+  void q5_KQ8_KBatchedMatmulRejectsUndersizedSumScratch() {
+    int batchSize = 2;
+    int cols = 256;
+    int[] unitScales = {1, 1, 1, 1, 1, 1, 1, 1};
+    MemorySegment weights =
+        MemorySegment.ofArray(q5KBlock(1.0f, 0.0f, ignored -> 1, unitScales, new int[8]));
+
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ5_KQ8_KBatchedMatmul(
+                    new float[batchSize * cols],
+                    weights,
+                    batchSize,
+                    1,
+                    cols,
+                    new float[batchSize],
+                    new byte[batchSize * cols],
+                    new float[batchSize],
+                    new short[batchSize * (cols / 16) - 1]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("q8Sums");
+  }
+
+  @Test
   void q5_KBatchDotProduct_respectsRowOffsets() {
     float[] query = patternedQuery(256);
     int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -208,6 +208,13 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ5_KQ8_KBatchedKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ5_KQ8_KBatchedMatmul");
+  }
+
+  @Test
   void panamaProviderOwnsQ6_KQ8_KKernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q5KColdHotDeterminismProbe.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q5KColdHotDeterminismProbe.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Random;
+
+/** Fresh-JVM probe used by {@link Q5KColdHotDeterminismTest}. */
+final class Q5KColdHotDeterminismProbe {
+
+  private static final int ROWS = 4_096;
+  private static final int COLS = 3_584;
+  private static final int BATCH_SIZE = 4;
+  private static final int Q5_K_BLOCK_BYTES = 176;
+
+  private Q5KColdHotDeterminismProbe() {}
+
+  public static void main(String[] args) {
+    Random random = new Random(0xD37E_5B48L);
+    float[] query = new float[COLS];
+    for (int index = 0; index < query.length; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[ROWS * (COLS / 256) * Q5_K_BLOCK_BYTES];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += Q5_K_BLOCK_BYTES) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+      buffer.putShort(offset + Short.BYTES, Float.floatToFloat16(random.nextFloat() * 0.025f));
+    }
+
+    PanamaVectorUtilSupport provider = new PanamaVectorUtilSupport();
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    byte[] quants = new byte[COLS];
+    float[] scales = new float[COLS / 256];
+    short[] sums = new short[COLS / 16];
+    float[] first = new float[ROWS];
+    float[] current = new float[ROWS];
+
+    provider.ggufQ5_KQ8_KMatVecDot(query, weightSegment, ROWS, COLS, first, quants, scales, sums);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ5_KQ8_KMatVecDot(
+          query, weightSegment, ROWS, COLS, current, quants, scales, sums);
+    }
+    assertBitIdentical("Q5_K GEMV", first, current);
+
+    float[] queries = new float[BATCH_SIZE * COLS];
+    for (int batch = 0; batch < BATCH_SIZE; batch++) {
+      for (int col = 0; col < COLS; col++) {
+        queries[batch * COLS + col] = random.nextFloat() * (batch + 1.0f) - batch * 0.5f;
+      }
+    }
+    byte[] batchQuants = new byte[BATCH_SIZE * COLS];
+    float[] batchScales = new float[BATCH_SIZE * (COLS / 256)];
+    short[] batchSums = new short[BATCH_SIZE * (COLS / 16)];
+    float[] firstBatch = new float[BATCH_SIZE * ROWS];
+    float[] currentBatch = new float[BATCH_SIZE * ROWS];
+
+    provider.ggufQ5_KQ8_KBatchedMatmul(
+        queries,
+        weightSegment,
+        BATCH_SIZE,
+        ROWS,
+        COLS,
+        firstBatch,
+        batchQuants,
+        batchScales,
+        batchSums);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ5_KQ8_KBatchedMatmul(
+          queries,
+          weightSegment,
+          BATCH_SIZE,
+          ROWS,
+          COLS,
+          currentBatch,
+          batchQuants,
+          batchScales,
+          batchSums);
+    }
+    assertBitIdentical("Q5_K batched matmul", firstBatch, currentBatch);
+  }
+
+  private static void assertBitIdentical(String operation, float[] first, float[] current) {
+    if (Arrays.equals(first, current)) {
+      return;
+    }
+    for (int index = 0; index < first.length; index++) {
+      if (Float.floatToRawIntBits(first[index]) != Float.floatToRawIntBits(current[index])) {
+        throw new AssertionError(
+            operation
+                + " cold/hot mismatch at index "
+                + index
+                + ": first="
+                + first[index]
+                + ", hot="
+                + current[index]);
+      }
+    }
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q5KColdHotDeterminismTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q5KColdHotDeterminismTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class Q5KColdHotDeterminismTest {
+
+  @Test
+  void q5_K256BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(256);
+  }
+
+  @Test
+  void q5_K128BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(128);
+  }
+
+  private static void runProbe(int maxBits) throws Exception {
+    Process process =
+        new ProcessBuilder(
+                javaExecutable(),
+                "--add-modules",
+                "jdk.incubator.vector",
+                "-Dvectors.maxBits=" + maxBits,
+                "-Dvectors.gguf.parallel=false",
+                "-cp",
+                System.getProperty("java.class.path"),
+                Q5KColdHotDeterminismProbe.class.getName())
+            .redirectErrorStream(true)
+            .start();
+
+    boolean completed = process.waitFor(60, TimeUnit.SECONDS);
+    String output = readOutput(process);
+
+    assertThat(completed).as("probe timed out; output:%n%s", output).isTrue();
+    assertThat(process.exitValue()).as("probe output:%n%s", output).isZero();
+  }
+
+  private static String javaExecutable() {
+    return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+  }
+
+  private static String readOutput(Process process) throws IOException {
+    return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -184,6 +184,58 @@ class ScalarVectorUtilSupportTest {
   }
 
   @Test
+  void q5_KBatchedMatmulMatchesIndependentScalarQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    int blockBytes = 176;
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = (float) Math.sin((index + 0.25) * 0.046875);
+    }
+    byte[] matrix = new byte[rows * (cols / 256) * blockBytes];
+    for (int index = 0; index < matrix.length; index++) {
+      matrix[index] = (byte) (index * 29 + 11);
+    }
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.01f));
+      matrixBuffer.putShort(offset + Short.BYTES, Float.floatToFloat16(0.005f));
+    }
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      scalar.ggufQ5_KQ8_KMatVecDot(
+          query,
+          weights,
+          rows,
+          cols,
+          result,
+          new byte[cols],
+          new float[cols / 256],
+          new short[cols / 16]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    scalar.ggufQ5_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
   void q6_KBatchedMatmulMatchesIndependentScalarQueriesExactly() {
     int batchSize = 3;
     int rows = 2;


### PR DESCRIPTION
## Summary
- add validated public Q5_K/Q8_K batched matmul with scalar fallback and a dedicated Panama kernel
- quantize each activation once and traverse each packed matrix row once while preserving exact block reduction order
- add projection-scale, provider, validation, fresh-JVM cold/hot determinism, and JMH coverage

## Verification
- `./gradlew check` (345 tasks, successful)
- exact independent-GEMV parity at 128- and 256-bit vector caps
- JMH allocation profile: about 465 B/op and no measured collections
- 11008x4096, batch 32: 1360.275 ms batched vs 1413.754 ms independent (3.78% faster) on the Intel AVX2 development host