### PR TITLE
perf(bench): add Vector API upstream probes

### DIFF
--- a/vectors-bench/build.gradle.kts
+++ b/vectors-bench/build.gradle.kts
@@ -1,3 +1,5 @@
+import me.champeau.jmh.JmhBytecodeGeneratorTask
+
 plugins {
     id("me.champeau.jmh") version "0.7.2"
 }
@@ -97,6 +99,13 @@ jmh {
     resultFormat.set(project.findProperty("jmh.resultFormat") as String? ?: "TEXT")
     val resultExt = (resultFormat.get() as String).lowercase()
     resultsFile.set(project.file("build/results/jmh/results.$resultExt"))
+}
+
+// The JMH plugin reflects over benchmark classes in a separate generator JVM. Benchmarks may use
+// Vector values directly in their state and method signatures, so that JVM needs the incubator
+// module just like compilation and benchmark forks do.
+tasks.withType<JmhBytecodeGeneratorTask>().configureEach {
+    jvmArgs.addAll("--add-modules", "jdk.incubator.vector")
 }
 
 // ---------------------------------------------------------------------------

--- a/vectors-bench/jmh-results/README.md
+++ b/vectors-bench/jmh-results/README.md
@@ -22,6 +22,11 @@ They are **not authoritative**:
 first** — the gate is "did *my* number move", not "did it match the
 checked-in baseline".
 
+Focused JVM/compiler comparisons may also be recorded as Markdown reports. Unlike the illustrative
+single-fork snapshots, each report must state its fork count, runtime revision, affinity, CPU
+features, generated-code evidence, and the limitation of its conclusion. See
+`vector-api-pairwise-jvm-baseline.md` for the first such comparison.
+
 Audit T4.11 (2026-06-06) noted this nuance. The `System.gc()` calls in
 the hand-rolled benchmarks have been audited; the only ones that remain
 are in `BuildScalabilityBenchmark`, where they're justified for heap-size

--- a/vectors-bench/jmh-results/vector-api-pairwise-jvm-baseline.md
+++ b/vectors-bench/jmh-results/vector-api-pairwise-jvm-baseline.md
@@ -1,0 +1,77 @@
+# Vector API Pairwise Multiply-Add JVM Baseline
+
+Date: 2026-07-18
+
+This is a controlled comparison of the standalone graphs in
+`VectorApiPairwiseMultiplyAddBenchmark`. It verifies the Graal fix before those graphs are
+considered for a production quantized model kernel.
+
+## Environment
+
+- Host: KVM, AMD EPYC Milan, 4 physical cores / 8 logical CPUs, AVX2, no AVX-512
+- Affinity: benchmark process and forks pinned to logical CPU 2
+- JMH: 1.37, average time, 3 forks, 5 x 1-second warmups, 5 x 1-second measurements
+- Profiler: `gc`
+- HotSpot: Temurin 25.0.3+9-LTS, C2
+- Graal: GraalVM CE 25.2.4-dev+9.1, OpenJDK 25.0.3+9, JVMCI 25.1-b19
+- Graal development build: `25.2.4-dev-20260717_0119`
+- Graal archive SHA-256: `3a4edf22112daa4433556b5aae1ceb707991ef4851ff24952e5a5dd7b5913597`
+
+## Results
+
+| Width | Kernel | HotSpot 25 C2 | Graal development build | Graal speedup | Latency reduction |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 128 | signed short pairs to int (`PMADDWD`) | 3.0564 +/- 0.0067 ns/op | 1.2754 +/- 0.0108 ns/op | 2.396x | 58.27% |
+| 128 | unsigned byte x signed byte, saturated short (`PMADDUBSW`) | 2.6991 +/- 0.0125 ns/op | 1.4084 +/- 0.0243 ns/op | 1.916x | 47.82% |
+| 256 | signed short pairs to int (`VPMADDWD`) | 4.1725 +/- 0.0072 ns/op | 1.3047 +/- 0.0706 ns/op | 3.198x | 68.73% |
+| 256 | unsigned byte x signed byte, saturated short (`VPMADDUBSW`) | 4.4337 +/- 0.0177 ns/op | 1.4220 +/- 0.0090 ns/op | 3.118x | 67.93% |
+
+All four measurements reported approximately `10^-5 B/op` and no collections. The score error is
+JMH's reported confidence interval.
+
+### Complete 32-byte Q8 dot product
+
+The follow-up benchmark compares the existing four-way byte-to-int widening kernel with a
+two-way byte-to-short widening graph that uses the new pairwise matcher. Both calculate one exact
+signed 32-byte dot product.
+
+| Kernel | HotSpot 25 C2 | Graal development build | Graal speedup | Latency reduction |
+| --- | ---: | ---: | ---: | ---: |
+| Current `B2I` plus `VPMULLD` | 3.361 +/- 0.034 ns/op | 2.598 +/- 0.024 ns/op | 1.294x | 22.70% |
+| Pairwise `B2S` plus `VPMADDWD` | 7.280 +/- 0.034 ns/op | 3.157 +/- 0.077 ns/op | 2.306x | 56.63% |
+
+Both full-block kernels reported effectively zero allocation and no collections. Within one
+runtime, however, the pairwise formulation is 116.6% slower on HotSpot and 21.5% slower on the
+post-fix Graal build. The pairwise micro-operation improvement therefore does not translate into a
+better Q8 block kernel on this AMD Zen 3 host.
+
+## Generated Code
+
+The Graal JVMCI compilation contained these byte sequences in the benchmark kernel:
+
+```text
+c5 f9 f5 c1       vpmaddwd   xmm0,xmm0,xmm1
+c4 e2 71 04 c0    vpmaddubsw xmm0,xmm1,xmm0
+c5 fd f5 c1       vpmaddwd   ymm0,ymm0,ymm1
+c4 e2 75 04 c0    vpmaddubsw ymm0,ymm1,ymm0
+```
+
+The mnemonics were independently decoded with GNU `objdump -D -b binary -m i386:x86-64 -Mintel`.
+The corresponding HotSpot C2 compilations contained neither opcode and instead retained the
+expanded rearrange, extension, multiply, add, and saturating-add sequence.
+
+For the complete Q8 block, the Graal JVMCI compilation used four `VPMOVSXBW` conversions and two
+`VPMADDWD` operations in the pairwise kernel. The faster current kernel used eight `VPMOVSXBD`
+conversions and four independent `VPMULLD` operations. This confirms that the slower pairwise score
+is not caused by failure to activate the new matcher.
+
+## Interpretation
+
+This proves that Graal commit `0bc546878361` materially closes one compiler gap on AMD64. It also
+demonstrates why generated instructions are only an intermediate gate: the exact 32-byte Q8
+experiment rejects the pairwise formulation on the tested host even after successful lowering.
+No production kernel or runtime-specific dispatch is justified by these results.
+
+The remaining API gap is still material for packed mixed-byte Q4 kernels that need
+`VPMADDUBSW` followed by `VPMADDWD`, but that requires a quantization-exact full-block benchmark.
+The current Graal source also has no equivalent AArch64 SDOT/UDOT lowering.

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/jvm/VectorApiPairwiseMultiplyAddBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/jvm/VectorApiPairwiseMultiplyAddBenchmark.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench.jvm;
+
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorOperators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Standalone reproducer for packed pairwise multiply-add lowering.
+ *
+ * <p>Run with {@code ./gradlew :vectors-bench:jmh
+ * -Pjmh.includes=VectorApiPairwiseMultiplyAddBenchmark}. Compare a stable JDK 25 runtime with a
+ * post-{@code 0bc546878361} Graal development build and inspect generated code for {@code
+ * VPMADDWD}/{@code VPMADDUBSW}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class VectorApiPairwiseMultiplyAddBenchmark {
+
+  private ShortVector signedShorts;
+  private ShortVector signedShortWeights;
+  private ShortVector signedShorts256;
+  private ShortVector signedShortWeights256;
+  private ByteVector unsignedBytes;
+  private ByteVector signedByteWeights;
+  private ByteVector unsignedBytes256;
+  private ByteVector signedByteWeights256;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    SplittableRandom random = new SplittableRandom(0x5eed5eedL);
+
+    short[] shorts = new short[ShortVector.SPECIES_128.length()];
+    short[] shortWeights = new short[ShortVector.SPECIES_128.length()];
+    for (int lane = 0; lane < shorts.length; lane++) {
+      shorts[lane] = (short) random.nextInt();
+      shortWeights[lane] = (short) random.nextInt();
+    }
+    signedShorts = ShortVector.fromArray(ShortVector.SPECIES_128, shorts, 0);
+    signedShortWeights = ShortVector.fromArray(ShortVector.SPECIES_128, shortWeights, 0);
+
+    short[] shorts256 = new short[ShortVector.SPECIES_256.length()];
+    short[] shortWeights256 = new short[ShortVector.SPECIES_256.length()];
+    for (int lane = 0; lane < shorts256.length; lane++) {
+      shorts256[lane] = (short) random.nextInt();
+      shortWeights256[lane] = (short) random.nextInt();
+    }
+    signedShorts256 = ShortVector.fromArray(ShortVector.SPECIES_256, shorts256, 0);
+    signedShortWeights256 = ShortVector.fromArray(ShortVector.SPECIES_256, shortWeights256, 0);
+
+    byte[] bytes = new byte[ByteVector.SPECIES_128.length()];
+    byte[] byteWeights = new byte[ByteVector.SPECIES_128.length()];
+    random.nextBytes(bytes);
+    random.nextBytes(byteWeights);
+    unsignedBytes = ByteVector.fromArray(ByteVector.SPECIES_128, bytes, 0);
+    signedByteWeights = ByteVector.fromArray(ByteVector.SPECIES_128, byteWeights, 0);
+
+    byte[] bytes256 = new byte[ByteVector.SPECIES_256.length()];
+    byte[] byteWeights256 = new byte[ByteVector.SPECIES_256.length()];
+    random.nextBytes(bytes256);
+    random.nextBytes(byteWeights256);
+    unsignedBytes256 = ByteVector.fromArray(ByteVector.SPECIES_256, bytes256, 0);
+    signedByteWeights256 = ByteVector.fromArray(ByteVector.SPECIES_256, byteWeights256, 0);
+  }
+
+  @Benchmark
+  public int signedShortPairwiseMultiplyAdd() {
+    return signedShortPairwiseMultiplyAddKernel(signedShorts, signedShortWeights);
+  }
+
+  @Benchmark
+  public short unsignedSignedBytePairwiseMultiplyAdd() {
+    return unsignedSignedBytePairwiseMultiplyAddKernel(unsignedBytes, signedByteWeights);
+  }
+
+  @Benchmark
+  public int signedShortPairwiseMultiplyAdd256() {
+    return signedShortPairwiseMultiplyAddKernel256(signedShorts256, signedShortWeights256);
+  }
+
+  @Benchmark
+  public short unsignedSignedBytePairwiseMultiplyAdd256() {
+    return unsignedSignedBytePairwiseMultiplyAddKernel256(unsignedBytes256, signedByteWeights256);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static int signedShortPairwiseMultiplyAddKernel(ShortVector left, ShortVector right) {
+    return PairwiseMultiplyAddKernels.multiplyAddSignedShorts(left, right)
+        .reduceLanes(VectorOperators.ADD);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static short unsignedSignedBytePairwiseMultiplyAddKernel(ByteVector left, ByteVector right) {
+    return PairwiseMultiplyAddKernels.multiplyAddUnsignedSignedBytesSaturating(left, right)
+        .reduceLanes(VectorOperators.ADD);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static int signedShortPairwiseMultiplyAddKernel256(ShortVector left, ShortVector right) {
+    return PairwiseMultiplyAddKernels.multiplyAddSignedShorts256(left, right)
+        .reduceLanes(VectorOperators.ADD);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static short unsignedSignedBytePairwiseMultiplyAddKernel256(ByteVector left, ByteVector right) {
+    return PairwiseMultiplyAddKernels.multiplyAddUnsignedSignedBytesSaturating256(left, right)
+        .reduceLanes(VectorOperators.ADD);
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/jvm/VectorApiSignedByteDotProductBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/jvm/VectorApiSignedByteDotProductBenchmark.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench.jvm;
+
+import java.lang.foreign.MemorySegment;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Compares two Vector API shapes for one 32-byte GGUF Q8 dot-product block. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class VectorApiSignedByteDotProductBenchmark {
+
+  private MemorySegment left;
+  private byte[] right;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    SplittableRandom random = new SplittableRandom(0x5eed5eedL);
+    byte[] leftBytes = new byte[32];
+    right = new byte[32];
+    random.nextBytes(leftBytes);
+    random.nextBytes(right);
+    left = MemorySegment.ofArray(leftBytes);
+  }
+
+  @Benchmark
+  public int currentB2I() {
+    return currentB2IKernel(left, right);
+  }
+
+  @Benchmark
+  public int pairwiseB2S() {
+    return pairwiseB2SKernel(left, right);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static int currentB2IKernel(MemorySegment left, byte[] right) {
+    return SignedByteDotProductKernels.dotB2I256(left, right);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  static int pairwiseB2SKernel(MemorySegment left, byte[] right) {
+    return SignedByteDotProductKernels.dotPairwise256(left, right);
+  }
+}

--- a/vectors-bench/src/main/java/com/integrallis/vectors/bench/jvm/PairwiseMultiplyAddKernels.java
+++ b/vectors-bench/src/main/java/com/integrallis/vectors/bench/jvm/PairwiseMultiplyAddKernels.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench.jvm;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorShuffle;
+
+/** Standalone Vector API graphs used to verify pairwise multiply-add compiler lowering. */
+public final class PairwiseMultiplyAddKernels {
+
+  private static final VectorShuffle<Short> SHORT_EVEN_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 0);
+  private static final VectorShuffle<Short> SHORT_ODD_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 1);
+  private static final VectorShuffle<Short> SHORT_256_EVEN_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 0);
+  private static final VectorShuffle<Short> SHORT_256_ODD_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 1);
+  private static final VectorShuffle<Byte> BYTE_EVEN_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 0);
+  private static final VectorShuffle<Byte> BYTE_ODD_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 1);
+  private static final VectorShuffle<Byte> BYTE_256_EVEN_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 0);
+  private static final VectorShuffle<Byte> BYTE_256_ODD_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 1);
+
+  private PairwiseMultiplyAddKernels() {}
+
+  /** Equivalent to the x86 {@code PMADDWD} operation for a 128-bit vector. */
+  public static IntVector multiplyAddSignedShorts(ShortVector left, ShortVector right) {
+    ShortVector leftEven = left.rearrange(SHORT_EVEN_LANES);
+    ShortVector leftOdd = left.rearrange(SHORT_ODD_LANES);
+    ShortVector rightEven = right.rearrange(SHORT_EVEN_LANES);
+    ShortVector rightOdd = right.rearrange(SHORT_ODD_LANES);
+
+    IntVector leftEvenInts =
+        (IntVector) leftEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector leftOddInts =
+        (IntVector) leftOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector rightEvenInts =
+        (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector rightOddInts =
+        (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+
+    return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
+  }
+
+  /** Equivalent to the x86 {@code VPMADDWD} operation for a 256-bit vector. */
+  public static IntVector multiplyAddSignedShorts256(ShortVector left, ShortVector right) {
+    ShortVector leftEven = left.rearrange(SHORT_256_EVEN_LANES);
+    ShortVector leftOdd = left.rearrange(SHORT_256_ODD_LANES);
+    ShortVector rightEven = right.rearrange(SHORT_256_EVEN_LANES);
+    ShortVector rightOdd = right.rearrange(SHORT_256_ODD_LANES);
+
+    IntVector leftEvenInts =
+        (IntVector) leftEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    IntVector leftOddInts =
+        (IntVector) leftOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    IntVector rightEvenInts =
+        (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    IntVector rightOddInts =
+        (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+
+    return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
+  }
+
+  /** Equivalent to the x86 {@code PMADDUBSW} operation for a 128-bit vector. */
+  public static ShortVector multiplyAddUnsignedSignedBytesSaturating(
+      ByteVector unsigned, ByteVector signed) {
+    ByteVector unsignedEven = unsigned.rearrange(BYTE_EVEN_LANES);
+    ByteVector unsignedOdd = unsigned.rearrange(BYTE_ODD_LANES);
+    ByteVector signedEven = signed.rearrange(BYTE_EVEN_LANES);
+    ByteVector signedOdd = signed.rearrange(BYTE_ODD_LANES);
+
+    ShortVector unsignedEvenShorts =
+        (ShortVector)
+            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
+    ShortVector unsignedOddShorts =
+        (ShortVector)
+            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
+    ShortVector signedEvenShorts =
+        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+    ShortVector signedOddShorts =
+        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+
+    return unsignedEvenShorts
+        .mul(signedEvenShorts)
+        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
+  }
+
+  /** Equivalent to the x86 {@code VPMADDUBSW} operation for a 256-bit vector. */
+  public static ShortVector multiplyAddUnsignedSignedBytesSaturating256(
+      ByteVector unsigned, ByteVector signed) {
+    ByteVector unsignedEven = unsigned.rearrange(BYTE_256_EVEN_LANES);
+    ByteVector unsignedOdd = unsigned.rearrange(BYTE_256_ODD_LANES);
+    ByteVector signedEven = signed.rearrange(BYTE_256_EVEN_LANES);
+    ByteVector signedOdd = signed.rearrange(BYTE_256_ODD_LANES);
+
+    ShortVector unsignedEvenShorts =
+        (ShortVector)
+            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_256, 0);
+    ShortVector unsignedOddShorts =
+        (ShortVector)
+            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_256, 0);
+    ShortVector signedEvenShorts =
+        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector signedOddShorts =
+        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+
+    return unsignedEvenShorts
+        .mul(signedEvenShorts)
+        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
+  }
+}

--- a/vectors-bench/src/main/java/com/integrallis/vectors/bench/jvm/SignedByteDotProductKernels.java
+++ b/vectors-bench/src/main/java/com/integrallis/vectors/bench/jvm/SignedByteDotProductKernels.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench.jvm;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorOperators;
+
+/** Standalone 32-byte signed dot products matching one GGUF Q8 block. */
+public final class SignedByteDotProductKernels {
+
+  private static final int BLOCK_SIZE = 32;
+
+  private SignedByteDotProductKernels() {}
+
+  /** Current JDK 25-compatible shape: widen eight byte products directly to int lanes. */
+  public static int dotB2I256(MemorySegment left, byte[] right) {
+    IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
+    for (int index = 0; index < BLOCK_SIZE; index += ByteVector.SPECIES_64.length()) {
+      ByteVector leftBytes =
+          ByteVector.fromMemorySegment(ByteVector.SPECIES_64, left, index, ByteOrder.LITTLE_ENDIAN);
+      ByteVector rightBytes = ByteVector.fromArray(ByteVector.SPECIES_64, right, index);
+      IntVector leftInts =
+          (IntVector) leftBytes.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector rightInts =
+          (IntVector) rightBytes.convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      accumulator = accumulator.add(leftInts.mul(rightInts));
+    }
+    return accumulator.reduceLanes(VectorOperators.ADD);
+  }
+
+  /** Graal pairwise shape: widen sixteen bytes to shorts, then lower pairs to {@code VPMADDWD}. */
+  public static int dotPairwise256(MemorySegment left, byte[] right) {
+    IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
+    for (int index = 0; index < BLOCK_SIZE; index += ByteVector.SPECIES_128.length()) {
+      ShortVector leftShorts =
+          (ShortVector)
+              ByteVector.fromMemorySegment(
+                      ByteVector.SPECIES_128, left, index, ByteOrder.LITTLE_ENDIAN)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      ShortVector rightShorts =
+          (ShortVector)
+              ByteVector.fromArray(ByteVector.SPECIES_128, right, index)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      accumulator =
+          accumulator.add(
+              PairwiseMultiplyAddKernels.multiplyAddSignedShorts256(leftShorts, rightShorts));
+    }
+    return accumulator.reduceLanes(VectorOperators.ADD);
+  }
+}

--- a/vectors-bench/src/test/java/com/integrallis/vectors/bench/jvm/PairwiseMultiplyAddKernelsTest.java
+++ b/vectors-bench/src/test/java/com/integrallis/vectors/bench/jvm/PairwiseMultiplyAddKernelsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench.jvm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.ShortVector;
+import org.junit.jupiter.api.Test;
+
+class PairwiseMultiplyAddKernelsTest {
+
+  private static final int TRIALS = 10_000;
+
+  @Test
+  void signedShortPairsProduceIntSums() {
+    Random random = new Random(0x5eed5eedL);
+    short[] left = new short[ShortVector.SPECIES_128.length()];
+    short[] right = new short[ShortVector.SPECIES_128.length()];
+
+    for (int trial = 0; trial < TRIALS; trial++) {
+      for (int lane = 0; lane < left.length; lane++) {
+        left[lane] = (short) random.nextInt();
+        right[lane] = (short) random.nextInt();
+      }
+
+      int[] actual =
+          PairwiseMultiplyAddKernels.multiplyAddSignedShorts(
+                  ShortVector.fromArray(ShortVector.SPECIES_128, left, 0),
+                  ShortVector.fromArray(ShortVector.SPECIES_128, right, 0))
+              .toArray();
+
+      for (int lane = 0; lane < actual.length; lane++) {
+        int source = lane * 2;
+        int expected = left[source] * right[source] + left[source + 1] * right[source + 1];
+        assertThat(actual[lane]).isEqualTo(expected);
+      }
+    }
+  }
+
+  @Test
+  void signedShortPairsProduceIntSumsAt256Bits() {
+    Random random = new Random(0x2565eedL);
+    short[] left = new short[ShortVector.SPECIES_256.length()];
+    short[] right = new short[ShortVector.SPECIES_256.length()];
+
+    for (int trial = 0; trial < TRIALS; trial++) {
+      for (int lane = 0; lane < left.length; lane++) {
+        left[lane] = (short) random.nextInt();
+        right[lane] = (short) random.nextInt();
+      }
+
+      int[] actual =
+          PairwiseMultiplyAddKernels.multiplyAddSignedShorts256(
+                  ShortVector.fromArray(ShortVector.SPECIES_256, left, 0),
+                  ShortVector.fromArray(ShortVector.SPECIES_256, right, 0))
+              .toArray();
+
+      for (int lane = 0; lane < actual.length; lane++) {
+        int source = lane * 2;
+        int expected = left[source] * right[source] + left[source + 1] * right[source + 1];
+        assertThat(actual[lane]).isEqualTo(expected);
+      }
+    }
+  }
+
+  @Test
+  void unsignedSignedBytePairsProduceSaturatedShortSums() {
+    Random random = new Random(0x51a7eL);
+    byte[] unsigned = new byte[ByteVector.SPECIES_128.length()];
+    byte[] signed = new byte[ByteVector.SPECIES_128.length()];
+
+    for (int trial = 0; trial < TRIALS; trial++) {
+      random.nextBytes(unsigned);
+      random.nextBytes(signed);
+
+      short[] actual =
+          PairwiseMultiplyAddKernels.multiplyAddUnsignedSignedBytesSaturating(
+                  ByteVector.fromArray(ByteVector.SPECIES_128, unsigned, 0),
+                  ByteVector.fromArray(ByteVector.SPECIES_128, signed, 0))
+              .toArray();
+
+      for (int lane = 0; lane < actual.length; lane++) {
+        int source = lane * 2;
+        int sum =
+            Byte.toUnsignedInt(unsigned[source]) * signed[source]
+                + Byte.toUnsignedInt(unsigned[source + 1]) * signed[source + 1];
+        short expected = (short) Math.clamp(sum, Short.MIN_VALUE, Short.MAX_VALUE);
+        assertThat(actual[lane]).isEqualTo(expected);
+      }
+    }
+  }
+
+  @Test
+  void unsignedSignedBytePairsProduceSaturatedShortSumsAt256Bits() {
+    Random random = new Random(0x25651a7eL);
+    byte[] unsigned = new byte[ByteVector.SPECIES_256.length()];
+    byte[] signed = new byte[ByteVector.SPECIES_256.length()];
+
+    for (int trial = 0; trial < TRIALS; trial++) {
+      random.nextBytes(unsigned);
+      random.nextBytes(signed);
+
+      short[] actual =
+          PairwiseMultiplyAddKernels.multiplyAddUnsignedSignedBytesSaturating256(
+                  ByteVector.fromArray(ByteVector.SPECIES_256, unsigned, 0),
+                  ByteVector.fromArray(ByteVector.SPECIES_256, signed, 0))
+              .toArray();
+
+      for (int lane = 0; lane < actual.length; lane++) {
+        int source = lane * 2;
+        int sum =
+            Byte.toUnsignedInt(unsigned[source]) * signed[source]
+                + Byte.toUnsignedInt(unsigned[source + 1]) * signed[source + 1];
+        short expected = (short) Math.clamp(sum, Short.MIN_VALUE, Short.MAX_VALUE);
+        assertThat(actual[lane]).isEqualTo(expected);
+      }
+    }
+  }
+}

--- a/vectors-bench/src/test/java/com/integrallis/vectors/bench/jvm/SignedByteDotProductKernelsTest.java
+++ b/vectors-bench/src/test/java/com/integrallis/vectors/bench/jvm/SignedByteDotProductKernelsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench.jvm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class SignedByteDotProductKernelsTest {
+
+  private static final int BLOCK_SIZE = 32;
+  private static final int TRIALS = 10_000;
+
+  @Test
+  void currentAndPairwiseKernelsMatchScalarAcrossRandomSignedByteBlocks() {
+    Random random = new Random(0x08d07L);
+    byte[] left = new byte[BLOCK_SIZE];
+    byte[] right = new byte[BLOCK_SIZE];
+
+    for (int trial = 0; trial < TRIALS; trial++) {
+      random.nextBytes(left);
+      random.nextBytes(right);
+
+      int expected = 0;
+      for (int lane = 0; lane < BLOCK_SIZE; lane++) {
+        expected += left[lane] * right[lane];
+      }
+
+      MemorySegment leftSegment = MemorySegment.ofArray(left);
+      assertThat(SignedByteDotProductKernels.dotB2I256(leftSegment, right)).isEqualTo(expected);
+      assertThat(SignedByteDotProductKernels.dotPairwise256(leftSegment, right))
+          .isEqualTo(expected);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone Vector API pairwise multiply-add and 32-byte Q8 probes
- verify correctness with randomized scalar-oracle tests
- record controlled HotSpot 25 and post-fix GraalVM measurements plus assembly evidence
- enable the incubator module for JMH reflection generation

## Verification
- `./gradlew :vectors-bench:spotlessApply :vectors-bench:check :vectors-bench:jmhClasses`
- controlled 3-fork JMH runs on AMD EPYC Milan with allocation profiling
- Graal/HotSpot generated-code inspection

The full Q8 gate rejects production use of the pairwise graph, so this PR changes benchmark and research infrastructure only.