### PR TITLE
perf(core): add batched Q8_0 matmul

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares row-local Q8_0 batched matmul with independent GEMV calls. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ8BatchedMatmulBenchmark {
+
+  @Param({"1", "2", "4", "8", "32"})
+  int batchSize;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] queries;
+  private float[][] independentQueries;
+  private MemorySegment weights;
+  private float[] batchedOut;
+  private float[] independentOut;
+  private byte[] batchedQuants;
+  private float[] batchedScales;
+  private byte[] independentQuants;
+  private float[] independentScales;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(48L);
+    queries = new float[batchSize * cols];
+    independentQueries = new float[batchSize][cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        float value = random.nextFloat() * 2.0f - 1.0f;
+        queries[batch * cols + col] = value;
+        independentQueries[batch][col] = value;
+      }
+    }
+
+    byte[] blocks = randomQ8Blocks(random, rows * (cols / 32) * 34);
+    weights = MemorySegment.ofArray(blocks);
+    batchedOut = new float[batchSize * rows];
+    independentOut = new float[rows];
+    batchedQuants = new byte[batchSize * cols];
+    batchedScales = new float[batchSize * (cols / 32)];
+    independentQuants = new byte[cols];
+    independentScales = new float[cols / 32];
+  }
+
+  private static byte[] randomQ8Blocks(Random random, int byteCount) {
+    byte[] blocks = new byte[byteCount];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    for (int offset = 0; offset < blocks.length; offset += 34) {
+      buffer.putShort(offset, scale);
+    }
+    return blocks;
+  }
+
+  @Benchmark
+  public void batched(Blackhole blackhole) {
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries, weights, batchSize, rows, cols, batchedOut, batchedQuants, batchedScales);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void independent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+          query, weights, rows, cols, independentOut, independentQuants, independentScales);
+      blackhole.consume(independentOut);
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1909,6 +1909,58 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         row -> out[row] = q8_0Q8_0RowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
   }
 
+  /** SIMD Q8_0 by a batch of Q8_0 activations with row-local weight reuse. */
+  @Override
+  public void ggufQ8_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize == 1) {
+      ggufQ8_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q8_0_BLOCK_BYTES;
+    int effectiveCols = Math.multiplyExact(cols, batchSize);
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        effectiveCols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            long weightOffset = blockOffset + Short.BYTES;
+            int blockActivationOffset = block * GGUF_Q_BLOCK_SIZE;
+            for (int batch = 0; batch < batchSize; batch++) {
+              float scale = weightScale * q8Scales[batch * blocks + block];
+              int integerSum =
+                  q8_0Q8_0IntegerDot(
+                      qWeight, weightOffset, q8Quants, batch * cols + blockActivationOffset);
+              int outputIndex = batch * rows + row;
+              out[outputIndex] = MathUtil.fma(scale, integerSum, out[outputIndex]);
+            }
+          }
+        });
+  }
+
   @Override
   public void ggufQ8_0Q8_0DualMatVecDot(
       float[] query,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1106,6 +1106,68 @@ public final class VectorUtil {
   }
 
   /**
+   * Multiplies one Q8_0 matrix by a batch-major collection of activation vectors.
+   *
+   * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code
+   * [batchSize][rows]}. Each activation row is quantized independently to Q8_0 in caller-owned
+   * scratch before the matrix rows are evaluated.
+   *
+   * @param q8Quants scratch space with at least {@code batchSize * cols} entries
+   * @param q8Scales scratch space with at least {@code batchSize * (cols / 32)} entries
+   */
+  public static void ggufQ8_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int scaleEntries =
+        checkedProduct(batchSize, cols / VectorUtilSupport.GGUF_Q_BLOCK_SIZE, "batch Q8_0 scales");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    if (q8Quants.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= batchSize * cols: " + q8Quants.length + " < " + queryEntries);
+    }
+    if (q8Scales.length < scaleEntries) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= batch Q8_0 scales: "
+              + q8Scales.length
+              + " < "
+              + scaleEntries);
+    }
+    IMPL.ggufQ8_0Q8_0BatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+  }
+
+  /**
    * Multiplies two Q8_0 matrices by the same activation with one Q8_0 quantization and one row
    * dispatch.
    */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1333,6 +1333,40 @@ public interface VectorUtilSupport {
                 ggufQ8_0Q8_0ScalarRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
   }
 
+  /** Q8_0 matrix multiplication over batch-major Q8_0-quantized activation rows. */
+  default void ggufQ8_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = ggufQ8_0RowBytes(cols);
+    for (int batch = 0; batch < batchSize; batch++) {
+      int quantBatchOffset = batch * cols;
+      int scaleBatchOffset = batch * blocks;
+      for (int row = 0; row < rows; row++) {
+        out[batch * rows + row] =
+            ggufQ8_0Q8_0ScalarRowDot(
+                qWeight,
+                row * rowBytes,
+                blocks,
+                q8Quants,
+                quantBatchOffset,
+                q8Scales,
+                scaleBatchOffset);
+      }
+    }
+  }
+
   /** Two Q8_0 projections sharing one Q8_0 activation quantization and row dispatch. */
   default void ggufQ8_0Q8_0DualMatVecDot(
       float[] query,
@@ -1419,12 +1453,25 @@ public interface VectorUtilSupport {
 
   private static float ggufQ8_0Q8_0ScalarRowDot(
       MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    return ggufQ8_0Q8_0ScalarRowDot(qWeight, rowOffset, blocks, q8Quants, 0, q8Scales, 0);
+  }
+
+  private static float ggufQ8_0Q8_0ScalarRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      int quantBaseOffset,
+      float[] q8Scales,
+      int scaleBaseOffset) {
     float sum = 0.0f;
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
-      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      float scale =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset))
+              * q8Scales[scaleBaseOffset + block];
       long quantOffset = blockOffset + Short.BYTES;
-      int queryOffset = block * GGUF_Q_BLOCK_SIZE;
+      int queryOffset = quantBaseOffset + block * GGUF_Q_BLOCK_SIZE;
       int integerSum = 0;
       for (int index = 0; index < GGUF_Q_BLOCK_SIZE; index++) {
         integerSum +=

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -739,6 +739,112 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0BatchedMatmulMatchesIndependentQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 64;
+    float[] queries = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        queries[batch * cols + col] =
+            (float) Math.sin((batch + 0.375) * (col + 0.625)) * (batch + 0.75f);
+      }
+    }
+    byte[] firstBlock = q8Block(0.125f, index -> index * 7 - 53);
+    byte[] secondBlock = q8Block(-0.25f, index -> 61 - index * 5);
+    MemorySegment weights =
+        MemorySegment.ofArray(
+            concat(concat(firstBlock, secondBlock), concat(secondBlock, firstBlock)));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+          query, weights, rows, cols, result, new byte[cols], new float[cols / 32]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q8_0Q8_0BatchedMatmulMatchesGemvAtProjectionScaleAfterWarmup() {
+    int batchSize = 4;
+    int rows = 512;
+    int cols = 2_048;
+    int blocks = cols / 32;
+    int blockBytes = 34;
+    Random random = new Random(0xB47C_8B48L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 8.0f - 4.0f;
+    }
+    byte[] matrix = new byte[rows * blocks * blockBytes];
+    random.nextBytes(matrix);
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.001f + random.nextFloat() * 0.1f));
+    }
+
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] gemvOut = new float[rows];
+    byte[] gemvQuants = new byte[cols];
+    float[] gemvScales = new float[blocks];
+    byte[] batchQuants = new byte[batchSize * cols];
+    float[] batchScales = new float[batchSize * blocks];
+
+    for (int iteration = 0; iteration < 12; iteration++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        System.arraycopy(queries, batch * cols, query, 0, cols);
+        VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
+            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales);
+        System.arraycopy(gemvOut, 0, expected, batch * rows, rows);
+      }
+
+      VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+          queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales);
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  @Test
+  void q8_0Q8_0BatchedMatmulRejectsUndersizedScaleScratch() {
+    int batchSize = 2;
+    int cols = 32;
+    MemorySegment weights = MemorySegment.ofArray(q8Block(1.0f));
+
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+                    new float[batchSize * cols],
+                    weights,
+                    batchSize,
+                    1,
+                    cols,
+                    new float[batchSize],
+                    new byte[batchSize * cols],
+                    new float[batchSize - 1]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("q8Scales");
+  }
+
+  @Test
   void activationQuantizedBatchDotProducts_rejectUndersizedScratch() {
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment q4 = copy(arena, q4Block(1.0f, ones(32), null));

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -187,6 +187,13 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ8_0Q8_0BatchedKernel() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ8_0Q8_0BatchedMatmul");
+  }
+
+  @Test
   void panamaProviderOwnsQ4_KQ8_KKernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q8ColdHotDeterminismProbe.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q8ColdHotDeterminismProbe.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Random;
+
+/** Fresh-JVM probe used by {@link Q8ColdHotDeterminismTest}. */
+final class Q8ColdHotDeterminismProbe {
+
+  private static final int ROWS = 4_096;
+  private static final int COLS = 3_584;
+  private static final int BATCH_SIZE = 4;
+  private static final int Q8_0_BLOCK_BYTES = 34;
+
+  private Q8ColdHotDeterminismProbe() {}
+
+  public static void main(String[] args) {
+    Random random = new Random(0xD37E_8B48L);
+    float[] query = new float[COLS];
+    for (int index = 0; index < query.length; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[ROWS * (COLS / 32) * Q8_0_BLOCK_BYTES];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += Q8_0_BLOCK_BYTES) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    PanamaVectorUtilSupport provider = new PanamaVectorUtilSupport();
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    byte[] quants = new byte[COLS];
+    float[] scales = new float[COLS / 32];
+    float[] first = new float[ROWS];
+    float[] current = new float[ROWS];
+
+    provider.ggufQ8_0Q8_0MatVecDot(query, weightSegment, ROWS, COLS, first, quants, scales);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ8_0Q8_0MatVecDot(query, weightSegment, ROWS, COLS, current, quants, scales);
+    }
+    assertBitIdentical("Q8_0 GEMV", first, current);
+
+    float[] queries = new float[BATCH_SIZE * COLS];
+    for (int batch = 0; batch < BATCH_SIZE; batch++) {
+      for (int col = 0; col < COLS; col++) {
+        queries[batch * COLS + col] = random.nextFloat() * (batch + 1.0f) - batch * 0.5f;
+      }
+    }
+    byte[] batchQuants = new byte[BATCH_SIZE * COLS];
+    float[] batchScales = new float[BATCH_SIZE * (COLS / 32)];
+    float[] firstBatch = new float[BATCH_SIZE * ROWS];
+    float[] currentBatch = new float[BATCH_SIZE * ROWS];
+
+    provider.ggufQ8_0Q8_0BatchedMatmul(
+        queries, weightSegment, BATCH_SIZE, ROWS, COLS, firstBatch, batchQuants, batchScales);
+    for (int iteration = 0; iteration < 8; iteration++) {
+      provider.ggufQ8_0Q8_0BatchedMatmul(
+          queries, weightSegment, BATCH_SIZE, ROWS, COLS, currentBatch, batchQuants, batchScales);
+    }
+    assertBitIdentical("Q8_0 batched matmul", firstBatch, currentBatch);
+  }
+
+  private static void assertBitIdentical(String operation, float[] first, float[] current) {
+    if (Arrays.equals(first, current)) {
+      return;
+    }
+    for (int index = 0; index < first.length; index++) {
+      if (Float.floatToRawIntBits(first[index]) != Float.floatToRawIntBits(current[index])) {
+        throw new AssertionError(
+            operation
+                + " cold/hot mismatch at index "
+                + index
+                + ": first="
+                + first[index]
+                + ", hot="
+                + current[index]);
+      }
+    }
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/Q8ColdHotDeterminismTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/Q8ColdHotDeterminismTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class Q8ColdHotDeterminismTest {
+
+  @Test
+  void q8_0256BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(256);
+  }
+
+  @Test
+  void q8_0128BitKernelIsBitIdenticalBeforeAndAfterCompilation() throws Exception {
+    runProbe(128);
+  }
+
+  private static void runProbe(int maxBits) throws Exception {
+    Process process =
+        new ProcessBuilder(
+                javaExecutable(),
+                "--add-modules",
+                "jdk.incubator.vector",
+                "-Dvectors.maxBits=" + maxBits,
+                "-Dvectors.gguf.parallel=false",
+                "-cp",
+                System.getProperty("java.class.path"),
+                Q8ColdHotDeterminismProbe.class.getName())
+            .redirectErrorStream(true)
+            .start();
+
+    boolean completed = process.waitFor(60, TimeUnit.SECONDS);
+    String output = readOutput(process);
+
+    assertThat(completed).as("probe timed out; output:%n%s", output).isTrue();
+    assertThat(process.exitValue()).as("probe output:%n%s", output).isZero();
+  }
+
+  private static String javaExecutable() {
+    return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+  }
+
+  private static String readOutput(Process process) throws IOException {
+    return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+  }
+}

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -278,6 +278,48 @@ class ScalarVectorUtilSupportTest {
     assertThat(actual).containsExactly(expected);
   }
 
+  @Test
+  void q8_0BatchedMatmulMatchesIndependentScalarQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 64;
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = (float) Math.sin((index + 0.375) * 0.078125);
+    }
+    byte[] matrix = new byte[rows * (cols / 32) * 34];
+    for (int index = 0; index < matrix.length; index++) {
+      matrix[index] = (byte) (index * 23 + 9);
+    }
+    ByteBuffer matrixBuffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += 34) {
+      matrixBuffer.putShort(offset, Float.floatToFloat16(0.01f));
+    }
+    MemorySegment weights = MemorySegment.ofArray(matrix);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+    float[] result = new float[rows];
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      scalar.ggufQ8_0Q8_0MatVecDot(
+          query, weights, rows, cols, result, new byte[cols], new float[cols / 32]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    scalar.ggufQ8_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
   private static float referenceDot(float[] a, int ao, float[] b, int bo, int length) {
     float result = 0f;
     for (int i = 0; i < length; i++) result = Math.fma(a[ao + i], b[bo + i], result);


### PR DESCRIPTION
## What changed

- add a validated public Q8_0/Q8_0 multi-activation matmul API
- add exact scalar and Panama implementations with caller-owned activation scratch
- reuse row-local weights and account for aggregate batch work in bounded row parallelism
- add scalar, SIMD ownership, projection-scale, scratch, and fresh-JVM determinism coverage
- add a Q8_0 batched-versus-independent JMH benchmark

## Why

Q8_0 models could use quantized GEMV and grouped decode projections, but prompt prefill still evaluated each activation independently. This prevented all-Q8 models such as SmolLM2 from using the batched transformer path.

## Validation

- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`
- exact independent-GEMV parity at small and 512x2048 projection geometries
- cold/hot bit determinism at 128-bit and 256-bit vector caps
- local JDK 25 JMH at 1024x2048: 70.1% to 73.1% lower latency for batches 2 through 32
- batch-32 GC profile: about 1.16 KB/op and no collections
