### PR TITLE
perf(core): group mixed K-quant projections

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1025,39 +1025,115 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             out = thirdOut;
             matrixRow = row - thirdStart;
           }
+          out[matrixRow] =
+              ggufQ4_KQ8_KVectorRowDot(
+                  qWeight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+        });
+  }
 
-          float sum = 0.0f;
-          long rowOffset = matrixRow * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-            float q8Scale = q8Scales[block];
-            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
-            float dMin =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
-                    * q8Scale;
-            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-            int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-            int quantizedSum = 0;
-            int minimumSum = 0;
+  private static float ggufQ4_KQ8_KVectorRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+      float q8Scale = q8Scales[block];
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+      float dMin =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+      int quantizedSum = 0;
+      int minimumSum = 0;
 
-            for (int group = 0; group < 8; group++) {
-              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-              int shift = (group & 1) * 4;
-              int groupActivationOffset = activationOffset + group * 32;
-              int groupDot =
-                  q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
-              quantizedSum += scale * groupDot;
-              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
-            }
+      for (int group = 0; group < 8; group++) {
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int groupActivationOffset = activationOffset + group * 32;
+        int groupDot =
+            q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+        quantizedSum += scale * groupDot;
+        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+      }
 
-            sum = MathUtil.fma(d, quantizedSum, sum);
-            sum = MathUtil.fma(-dMin, minimumSum, sum);
+      sum = MathUtil.fma(d, quantizedSum, sum);
+      sum = MathUtil.fma(-dMin, minimumSum, sum);
+    }
+    return sum;
+  }
+
+  @Override
+  public void ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
+          query,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          thirdWeight,
+          thirdRows,
+          thirdOut,
+          cols,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      return;
+    }
+
+    GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    long q4RowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
+    long q6RowBytes = (long) blocks * GGUF_Q6_K_BLOCK_BYTES;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          if (row < secondStart) {
+            firstOut[row] =
+                ggufQ4_KQ8_KVectorRowDot(
+                    firstWeight, row * q4RowBytes, blocks, q8Quants, q8Scales, q8Sums);
+          } else if (row < thirdStart) {
+            int matrixRow = row - secondStart;
+            secondOut[matrixRow] =
+                ggufQ4_KQ8_KVectorRowDot(
+                    secondWeight, matrixRow * q4RowBytes, blocks, q8Quants, q8Scales, q8Sums);
+          } else {
+            int matrixRow = row - thirdStart;
+            thirdOut[matrixRow] =
+                ggufQ6_KQ8_KVectorRowDot(
+                    thirdWeight, matrixRow * q6RowBytes, blocks, q8Quants, q8Scales);
           }
-          out[matrixRow] = sum;
         });
   }
 
@@ -1629,56 +1705,57 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
-        row -> {
-          float sum = 0.0f;
-          long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
-            float d =
-                Float.float16ToFloat(
-                        qWeight.get(
-                            GGUF_LE_SHORT,
-                            blockOffset
-                                + GGUF_Q6_K_QL_BYTES
-                                + GGUF_Q6_K_QH_BYTES
-                                + GGUF_Q6_K_SCALES))
-                    * q8Scales[block];
-            long qlOffset = blockOffset;
-            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
-            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
-            int activationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
-            int blockSum = 0;
+        row ->
+            out[row] =
+                ggufQ6_KQ8_KVectorRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
+  }
 
-            for (int superBlock = 0; superBlock < 2; superBlock++) {
-              long qlBase = qlOffset + (long) superBlock * 64;
-              long qhBase = qhOffset + (long) superBlock * 32;
-              long scaleBase = scaleOffset + (long) superBlock * 8;
-              int quantBase = activationOffset + superBlock * 128;
-              for (int batch = 0; batch < 32; batch += 16) {
-                int scaleIndex = batch / 16;
-                int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
-                int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
-                int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
-                int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
-                blockSum +=
-                    q6_KQ8_KIntegerDot(
-                        qWeight,
-                        qlBase + batch,
-                        qlBase + 32L + batch,
-                        qhBase + batch,
-                        q8Quants,
-                        quantBase + batch,
-                        s1,
-                        s2,
-                        s3,
-                        s4);
-              }
-            }
+  private static float ggufQ6_KQ8_KVectorRowDot(
+      MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    float sum = 0.0f;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float d =
+          Float.float16ToFloat(
+                  qWeight.get(
+                      GGUF_LE_SHORT,
+                      blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES))
+              * q8Scales[block];
+      long qlOffset = blockOffset;
+      long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+      long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+      int activationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+      int blockSum = 0;
 
-            sum = MathUtil.fma(d, blockSum, sum);
-          }
-          out[row] = sum;
-        });
+      for (int superBlock = 0; superBlock < 2; superBlock++) {
+        long qlBase = qlOffset + (long) superBlock * 64;
+        long qhBase = qhOffset + (long) superBlock * 32;
+        long scaleBase = scaleOffset + (long) superBlock * 8;
+        int quantBase = activationOffset + superBlock * 128;
+        for (int batch = 0; batch < 32; batch += 16) {
+          int scaleIndex = batch / 16;
+          int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+          int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+          int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+          int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+          blockSum +=
+              q6_KQ8_KIntegerDot(
+                  qWeight,
+                  qlBase + batch,
+                  qlBase + 32L + batch,
+                  qhBase + batch,
+                  q8Quants,
+                  quantBase + batch,
+                  s1,
+                  s2,
+                  s3,
+                  s4);
+        }
+      }
+
+      sum = MathUtil.fma(d, blockSum, sum);
+    }
+    return sum;
   }
 
   /** SIMD Q6_K by a batch of Q8_K activations with row-local weight reuse. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1025,9 +1025,39 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             out = thirdOut;
             matrixRow = row - thirdStart;
           }
-          out[matrixRow] =
-              ggufQ4_KQ8_KVectorRowDot(
-                  qWeight, matrixRow * rowBytes, blocks, q8Quants, q8Scales, q8Sums);
+
+          float sum = 0.0f;
+          long rowOffset = matrixRow * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+            float q8Scale = q8Scales[block];
+            float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+            float dMin =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES))
+                    * q8Scale;
+            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+            int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+            int quantizedSum = 0;
+            int minimumSum = 0;
+
+            for (int group = 0; group < 8; group++) {
+              int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+              int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+              long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+              int shift = (group & 1) * 4;
+              int groupActivationOffset = activationOffset + group * 32;
+              int groupDot =
+                  q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+              quantizedSum += scale * groupDot;
+              int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+              minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+            }
+
+            sum = MathUtil.fma(d, quantizedSum, sum);
+            sum = MathUtil.fma(-dMin, minimumSum, sum);
+          }
+          out[matrixRow] = sum;
         });
   }
 
@@ -1705,9 +1735,56 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
-        row ->
-            out[row] =
-                ggufQ6_KQ8_KVectorRowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
+        row -> {
+          float sum = 0.0f;
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+            float d =
+                Float.float16ToFloat(
+                        qWeight.get(
+                            GGUF_LE_SHORT,
+                            blockOffset
+                                + GGUF_Q6_K_QL_BYTES
+                                + GGUF_Q6_K_QH_BYTES
+                                + GGUF_Q6_K_SCALES))
+                    * q8Scales[block];
+            long qlOffset = blockOffset;
+            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+            int activationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+            int blockSum = 0;
+
+            for (int superBlock = 0; superBlock < 2; superBlock++) {
+              long qlBase = qlOffset + (long) superBlock * 64;
+              long qhBase = qhOffset + (long) superBlock * 32;
+              long scaleBase = scaleOffset + (long) superBlock * 8;
+              int quantBase = activationOffset + superBlock * 128;
+              for (int batch = 0; batch < 32; batch += 16) {
+                int scaleIndex = batch / 16;
+                int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+                int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+                int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+                int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+                blockSum +=
+                    q6_KQ8_KIntegerDot(
+                        qWeight,
+                        qlBase + batch,
+                        qlBase + 32L + batch,
+                        qhBase + batch,
+                        q8Quants,
+                        quantBase + batch,
+                        s1,
+                        s2,
+                        s3,
+                        s4);
+              }
+            }
+
+            sum = MathUtil.fma(d, blockSum, sum);
+          }
+          out[row] = sum;
+        });
   }
 
   private static float ggufQ6_KQ8_KVectorRowDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -831,6 +831,68 @@ public final class VectorUtil {
         q8Sums);
   }
 
+  /**
+   * Multiplies two Q4_K matrices and one Q6_K matrix by one shared Q8_K activation quantization and
+   * row dispatch.
+   */
+  public static void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchArguments(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchArguments(
+        query,
+        thirdWeight,
+        thirdRows,
+        cols,
+        thirdOut,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_BYTES);
+    checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, cols);
+    IMPL.ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
   /** Batched row-major GEMV over GGUF Q5_K rows. */
   public static void ggufQ5_KBatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -841,6 +841,55 @@ public interface VectorUtilSupport {
         });
   }
 
+  /** Two Q4_K projections and one Q6_K projection sharing Q8_K quantization and row dispatch. */
+  default void ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+    long q4RowBytes = ggufQ4_KRowBytes(cols);
+    long q6RowBytes = ggufQ6_KRowBytes(cols);
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          if (row < secondStart) {
+            firstOut[row] =
+                ggufQ4_KQ8_KScalarRowDot(
+                    firstWeight, row * q4RowBytes, blocks, q8Quants, q8Scales, q8Sums);
+          } else if (row < thirdStart) {
+            int matrixRow = row - secondStart;
+            secondOut[matrixRow] =
+                ggufQ4_KQ8_KScalarRowDot(
+                    secondWeight, matrixRow * q4RowBytes, blocks, q8Quants, q8Scales, q8Sums);
+          } else {
+            int matrixRow = row - thirdStart;
+            thirdOut[matrixRow] =
+                ggufQ6_KQ8_KScalarRowDot(
+                    thirdWeight, matrixRow * q6RowBytes, blocks, q8Quants, 0, q8Scales, 0);
+          }
+        });
+  }
+
   private static float ggufQ4_KQ8_KScalarRowDot(
       MemorySegment qWeight,
       long rowOffset,

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1397,6 +1397,73 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KQ4_KQ6_KQ8_KTripleBatchDotProductMatchesSeparateMatmulsExactly() {
+    int cols = 256;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 2;
+    float[] query = patternedQuery(cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins), firstRows));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(-0.25f, 0.03125f, i -> 15 - i % 16, scales, mins), secondRows));
+    MemorySegment thirdWeight =
+        MemorySegment.ofArray(
+            repeat(q6KBlock(0.25f, i -> (i * 5 + 3) % 64 - 32, i -> i - 8), thirdRows));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] expectedThird = new float[thirdRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+    float[] actualThird = new float[thirdRows];
+
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+        query, thirdWeight, thirdRows, cols, expectedThird, new byte[cols], new float[cols / 256]);
+
+    VectorUtil.ggufQ4_KQ4_KQ6_KQ8_KTripleBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        cols,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q5_KQ8_KDualBatchDotProductMatchesSeparateMatmulsExactly() {
     int cols = 256;
     int firstRows = 3;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/ScalarVectorUtilSupportTest.java
@@ -279,6 +279,70 @@ class ScalarVectorUtilSupportTest {
   }
 
   @Test
+  void mixedQ4_KQ6_KTripleMatmulMatchesIndependentScalarProjectionsExactly() {
+    int cols = 512;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 2;
+    float[] query = new float[cols];
+    for (int index = 0; index < query.length; index++) {
+      query[index] = (float) Math.sin((index + 0.75) * 0.0234375);
+    }
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(q4_KMatrix(firstRows, cols, 23, 0.01f, 0.005f));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(q4_KMatrix(secondRows, cols, 31, -0.02f, 0.0025f));
+    MemorySegment thirdWeight = MemorySegment.ofArray(q6_KMatrix(thirdRows, cols, 17, 0.015f));
+    float[] expectedFirst = new float[firstRows];
+    float[] expectedSecond = new float[secondRows];
+    float[] expectedThird = new float[thirdRows];
+    float[] actualFirst = new float[firstRows];
+    float[] actualSecond = new float[secondRows];
+    float[] actualThird = new float[thirdRows];
+
+    scalar.ggufQ4_KQ8_KMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    scalar.ggufQ4_KQ8_KMatVecDot(
+        query,
+        secondWeight,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+    scalar.ggufQ6_KQ8_KMatVecDot(
+        query, thirdWeight, thirdRows, cols, expectedThird, new byte[cols], new float[cols / 256]);
+
+    scalar.ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
+        query,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        cols,
+        new byte[cols],
+        new float[cols / 256],
+        new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q8_0BatchedMatmulMatchesIndependentScalarQueriesExactly() {
     int batchSize = 3;
     int rows = 2;
@@ -333,6 +397,36 @@ class ScalarVectorUtilSupportTest {
       result += delta * delta;
     }
     return result;
+  }
+
+  private static byte[] q4_KMatrix(
+      int rows, int cols, int multiplier, float scale, float minScale) {
+    int blockBytes = 144;
+    byte[] matrix = patternedMatrix(rows, cols, blockBytes, multiplier);
+    ByteBuffer buffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      buffer.putShort(offset, Float.floatToFloat16(scale));
+      buffer.putShort(offset + Short.BYTES, Float.floatToFloat16(minScale));
+    }
+    return matrix;
+  }
+
+  private static byte[] q6_KMatrix(int rows, int cols, int multiplier, float scale) {
+    int blockBytes = 210;
+    byte[] matrix = patternedMatrix(rows, cols, blockBytes, multiplier);
+    ByteBuffer buffer = ByteBuffer.wrap(matrix).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < matrix.length; offset += blockBytes) {
+      buffer.putShort(offset + 208, Float.floatToFloat16(scale));
+    }
+    return matrix;
+  }
+
+  private static byte[] patternedMatrix(int rows, int cols, int blockBytes, int multiplier) {
+    byte[] matrix = new byte[rows * (cols / 256) * blockBytes];
+    for (int index = 0; index < matrix.length; index++) {
+      matrix[index] = (byte) (index * multiplier + 7);
+    }
+    return matrix;
   }
 
   private static org.assertj.core.data.Offset<Float> within(float value) {


### PR DESCRIPTION
## Summary
- add an exact Q4_K/Q4_K/Q6_K triple projection primitive with one shared Q8_K quantization and persistent row dispatch
- cover scalar and Panama providers against independent-kernel controls
- preserve the established standalone Q4_K and Q6_K hot-loop source shapes

## Validation
- `./gradlew :vectors-core:check`
- controlled MiniCPM full-model gate in the dependent Models branch: +2.52% HotSpot and +1.31% GraalVM decode with exact paired hashes