### PR TITLE
perf(core): eliminate K-quant vector allocation

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -791,44 +791,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         rows,
         cols,
         row -> {
-          if (VECTOR_BITSIZE >= 256) {
-            float sum = 0.0f;
-            long rowOffset = row * rowBytes;
-            for (int block = 0; block < blocks; block++) {
-              long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-              float q8Scale = q8Scales[block];
-              float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-              float dMin =
-                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
-                      * q8Scale;
-              long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-              long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-              int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-              IntVector blockLanes = IntVector.zero(IntVector.SPECIES_256);
-              int minimumSum = 0;
-
-              for (int group = 0; group < 8; group++) {
-                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-                int shift = (group & 1) * 4;
-                int groupActivationOffset = activationOffset + group * 32;
-                IntVector groupLanes =
-                    q4_KQ8_KIntegerLanes(
-                        qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
-                blockLanes = blockLanes.add(groupLanes.mul(scale));
-                int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-                minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-              }
-
-              int quantizedSum = blockLanes.reduceLanes(VectorOperators.ADD);
-              sum = MathUtil.fma(d, quantizedSum, sum);
-              sum = MathUtil.fma(-dMin, minimumSum, sum);
-            }
-            out[row] = sum;
-            return;
-          }
-
           float sum = 0.0f;
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
@@ -932,25 +894,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                 long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
                 int shift = (group & 1) * 4;
                 int groupActivationOffset = blockActivationOffset + group * 32;
-                int groupDot;
-                if (VECTOR_BITSIZE >= 256) {
-                  IntVector groupLanes =
-                      q4_KQ8_KIntegerLanes(
-                          qWeight,
-                          packedOffset,
-                          shift,
-                          q8Quants,
-                          quantBatchOffset + groupActivationOffset);
-                  groupDot = groupLanes.reduceLanes(VectorOperators.ADD);
-                } else {
-                  groupDot =
-                      q4_KQ8_KIntegerDot(
-                          qWeight,
-                          packedOffset,
-                          shift,
-                          q8Quants,
-                          quantBatchOffset + groupActivationOffset);
-                }
+                int groupDot =
+                    q4_KQ8_KIntegerDot(
+                        qWeight,
+                        packedOffset,
+                        shift,
+                        q8Quants,
+                        quantBatchOffset + groupActivationOffset);
                 quantizedSum += scale * groupDot;
                 int activationSumOffset =
                     sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
@@ -1076,45 +1026,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             matrixRow = row - thirdStart;
           }
 
-          // Keep the SIMD body in this lambda. Extracting Vector values defeats C2 scalarization.
-          if (VECTOR_BITSIZE >= 256) {
-            float sum = 0.0f;
-            long rowOffset = matrixRow * rowBytes;
-            for (int block = 0; block < blocks; block++) {
-              long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-              float q8Scale = q8Scales[block];
-              float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-              float dMin =
-                  Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
-                      * q8Scale;
-              long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-              long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-              int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-              IntVector blockLanes = IntVector.zero(IntVector.SPECIES_256);
-              int minimumSum = 0;
-
-              for (int group = 0; group < 8; group++) {
-                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-                int shift = (group & 1) * 4;
-                int groupActivationOffset = activationOffset + group * 32;
-                IntVector groupLanes =
-                    q4_KQ8_KIntegerLanes(
-                        qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
-                blockLanes = blockLanes.add(groupLanes.mul(scale));
-                int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-                minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-              }
-
-              int quantizedSum = blockLanes.reduceLanes(VectorOperators.ADD);
-              sum = MathUtil.fma(d, quantizedSum, sum);
-              sum = MathUtil.fma(-dMin, minimumSum, sum);
-            }
-            out[matrixRow] = sum;
-            return;
-          }
-
           float sum = 0.0f;
           long rowOffset = matrixRow * rowBytes;
           for (int block = 0; block < blocks; block++) {
@@ -1150,15 +1061,24 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
-  private static int q4_KQ8_KIntegerDot(
+  static int q4_KQ8_KIntegerDot(
       MemorySegment qWeight, long packedOffset, int shift, byte[] q8Quants, int quantOffset) {
+    return switch (shift) {
+      case 0 -> q4_KQ8_KLowIntegerDot(qWeight, packedOffset, q8Quants, quantOffset);
+      case 4 -> q4_KQ8_KHighIntegerDot(qWeight, packedOffset, q8Quants, quantOffset);
+      default -> throw new IllegalArgumentException("Q4_K shift must be 0 or 4: " + shift);
+    };
+  }
+
+  private static int q4_KQ8_KLowIntegerDot(
+      MemorySegment qWeight, long packedOffset, byte[] q8Quants, int quantOffset) {
     if (VECTOR_BITSIZE >= 256) {
       int sum = 0;
       for (int index = 0; index < 32; index += 16) {
         ByteVector packed =
             ByteVector.fromMemorySegment(
                 ByteVector.SPECIES_128, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
-        ByteVector q4 = packed.lanewise(VectorOperators.LSHR, shift).and((byte) 0x0F);
+        ByteVector q4 = packed.and((byte) 0x0F);
         ShortVector q4Shorts =
             (ShortVector) q4.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
         ShortVector q8Shorts =
@@ -1176,7 +1096,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         ByteVector packed =
             ByteVector.fromMemorySegment(
                 ByteVector.SPECIES_64, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
-        ByteVector q4 = packed.lanewise(VectorOperators.LSHR, shift).and((byte) 0x0F);
+        ByteVector q4 = packed.and((byte) 0x0F);
         ShortVector q4Shorts =
             (ShortVector) q4.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
         ShortVector q8Shorts =
@@ -1191,40 +1111,55 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int sum = 0;
     for (int index = 0; index < 32; index++) {
       int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
-      sum += ((packed >>> shift) & 0x0F) * q8Quants[quantOffset + index];
+      sum += (packed & 0x0F) * q8Quants[quantOffset + index];
     }
     return sum;
   }
 
-  static IntVector q4_KQ8_KIntegerLanes(
-      MemorySegment qWeight, long packedOffset, int shift, byte[] q8Quants, int quantOffset) {
-    ByteVector firstPacked =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, packedOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector secondPacked =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, packedOffset + 16, ByteOrder.LITTLE_ENDIAN);
-    ShortVector firstProducts =
-        ((ShortVector)
-                firstPacked
-                    .lanewise(VectorOperators.LSHR, shift)
-                    .and((byte) 0x0F)
-                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
-            .mul(
-                (ShortVector)
-                    ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
-                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
-    ShortVector secondProducts =
-        ((ShortVector)
-                secondPacked
-                    .lanewise(VectorOperators.LSHR, shift)
-                    .and((byte) 0x0F)
-                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
-            .mul(
-                (ShortVector)
-                    ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
-                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
-    return fourProductLanes(firstProducts, secondProducts);
+  private static int q4_KQ8_KHighIntegerDot(
+      MemorySegment qWeight, long packedOffset, byte[] q8Quants, int quantOffset) {
+    if (VECTOR_BITSIZE >= 256) {
+      int sum = 0;
+      for (int index = 0; index < 32; index += 16) {
+        ByteVector packed =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_128, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector q4 = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+        ShortVector q4Shorts =
+            (ShortVector) q4.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+        ShortVector q8Shorts =
+            (ShortVector)
+                ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + index)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+        sum += q4Shorts.mul(q8Shorts).reduceLanes(VectorOperators.ADD);
+      }
+      return sum;
+    }
+
+    if (VECTOR_BITSIZE >= 128) {
+      int sum = 0;
+      for (int index = 0; index < 32; index += 8) {
+        ByteVector packed =
+            ByteVector.fromMemorySegment(
+                ByteVector.SPECIES_64, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+        ByteVector q4 = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+        ShortVector q4Shorts =
+            (ShortVector) q4.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+        ShortVector q8Shorts =
+            (ShortVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                    .convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+        sum += q4Shorts.mul(q8Shorts).reduceLanes(VectorOperators.ADD);
+      }
+      return sum;
+    }
+
+    int sum = 0;
+    for (int index = 0; index < 32; index++) {
+      int packed = qWeight.get(ValueLayout.JAVA_BYTE, packedOffset + index) & 0xFF;
+      sum += ((packed >>> 4) & 0x0F) * q8Quants[quantOffset + index];
+    }
+    return sum;
   }
 
   /** SIMD Q5_K by Q8_K GEMV with one activation quantization shared by all rows. */
@@ -1846,20 +1781,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int s2,
       int s3,
       int s4) {
-    return s1 * q6_KQ8_KGroupDot(qWeight, ql1Offset, qhOffset, 0, 0, q8Quants, quantOffset)
-        + s2 * q6_KQ8_KGroupDot(qWeight, ql2Offset, qhOffset, 0, 2, q8Quants, quantOffset + 32)
-        + s3 * q6_KQ8_KGroupDot(qWeight, ql1Offset, qhOffset, 4, 4, q8Quants, quantOffset + 64)
-        + s4 * q6_KQ8_KGroupDot(qWeight, ql2Offset, qhOffset, 4, 6, q8Quants, quantOffset + 96);
+    return s1 * q6_KQ8_KGroup0Dot(qWeight, ql1Offset, qhOffset, q8Quants, quantOffset)
+        + s2 * q6_KQ8_KGroup2Dot(qWeight, ql2Offset, qhOffset, q8Quants, quantOffset + 32)
+        + s3 * q6_KQ8_KGroup4Dot(qWeight, ql1Offset, qhOffset, q8Quants, quantOffset + 64)
+        + s4 * q6_KQ8_KGroup6Dot(qWeight, ql2Offset, qhOffset, q8Quants, quantOffset + 96);
   }
 
-  private static int q6_KQ8_KGroupDot(
-      MemorySegment qWeight,
-      long qlOffset,
-      long qhOffset,
-      int qlShift,
-      int qhShift,
-      byte[] q8Quants,
-      int quantOffset) {
+  private static int q6_KQ8_KGroup0Dot(
+      MemorySegment qWeight, long qlOffset, long qhOffset, byte[] q8Quants, int quantOffset) {
     int sum = 0;
     for (int index = 0; index < 16; index += 8) {
       ByteVector ql =
@@ -1868,11 +1797,86 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       ByteVector qh =
           ByteVector.fromMemorySegment(
               ByteVector.SPECIES_64, qWeight, qhOffset + index, ByteOrder.LITTLE_ENDIAN);
-      ByteVector low = ql.lanewise(VectorOperators.LSHR, qlShift).and((byte) 0x0F);
-      ByteVector high =
-          qh.lanewise(VectorOperators.LSHR, qhShift)
-              .and((byte) 0x03)
-              .lanewise(VectorOperators.LSHL, 4);
+      ByteVector low = ql.and((byte) 0x0F);
+      ByteVector high = qh.and((byte) 0x03).lanewise(VectorOperators.LSHL, 4);
+      IntVector weights =
+          (IntVector)
+              low.add(high)
+                  .sub((byte) 32)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector quants =
+          (IntVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      sum += weights.mul(quants).reduceLanes(VectorOperators.ADD);
+    }
+    return sum;
+  }
+
+  private static int q6_KQ8_KGroup2Dot(
+      MemorySegment qWeight, long qlOffset, long qhOffset, byte[] q8Quants, int quantOffset) {
+    int sum = 0;
+    for (int index = 0; index < 16; index += 8) {
+      ByteVector ql =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qlOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector qh =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qhOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = ql.and((byte) 0x0F);
+      ByteVector high = qh.and((byte) 0x0C).lanewise(VectorOperators.LSHL, 2);
+      IntVector weights =
+          (IntVector)
+              low.add(high)
+                  .sub((byte) 32)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector quants =
+          (IntVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      sum += weights.mul(quants).reduceLanes(VectorOperators.ADD);
+    }
+    return sum;
+  }
+
+  private static int q6_KQ8_KGroup4Dot(
+      MemorySegment qWeight, long qlOffset, long qhOffset, byte[] q8Quants, int quantOffset) {
+    int sum = 0;
+    for (int index = 0; index < 16; index += 8) {
+      ByteVector ql =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qlOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector qh =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qhOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = ql.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+      ByteVector high = qh.and((byte) 0x30);
+      IntVector weights =
+          (IntVector)
+              low.add(high)
+                  .sub((byte) 32)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector quants =
+          (IntVector)
+              ByteVector.fromArray(ByteVector.SPECIES_64, q8Quants, quantOffset + index)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      sum += weights.mul(quants).reduceLanes(VectorOperators.ADD);
+    }
+    return sum;
+  }
+
+  private static int q6_KQ8_KGroup6Dot(
+      MemorySegment qWeight, long qlOffset, long qhOffset, byte[] q8Quants, int quantOffset) {
+    int sum = 0;
+    for (int index = 0; index < 16; index += 8) {
+      ByteVector ql =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qlOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector qh =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_64, qWeight, qhOffset + index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = ql.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+      ByteVector high = qh.and((byte) 0xC0).lanewise(VectorOperators.LSHR, 2);
       IntVector weights =
           (IntVector)
               low.add(high)

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -59,27 +59,38 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q4_KQ8_KIntegerLanesSumFourProductsPerLane() {
+  void q4_KQ8_KIntegerDotDecodesBothNibbleHalves() {
     byte[] packed = new byte[32];
     byte[] q8 = new byte[32];
-    int[] q4 = new int[32];
+    int expectedLow = 0;
+    int expectedHigh = 0;
     for (int index = 0; index < packed.length; index++) {
-      int value = (index * 3) % 16;
-      packed[index] = (byte) ((value << 4) | (15 - value));
-      q4[index] = value;
+      int high = (index * 3) % 16;
+      int low = 15 - high;
+      packed[index] = (byte) ((high << 4) | low);
       q8[index] = (byte) (index - 16);
+      expectedLow += low * q8[index];
+      expectedHigh += high * q8[index];
     }
 
-    IntVector actual =
-        PanamaVectorUtilSupport.q4_KQ8_KIntegerLanes(MemorySegment.ofArray(packed), 0, 4, q8, 0);
+    MemorySegment weights = MemorySegment.ofArray(packed);
+    assertThat(PanamaVectorUtilSupport.q4_KQ8_KIntegerDot(weights, 0, 0, q8, 0))
+        .isEqualTo(expectedLow);
+    assertThat(PanamaVectorUtilSupport.q4_KQ8_KIntegerDot(weights, 0, 4, q8, 0))
+        .isEqualTo(expectedHigh);
+  }
 
-    int[] expected = new int[8];
-    for (int lane = 0; lane < expected.length; lane++) {
-      for (int index = lane * 4; index < lane * 4 + 4; index++) {
-        expected[lane] += q4[index] * q8[index];
-      }
-    }
-    assertThat(actual.toArray()).containsExactly(expected);
+  @Test
+  void kQuantPackedDotHelpersReturnPrimitivesToPreserveScalarReplacement() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .filteredOn(
+            method ->
+                method.getName().equals("q4_KQ8_KIntegerDot")
+                    || method.getName().equals("q4_KQ8_KLowIntegerDot")
+                    || method.getName().equals("q4_KQ8_KHighIntegerDot")
+                    || method.getName().matches("q6_KQ8_KGroup[0246]Dot"))
+        .isNotEmpty()
+        .allSatisfy(method -> assertThat(method.getReturnType()).isEqualTo(int.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- keep Q4_K and Q6_K Vector API values inside compact helpers that return primitive integers
- split Q4_K nibble and Q6_K packed-group decoding into constant-shift paths
- remove Vector-valued helper boundaries that escape under the full inference call graph
- preserve scalar-reference, cold/hot, batched, grouped, and llama.cpp token parity

## Root cause

The isolated JMH kernels eventually scalarized, but the real mixed Q4_K/Q6_K transformer graph materialized Vector API wrapper arrays continuously. A 32-generation MiniCPM5 control performed 151 young collections and recycled roughly 624 MB per collection. JFR attributed the allocation to Vector API shift and lane operations.

## Impact

On the 2019 Intel Mac with JDK 25.0.3 and the same MiniCPM5 1B Q4_K_M bytes:

- decode: 4.37 to 7.44 tok/s (+70.3%)
- TTFT: 1.584 s to 0.940 s (-40.7%)
- young collections: 151 to 3 in the request control
- decode-only JFR: 2.71 to 7.47 tok/s (2.76x), 369 to 0 collections
- output SHA-256 and decode checksum remained identical

## Validation

- `./gradlew :vectors-core:check`
- `./gradlew :models-backend-purejava:unitTest`
- MiniCPM5 and DeepSeek-Coder ModelJars integration suites, including llama.cpp greedy-token parity
- targeted JMH with `-prof gc` for Q4_K grouped/single and Q6_K
- repeated non-JFR GC control and 128-token decode-only JFR profile