### PR TITLE
perf(core): accelerate mapped K-quant inference

### DIFF
--- a/vectors-bench/build.gradle.kts
+++ b/vectors-bench/build.gradle.kts
@@ -82,7 +82,8 @@ jmh {
         "vectors.gguf.parallelThreshold",
         "vectors.gguf.executor",
         "vectors.gguf.threads",
-        "vectors.gguf.chunksPerThread"
+        "vectors.gguf.chunksPerThread",
+        "vectors.gguf.mappedKQuantLongOffsets"
     ).forEach { key ->
         (project.findProperty(key) as String?)?.let { jvmArgs.add("-D$key=$it") }
     }

--- a/vectors-bench/jmh-results/README.md
+++ b/vectors-bench/jmh-results/README.md
@@ -25,7 +25,8 @@ checked-in baseline".
 Focused JVM/compiler comparisons may also be recorded as Markdown reports. Unlike the illustrative
 single-fork snapshots, each report must state its fork count, runtime revision, affinity, CPU
 features, generated-code evidence, and the limitation of its conclusion. See
-`vector-api-pairwise-jvm-baseline.md` for the first such comparison.
+`vector-api-pairwise-jvm-baseline.md` for the first such comparison and
+`mapped-kquant-jdk25-jdk26.md` for the controlled mapped GGUF K-quant gate.
 
 Audit T4.11 (2026-06-06) noted this nuance. The `System.gc()` calls in
 the hand-rolled benchmarks have been audited; the only ones that remain

--- a/vectors-bench/jmh-results/mapped-kquant-jdk25-jdk26.md
+++ b/vectors-bench/jmh-results/mapped-kquant-jdk25-jdk26.md
@@ -1,0 +1,96 @@
+# Mapped K-Quant Long-Offset Gate
+
+Date: 2026-07-18
+
+This report records the acceptance evidence for
+`vectors.gguf.mappedKQuantLongOffsets`. Vectors still compiles, tests, and
+publishes for Java 25. Java 26 is an optional runtime, not a new minimum.
+
+## Environment
+
+- Branch: `perf/jdk26-mapped-kquant`
+- Candidate head: `a54986f`
+- Controlled host: AMD EPYC Milan, 4 physical cores / 8 vCPUs, AVX2, 30 GiB
+- Java 25: Temurin 25.0.3+9-LTS
+- Java 26: Temurin 26.0.1+8
+- Parallel policy: persistent executor, 8 threads, 2 chunks/thread
+- JMH: 3 forks, 3 x 1-second warmups, 5 x 1-second measurements
+- Storage: read-only file mappings in `Arena.ofShared()`
+
+The benchmark asserts that every mapped segment is accessible from a platform
+worker thread. Earlier `Arena.ofConfined()` results were serial and are not
+used. Runs observed while an orphaned `llama-cli` consumed CPU were also
+discarded.
+
+## Java 26 Kernels
+
+| Kernel and shape | Legacy | Candidate | Change |
+| --- | ---: | ---: | ---: |
+| Q4_K GEMV, 1024x2048 | 0.165 ms/op | 0.149 ms/op | -9.7% |
+| Q5_K GEMV, 1024x2048 | 0.267 ms/op | 0.269 ms/op | +0.7% |
+| Q6_K GEMV, 1024x2048 | 0.258 ms/op | 0.253 ms/op | -1.9% |
+| Mixed Q4_K/Q4_K/Q6_K, 1536/192/192x1536 | 0.295 ms/op | 0.274 ms/op | -7.1% |
+| Q6_K vocabulary projection, 130560x1536 | 24.158 ms/op | 23.680 ms/op | -2.0% |
+| Q4_K prefill, batch 32, 4608x1536 | 20.556 ms/op | 17.910 ms/op | -12.9% |
+
+The Q4_K prefill result has non-overlapping 99.9% confidence intervals:
+20.556 +/- 0.075 ms/op versus 17.910 +/- 0.066 ms/op.
+
+## Java 25 Kernel
+
+The same mapped Q4_K prefill case improved from 15.787 +/- 0.074 ms/op to
+15.519 +/- 0.072 ms/op, or 1.7%. Java 25 remains faster than Java 26 for this
+kernel on the controlled host.
+
+## Full Model Gate
+
+MiniCPM5-1B-Q4_K_M used two warmups and ten measured 64-token trials at a
+2,048-token context with eight threads. The GGUF SHA-256 is
+`81b64d05a23b17b34c475f42b3e72fbde62d4b92cc34541f7a8031d0752deafa`.
+
+| Runtime | Metric | Legacy | Candidate | Change |
+| --- | --- | ---: | ---: | ---: |
+| Java 26.0.1 | p50 decode | 11.5456 tok/s | 12.7896 tok/s | +10.77% |
+| Java 26.0.1 | p50 TTFT | 10,820.8 ms | 9,427.8 ms | -12.87% |
+| Java 26.0.1 | p95 TTFT | 10,998.4 ms | 9,552.0 ms | -13.15% |
+| Java 25.0.3 | p50 decode | 13.2951 tok/s | 13.5012 tok/s | +1.55% |
+| Java 25.0.3 | p50 TTFT | 8,443.4 ms | 8,356.9 ms | -1.02% |
+| Java 25.0.3 | p95 TTFT | 8,557.4 ms | 8,493.4 ms | -0.75% |
+
+All ten corresponding output hashes matched for both runtime comparisons.
+Java 26 candidate RSS increased from 841,883,648 to 918,843,392 bytes and
+requires separate attribution.
+
+## Retained Policy
+
+The default mode is `auto`. It requires mapped storage and currently enables
+only combinations with controlled x86 evidence:
+
+| Format | Java 25 x86 | Java 26+ x86 | Unmeasured architectures |
+| --- | --- | --- | --- |
+| Q4_K and Q4-led mixed groups | enabled | enabled | legacy |
+| Q5_K | legacy | legacy | legacy |
+| Q6_K | legacy | enabled | legacy |
+
+Use `-Dvectors.gguf.mappedKQuantLongOffsets=false` for rollback or `true` to
+force all implemented long-offset paths during an explicit experiment.
+Startup diagnostics print the resolved Q4/Q5/Q6 policy.
+
+## Reproduction
+
+Build the Java 25-compatible benchmark JAR:
+
+```bash
+./gradlew :vectors-core:check :vectors-bench:jmhJar
+```
+
+Run the mapped Q4_K prefill case with the selected JDK, changing the final
+property between `false`, `true`, and `auto`:
+
+```bash
+java -jar vectors-bench/build/libs/vectors-bench-0.1.0-SNAPSHOT-jmh.jar \
+  com.integrallis.vectors.bench.GgufMappedKQuantMatVecBenchmark.q4KBatched \
+  -p rows=4608 -p cols=1536 -p auxiliaryRows=192 -p batchSize=32 \
+  -wi 3 -i 5 -w 1s -r 1s -f 3 \
+  -jvmArgsAppend '-Dvectors.gguf.parallel=true -Dvectors.gguf.threads=8 -Dvectors.gguf.mappedKQuantLongOffsets=auto'
+```

--- a/vectors-bench/jmh-results/mapped-kquant-jdk25-jdk26.md
+++ b/vectors-bench/jmh-results/mapped-kquant-jdk25-jdk26.md
@@ -9,7 +9,7 @@ publishes for Java 25. Java 26 is an optional runtime, not a new minimum.
 ## Environment
 
 - Branch: `perf/jdk26-mapped-kquant`
-- Candidate head: `a54986f`
+- Candidate head: `3cd0233`
 - Controlled host: AMD EPYC Milan, 4 physical cores / 8 vCPUs, AVX2, 30 GiB
 - Java 25: Temurin 25.0.3+9-LTS
 - Java 26: Temurin 26.0.1+8
@@ -47,19 +47,36 @@ kernel on the controlled host.
 MiniCPM5-1B-Q4_K_M used two warmups and ten measured 64-token trials at a
 2,048-token context with eight threads. The GGUF SHA-256 is
 `81b64d05a23b17b34c475f42b3e72fbde62d4b92cc34541f7a8031d0752deafa`.
+Both Java 26 runs reached the benchmark's `OFFLINE` acceptance tier. The
+candidate used the production `auto` policy, not a forced experimental mode.
 
-| Runtime | Metric | Legacy | Candidate | Change |
-| --- | --- | ---: | ---: | ---: |
-| Java 26.0.1 | p50 decode | 11.5456 tok/s | 12.7896 tok/s | +10.77% |
-| Java 26.0.1 | p50 TTFT | 10,820.8 ms | 9,427.8 ms | -12.87% |
-| Java 26.0.1 | p95 TTFT | 10,998.4 ms | 9,552.0 ms | -13.15% |
-| Java 25.0.3 | p50 decode | 13.2951 tok/s | 13.5012 tok/s | +1.55% |
-| Java 25.0.3 | p50 TTFT | 8,443.4 ms | 8,356.9 ms | -1.02% |
-| Java 25.0.3 | p95 TTFT | 8,557.4 ms | 8,493.4 ms | -0.75% |
+| Java 26.0.1 metric | Legacy | Auto | Change |
+| --- | ---: | ---: | ---: |
+| p50 decode | 10.2792 tok/s | 10.7403 tok/s | +4.49% |
+| p50 TTFT | 11,000.6 ms | 9,825.9 ms | -10.68% |
+| p95 TTFT | 11,142.7 ms | 9,962.5 ms | -10.59% |
+| p50 prefill | 13.6320 tok/s | 15.2581 tok/s | +11.93% |
+| p50 TPOT | 97.198 ms | 93.015 ms | -4.30% |
 
-All ten corresponding output hashes matched for both runtime comparisons.
-Java 26 candidate RSS increased from 841,883,648 to 918,843,392 bytes and
-requires separate attribution.
+Linux `perf stat` covered each complete JVM run. Average reported frequency was
+3.440 GHz for legacy and 3.428 GHz for auto, while the candidate reduced
+task-clock by 8.59%, cycles by 8.93%, retired instructions by 7.06%, cache
+misses by 22.23%, and branch misses by 22.70%. All ten corresponding output
+hashes matched exactly.
+
+An earlier non-interleaved run reported a 10.77% decode gain. Replaying the
+same candidate commit later on the otherwise-idle KVM moved absolute decode
+from 12.7896 to 11.56 tok/s. That result is host-frequency/steal drift, not a
+defensible kernel effect, and is superseded by the counter-backed gate above.
+The earlier Java 25 full-model result (+1.55% decode, -1.02% p50 TTFT) remains
+corroborative rather than acceptance evidence; the Java 25 kernel gate is the
+non-overlapping JMH result in the preceding section.
+
+Peak `VmHWM` was also unstable across repeated candidate JVMs (850.8-926.2 MB).
+At comparable live lifecycle points, `/proc/<pid>/smaps_rollup` measured
+812-814 MiB RSS in both modes, split into approximately 216-218 MiB anonymous
+and 594 MiB file-backed memory. No memory-capacity improvement or regression is
+claimed from these runs; a lifecycle-aligned sampler is required for that gate.
 
 ## Retained Policy
 

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufMappedKQuantMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufMappedKQuantMatVecBenchmark.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures the K-quant GEMV path used by file-mapped GGUF model weights. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+public class GgufMappedKQuantMatVecBenchmark {
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private Arena arena;
+  private Path q4Path;
+  private Path q5Path;
+  private Path q6Path;
+  private MemorySegment q4Weights;
+  private MemorySegment q5Weights;
+  private MemorySegment q6Weights;
+  private float[] query;
+  private float[] out;
+  private byte[] q8Quants;
+  private float[] q8Scales;
+  private short[] q8Sums;
+
+  @Setup(Level.Trial)
+  public void setUp() throws IOException {
+    arena = Arena.ofConfined();
+    Random random = new Random(0x26_4bL);
+    q4Path = Files.createTempFile("mapped-q4-k-", ".bin");
+    q5Path = Files.createTempFile("mapped-q5-k-", ".bin");
+    q6Path = Files.createTempFile("mapped-q6-k-", ".bin");
+    q4Weights = mapReadOnly(randomBlocks(random, rows * (cols / 256) * 144, 144, 0, 2), q4Path);
+    q5Weights = mapReadOnly(randomBlocks(random, rows * (cols / 256) * 176, 176, 0, 2), q5Path);
+    q6Weights = mapReadOnly(randomBlocks(random, rows * (cols / 256) * 210, 210, 208), q6Path);
+    if (!q4Weights.isMapped() || !q5Weights.isMapped() || !q6Weights.isMapped()) {
+      throw new IllegalStateException("K-quant benchmark weights must be file mapped");
+    }
+
+    query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 2.0f - 1.0f;
+    }
+    out = new float[rows];
+    q8Quants = new byte[cols];
+    q8Scales = new float[cols / 256];
+    q8Sums = new short[cols / 16];
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws IOException {
+    arena.close();
+    Files.deleteIfExists(q4Path);
+    Files.deleteIfExists(q5Path);
+    Files.deleteIfExists(q6Path);
+  }
+
+  @Benchmark
+  public float[] q4K() {
+    VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+        query, q4Weights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q5K() {
+    VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+        query, q5Weights, rows, cols, out, q8Quants, q8Scales, q8Sums);
+    return out;
+  }
+
+  @Benchmark
+  public float[] q6K() {
+    VectorUtil.ggufQ6_KQ8_KBatchDotProduct(query, q6Weights, rows, cols, out, q8Quants, q8Scales);
+    return out;
+  }
+
+  private MemorySegment mapReadOnly(byte[] bytes, Path path) throws IOException {
+    Files.write(path, bytes);
+    try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      return channel.map(FileChannel.MapMode.READ_ONLY, 0, bytes.length, arena);
+    }
+  }
+
+  private static byte[] randomBlocks(
+      Random random, int byteCount, int blockBytes, int... scaleOffsets) {
+    byte[] bytes = new byte[byteCount];
+    random.nextBytes(bytes);
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    for (int block = 0; block < byteCount; block += blockBytes) {
+      for (int scaleOffset : scaleOffsets) {
+        buffer.putShort(block + scaleOffset, scale);
+      }
+    }
+    return bytes;
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufMappedKQuantMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufMappedKQuantMatVecBenchmark.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 /** Measures the K-quant GEMV path used by file-mapped GGUF model weights. */
 @BenchmarkMode(Mode.AverageTime)
@@ -58,6 +59,12 @@ public class GgufMappedKQuantMatVecBenchmark {
   @Param("2048")
   int cols;
 
+  @Param("256")
+  int auxiliaryRows;
+
+  @Param("32")
+  int batchSize;
+
   private Arena arena;
   private Path q4Path;
   private Path q5Path;
@@ -66,14 +73,21 @@ public class GgufMappedKQuantMatVecBenchmark {
   private MemorySegment q5Weights;
   private MemorySegment q6Weights;
   private float[] query;
+  private float[] batchedQueries;
   private float[] out;
+  private float[] batchedOut;
+  private float[] secondOut;
+  private float[] thirdOut;
   private byte[] q8Quants;
   private float[] q8Scales;
   private short[] q8Sums;
+  private byte[] batchedQ8Quants;
+  private float[] batchedQ8Scales;
+  private short[] batchedQ8Sums;
 
   @Setup(Level.Trial)
   public void setUp() throws IOException {
-    arena = Arena.ofConfined();
+    arena = Arena.ofShared();
     Random random = new Random(0x26_4bL);
     q4Path = Files.createTempFile("mapped-q4-k-", ".bin");
     q5Path = Files.createTempFile("mapped-q5-k-", ".bin");
@@ -84,15 +98,31 @@ public class GgufMappedKQuantMatVecBenchmark {
     if (!q4Weights.isMapped() || !q5Weights.isMapped() || !q6Weights.isMapped()) {
       throw new IllegalStateException("K-quant benchmark weights must be file mapped");
     }
+    Thread worker = Thread.ofPlatform().unstarted(() -> {});
+    if (!q4Weights.isAccessibleBy(worker)
+        || !q5Weights.isAccessibleBy(worker)
+        || !q6Weights.isAccessibleBy(worker)) {
+      throw new IllegalStateException("K-quant benchmark weights must be worker accessible");
+    }
 
     query = new float[cols];
     for (int index = 0; index < cols; index++) {
       query[index] = random.nextFloat() * 2.0f - 1.0f;
     }
+    batchedQueries = new float[batchSize * cols];
+    for (int index = 0; index < batchedQueries.length; index++) {
+      batchedQueries[index] = random.nextFloat() * 2.0f - 1.0f;
+    }
     out = new float[rows];
+    batchedOut = new float[batchSize * rows];
+    secondOut = new float[rows];
+    thirdOut = new float[Math.max(rows, auxiliaryRows)];
     q8Quants = new byte[cols];
     q8Scales = new float[cols / 256];
     q8Sums = new short[cols / 16];
+    batchedQ8Quants = new byte[batchSize * cols];
+    batchedQ8Scales = new float[batchSize * (cols / 256)];
+    batchedQ8Sums = new short[batchSize * (cols / 16)];
   }
 
   @TearDown(Level.Trial)
@@ -121,6 +151,51 @@ public class GgufMappedKQuantMatVecBenchmark {
   public float[] q6K() {
     VectorUtil.ggufQ6_KQ8_KBatchDotProduct(query, q6Weights, rows, cols, out, q8Quants, q8Scales);
     return out;
+  }
+
+  @Benchmark
+  public float[] q4KBatched() {
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        batchedQueries,
+        q4Weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQ8Quants,
+        batchedQ8Scales,
+        batchedQ8Sums);
+    return batchedOut;
+  }
+
+  @Benchmark
+  public void q4KDual(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KQ8_KDualBatchDotProduct(
+        query, q4Weights, rows, out, q4Weights, rows, secondOut, cols, q8Quants, q8Scales, q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+  }
+
+  @Benchmark
+  public void q4KQ4KQ6KTriple(Blackhole blackhole) {
+    VectorUtil.ggufQ4_KQ4_KQ6_KQ8_KTripleBatchDotProduct(
+        query,
+        q4Weights,
+        rows,
+        out,
+        q4Weights,
+        auxiliaryRows,
+        secondOut,
+        q6Weights,
+        auxiliaryRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+    blackhole.consume(out);
+    blackhole.consume(secondOut);
+    blackhole.consume(thirdOut);
   }
 
   private MemorySegment mapReadOnly(byte[] bytes, Path path) throws IOException {

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufMappedKQuantMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufMappedKQuantMatVecBenchmark.java
@@ -134,27 +134,27 @@ public class GgufMappedKQuantMatVecBenchmark {
   }
 
   @Benchmark
-  public float[] q4K() {
+  public void q4K(Blackhole blackhole) {
     VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
         query, q4Weights, rows, cols, out, q8Quants, q8Scales, q8Sums);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q5K() {
+  public void q5K(Blackhole blackhole) {
     VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
         query, q5Weights, rows, cols, out, q8Quants, q8Scales, q8Sums);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q6K() {
+  public void q6K(Blackhole blackhole) {
     VectorUtil.ggufQ6_KQ8_KBatchDotProduct(query, q6Weights, rows, cols, out, q8Quants, q8Scales);
-    return out;
+    blackhole.consume(out);
   }
 
   @Benchmark
-  public float[] q4KBatched() {
+  public void q4KBatched(Blackhole blackhole) {
     VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
         batchedQueries,
         q4Weights,
@@ -165,7 +165,7 @@ public class GgufMappedKQuantMatVecBenchmark {
         batchedQ8Quants,
         batchedQ8Scales,
         batchedQ8Sums);
-    return batchedOut;
+    blackhole.consume(batchedOut);
   }
 
   @Benchmark

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
@@ -48,6 +48,7 @@ public final class PanamaConstants {
 
   private static final int SMALLEST_SIMD_BITS = 64;
   private static final int LARGEST_SIMD_BITS = 512;
+  static final String MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY = "vectors.gguf.mappedKQuantLongOffsets";
 
   /**
    * The resolved SIMD register-width ceiling in bits. Defaults to {@link #DEFAULT_MAX_BITS};
@@ -109,6 +110,22 @@ public final class PanamaConstants {
               + parsed);
     }
     return parsed;
+  }
+
+  static boolean useMappedKQuantLongOffsets(int runtimeFeature, boolean mapped, String configured) {
+    if (!mapped || configured == null || configured.isBlank()) {
+      return false;
+    }
+    return switch (configured.trim().toLowerCase(Locale.ROOT)) {
+      case "true" -> true;
+      case "false" -> false;
+      default ->
+          throw new IllegalArgumentException(
+              "-D"
+                  + MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY
+                  + " must be true or false; got: "
+                  + configured);
+    };
   }
 
   /**

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
@@ -56,6 +56,26 @@ public final class PanamaConstants {
     Q6_K
   }
 
+  record MappedKQuantLongOffsetPolicy(String mode, boolean q4, boolean q5, boolean q6) {
+    boolean enabled(MappedKQuantFormat format) {
+      return switch (format) {
+        case Q4_K -> q4;
+        case Q5_K -> q5;
+        case Q6_K -> q6;
+      };
+    }
+  }
+
+  private static final MappedKQuantLongOffsetPolicy MAPPED_K_QUANT_LONG_OFFSET_POLICY =
+      resolveMappedKQuantLongOffsetPolicy(
+          Runtime.version().feature(),
+          System.getProperty("os.arch", ""),
+          System.getProperty(MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY));
+
+  static final boolean USE_MAPPED_Q4_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q4();
+  static final boolean USE_MAPPED_Q5_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q5();
+  static final boolean USE_MAPPED_Q6_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q6();
+
   /**
    * The resolved SIMD register-width ceiling in bits. Defaults to {@link #DEFAULT_MAX_BITS};
    * override with {@code -Dvectors.maxBits=<64|128|256|512>}. The effective species width is {@code
@@ -119,12 +139,7 @@ public final class PanamaConstants {
   }
 
   static boolean useMappedKQuantLongOffsets(MappedKQuantFormat format, boolean mapped) {
-    return useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        System.getProperty("os.arch", ""),
-        mapped,
-        format,
-        System.getProperty(MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY));
+    return mapped && MAPPED_K_QUANT_LONG_OFFSET_POLICY.enabled(format);
   }
 
   static boolean useMappedKQuantLongOffsets(
@@ -133,15 +148,18 @@ public final class PanamaConstants {
       boolean mapped,
       MappedKQuantFormat format,
       String configured) {
-    if (!mapped) {
-      return false;
-    }
+    return mapped
+        && resolveMappedKQuantLongOffsetPolicy(runtimeFeature, arch, configured).enabled(format);
+  }
+
+  static MappedKQuantLongOffsetPolicy resolveMappedKQuantLongOffsetPolicy(
+      int runtimeFeature, String arch, String configured) {
     String mode = configured == null || configured.isBlank() ? "auto" : configured.trim();
     switch (mode.toLowerCase(Locale.ROOT)) {
       case "true":
-        return true;
+        return new MappedKQuantLongOffsetPolicy("true", true, true, true);
       case "false":
-        return false;
+        return new MappedKQuantLongOffsetPolicy("false", false, false, false);
       case "auto":
         break;
       default:
@@ -152,13 +170,14 @@ public final class PanamaConstants {
                 + configured);
     }
     if (!isX86Arch(arch)) {
-      return false;
+      return new MappedKQuantLongOffsetPolicy("auto", false, false, false);
     }
-    return switch (format) {
-      case Q4_K -> runtimeFeature >= 25;
-      case Q5_K -> false;
-      case Q6_K -> runtimeFeature >= 26;
-    };
+    return new MappedKQuantLongOffsetPolicy(
+        "auto", runtimeFeature >= 25, false, runtimeFeature >= 26);
+  }
+
+  static MappedKQuantLongOffsetPolicy mappedKQuantLongOffsetPolicy() {
+    return MAPPED_K_QUANT_LONG_OFFSET_POLICY;
   }
 
   /**

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
@@ -50,6 +50,12 @@ public final class PanamaConstants {
   private static final int LARGEST_SIMD_BITS = 512;
   static final String MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY = "vectors.gguf.mappedKQuantLongOffsets";
 
+  enum MappedKQuantFormat {
+    Q4_K,
+    Q5_K,
+    Q6_K
+  }
+
   /**
    * The resolved SIMD register-width ceiling in bits. Defaults to {@link #DEFAULT_MAX_BITS};
    * override with {@code -Dvectors.maxBits=<64|128|256|512>}. The effective species width is {@code
@@ -112,19 +118,46 @@ public final class PanamaConstants {
     return parsed;
   }
 
-  static boolean useMappedKQuantLongOffsets(int runtimeFeature, boolean mapped, String configured) {
-    if (!mapped || configured == null || configured.isBlank()) {
+  static boolean useMappedKQuantLongOffsets(MappedKQuantFormat format, boolean mapped) {
+    return useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        System.getProperty("os.arch", ""),
+        mapped,
+        format,
+        System.getProperty(MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY));
+  }
+
+  static boolean useMappedKQuantLongOffsets(
+      int runtimeFeature,
+      String arch,
+      boolean mapped,
+      MappedKQuantFormat format,
+      String configured) {
+    if (!mapped) {
       return false;
     }
-    return switch (configured.trim().toLowerCase(Locale.ROOT)) {
-      case "true" -> true;
-      case "false" -> false;
-      default ->
-          throw new IllegalArgumentException(
-              "-D"
-                  + MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY
-                  + " must be true or false; got: "
-                  + configured);
+    String mode = configured == null || configured.isBlank() ? "auto" : configured.trim();
+    switch (mode.toLowerCase(Locale.ROOT)) {
+      case "true":
+        return true;
+      case "false":
+        return false;
+      case "auto":
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "-D"
+                + MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY
+                + " must be auto, true, or false; got: "
+                + configured);
+    }
+    if (!isX86Arch(arch)) {
+      return false;
+    }
+    return switch (format) {
+      case Q4_K -> runtimeFeature >= 25;
+      case Q5_K -> false;
+      case Q6_K -> runtimeFeature >= 26;
     };
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -785,8 +785,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
 
     long rowBytes = (long) (cols / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q4_K, qWeight.isMapped())) {
+    if (qWeight.isMapped() && PanamaConstants.USE_MAPPED_Q4_K_LONG_OFFSETS) {
       GgufParallelSupport.forEachRow(
           qWeight,
           rows,
@@ -872,8 +871,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
 
     long rowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q4_K, qWeight.isMapped())) {
+    if (qWeight.isMapped() && PanamaConstants.USE_MAPPED_Q4_K_LONG_OFFSETS) {
       ggufQ4_KQ8_KLongOffsetBatchedMatmul(
           qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
       return;
@@ -1094,9 +1092,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q4_K,
-        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped())) {
+    if (firstWeight.isMapped()
+        && secondWeight.isMapped()
+        && thirdWeight.isMapped()
+        && PanamaConstants.USE_MAPPED_Q4_K_LONG_OFFSETS) {
       GgufParallelSupport.forEachRow(
           firstWeight,
           secondWeight,
@@ -1305,9 +1304,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q4_K,
-        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped())) {
+    if (firstWeight.isMapped()
+        && secondWeight.isMapped()
+        && thirdWeight.isMapped()
+        && PanamaConstants.USE_MAPPED_Q4_K_LONG_OFFSETS) {
       GgufParallelSupport.forEachRow(
           firstWeight,
           secondWeight,
@@ -1479,8 +1479,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
     long rowBytes = (long) (cols / GGUF_Q5_K_BLOCK_SIZE) * GGUF_Q5_K_BLOCK_BYTES;
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q5_K, qWeight.isMapped())) {
+    if (qWeight.isMapped() && PanamaConstants.USE_MAPPED_Q5_K_LONG_OFFSETS) {
       GgufParallelSupport.forEachRow(
           qWeight,
           rows,
@@ -1719,9 +1718,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q5_K,
-        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped())) {
+    if (firstWeight.isMapped()
+        && secondWeight.isMapped()
+        && thirdWeight.isMapped()
+        && PanamaConstants.USE_MAPPED_Q5_K_LONG_OFFSETS) {
       GgufParallelSupport.forEachRow(
           firstWeight,
           secondWeight,
@@ -2015,8 +2015,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, null);
     long rowBytes = (long) (cols / GGUF_Q6_K_BLOCK_SIZE) * GGUF_Q6_K_BLOCK_BYTES;
-    if (PanamaConstants.useMappedKQuantLongOffsets(
-        PanamaConstants.MappedKQuantFormat.Q6_K, qWeight.isMapped())) {
+    if (qWeight.isMapped() && PanamaConstants.USE_MAPPED_Q6_K_LONG_OFFSETS) {
       GgufParallelSupport.forEachRow(
           qWeight,
           rows,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -785,6 +785,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
 
     long rowBytes = (long) (cols / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        qWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      GgufParallelSupport.forEachRow(
+          qWeight,
+          rows,
+          cols,
+          row ->
+              out[row] =
+                  ggufQ4_KQ8_KLongOffsetRowDot(
+                      qWeight, row * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums));
+      return;
+    }
+
     int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
     GgufParallelSupport.forEachRow(
         qWeight,
@@ -1002,6 +1017,36 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      GgufParallelSupport.forEachRow(
+          firstWeight,
+          secondWeight,
+          thirdWeight,
+          totalRows,
+          cols,
+          row -> {
+            if (row < secondStart) {
+              firstOut[row] =
+                  ggufQ4_KQ8_KLongOffsetRowDot(
+                      firstWeight, row * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums);
+            } else if (row < thirdStart) {
+              int matrixRow = row - secondStart;
+              secondOut[matrixRow] =
+                  ggufQ4_KQ8_KLongOffsetRowDot(
+                      secondWeight, matrixRow * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums);
+            } else {
+              int matrixRow = row - thirdStart;
+              thirdOut[matrixRow] =
+                  ggufQ4_KQ8_KLongOffsetRowDot(
+                      thirdWeight, matrixRow * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums);
+            }
+          });
+      return;
+    }
+
     GgufParallelSupport.forEachRow(
         firstWeight,
         secondWeight,
@@ -1100,6 +1145,48 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return sum;
   }
 
+  static float ggufQ4_KQ8_KLongOffsetRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      long rowBytes,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    float sum = 0.0f;
+    int block = 0;
+    long rowLimit = rowOffset + rowBytes;
+    for (long blockOffset = rowOffset;
+        blockOffset < rowLimit;
+        blockOffset += GGUF_Q4_K_BLOCK_BYTES, block++) {
+      float q8Scale = q8Scales[block];
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+      float dMin =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int activationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+      int quantizedSum = 0;
+      int minimumSum = 0;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int groupActivationOffset = activationOffset + group * 32;
+        int groupDot =
+            q4_KQ8_KIntegerDot(qWeight, packedOffset, shift, q8Quants, groupActivationOffset);
+        quantizedSum += scale * groupDot;
+        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+      }
+
+      sum = MathUtil.fma(d, quantizedSum, sum);
+      sum = MathUtil.fma(-dMin, minimumSum, sum);
+    }
+    return sum;
+  }
+
   @Override
   public void ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
       float[] query,
@@ -1142,6 +1229,36 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      GgufParallelSupport.forEachRow(
+          firstWeight,
+          secondWeight,
+          thirdWeight,
+          totalRows,
+          cols,
+          row -> {
+            if (row < secondStart) {
+              firstOut[row] =
+                  ggufQ4_KQ8_KLongOffsetRowDot(
+                      firstWeight, row * q4RowBytes, q4RowBytes, q8Quants, q8Scales, q8Sums);
+            } else if (row < thirdStart) {
+              int matrixRow = row - secondStart;
+              secondOut[matrixRow] =
+                  ggufQ4_KQ8_KLongOffsetRowDot(
+                      secondWeight, matrixRow * q4RowBytes, q4RowBytes, q8Quants, q8Scales, q8Sums);
+            } else {
+              int matrixRow = row - thirdStart;
+              thirdOut[matrixRow] =
+                  ggufQ6_KQ8_KLongOffsetRowDot(
+                      thirdWeight, matrixRow * q6RowBytes, q6RowBytes, q8Quants, q8Scales);
+            }
+          });
+      return;
+    }
+
     GgufParallelSupport.forEachRow(
         firstWeight,
         secondWeight,
@@ -1287,6 +1404,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
     long rowBytes = (long) (cols / GGUF_Q5_K_BLOCK_SIZE) * GGUF_Q5_K_BLOCK_BYTES;
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        qWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      GgufParallelSupport.forEachRow(
+          qWeight,
+          rows,
+          cols,
+          row ->
+              out[row] =
+                  ggufQ5_KQ8_KLongOffsetRowDot(
+                      qWeight, row * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums));
+      return;
+    }
+
     int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
     GgufParallelSupport.forEachRow(
         qWeight,
@@ -1514,6 +1646,36 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      GgufParallelSupport.forEachRow(
+          firstWeight,
+          secondWeight,
+          thirdWeight,
+          totalRows,
+          cols,
+          row -> {
+            if (row < secondStart) {
+              firstOut[row] =
+                  ggufQ5_KQ8_KLongOffsetRowDot(
+                      firstWeight, row * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums);
+            } else if (row < thirdStart) {
+              int matrixRow = row - secondStart;
+              secondOut[matrixRow] =
+                  ggufQ5_KQ8_KLongOffsetRowDot(
+                      secondWeight, matrixRow * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums);
+            } else {
+              int matrixRow = row - thirdStart;
+              thirdOut[matrixRow] =
+                  ggufQ5_KQ8_KLongOffsetRowDot(
+                      thirdWeight, matrixRow * rowBytes, rowBytes, q8Quants, q8Scales, q8Sums);
+            }
+          });
+      return;
+    }
+
     GgufParallelSupport.forEachRow(
         firstWeight,
         secondWeight,
@@ -1553,6 +1715,57 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     float sum = 0.0f;
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      float q8Scale = q8Scales[block];
+      float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
+      float dMin =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES)) * q8Scale;
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int activationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+      int quantizedSum = 0;
+      int minimumSum = 0;
+
+      for (int group = 0; group < 8; group++) {
+        int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+        int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+        long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+        int shift = (group & 1) * 4;
+        int highBit = 1 << group;
+        int groupActivationOffset = activationOffset + group * 32;
+        int groupDot =
+            q5_KQ8_KIntegerDot(
+                qWeight,
+                packedOffset,
+                shift,
+                highBitsOffset,
+                highBit,
+                q8Quants,
+                groupActivationOffset);
+        quantizedSum += scale * groupDot;
+        int sumOffset = groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum += min * (q8Sums[sumOffset] + q8Sums[sumOffset + 1]);
+      }
+
+      sum = MathUtil.fma(d, quantizedSum, sum);
+      sum = MathUtil.fma(-dMin, minimumSum, sum);
+    }
+    return sum;
+  }
+
+  static float ggufQ5_KQ8_KLongOffsetRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      long rowBytes,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    float sum = 0.0f;
+    int block = 0;
+    long rowLimit = rowOffset + rowBytes;
+    for (long blockOffset = rowOffset;
+        blockOffset < rowLimit;
+        blockOffset += GGUF_Q5_K_BLOCK_BYTES, block++) {
       float q8Scale = q8Scales[block];
       float d = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scale;
       float dMin =
@@ -1730,6 +1943,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, null);
     long rowBytes = (long) (cols / GGUF_Q6_K_BLOCK_SIZE) * GGUF_Q6_K_BLOCK_BYTES;
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        qWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      GgufParallelSupport.forEachRow(
+          qWeight,
+          rows,
+          cols,
+          row ->
+              out[row] =
+                  ggufQ6_KQ8_KLongOffsetRowDot(
+                      qWeight, row * rowBytes, rowBytes, q8Quants, q8Scales));
+      return;
+    }
+
     int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
     GgufParallelSupport.forEachRow(
         qWeight,
@@ -1792,6 +2020,57 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     float sum = 0.0f;
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float d =
+          Float.float16ToFloat(
+                  qWeight.get(
+                      GGUF_LE_SHORT,
+                      blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES))
+              * q8Scales[block];
+      long qlOffset = blockOffset;
+      long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+      long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+      int activationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+      int blockSum = 0;
+
+      for (int superBlock = 0; superBlock < 2; superBlock++) {
+        long qlBase = qlOffset + (long) superBlock * 64;
+        long qhBase = qhOffset + (long) superBlock * 32;
+        long scaleBase = scaleOffset + (long) superBlock * 8;
+        int quantBase = activationOffset + superBlock * 128;
+        for (int batch = 0; batch < 32; batch += 16) {
+          int scaleIndex = batch / 16;
+          int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+          int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+          int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+          int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+          blockSum +=
+              q6_KQ8_KIntegerDot(
+                  qWeight,
+                  qlBase + batch,
+                  qlBase + 32L + batch,
+                  qhBase + batch,
+                  q8Quants,
+                  quantBase + batch,
+                  s1,
+                  s2,
+                  s3,
+                  s4);
+        }
+      }
+
+      sum = MathUtil.fma(d, blockSum, sum);
+    }
+    return sum;
+  }
+
+  static float ggufQ6_KQ8_KLongOffsetRowDot(
+      MemorySegment qWeight, long rowOffset, long rowBytes, byte[] q8Quants, float[] q8Scales) {
+    float sum = 0.0f;
+    int block = 0;
+    long rowLimit = rowOffset + rowBytes;
+    for (long blockOffset = rowOffset;
+        blockOffset < rowLimit;
+        blockOffset += GGUF_Q6_K_BLOCK_BYTES, block++) {
       float d =
           Float.float16ToFloat(
                   qWeight.get(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -786,9 +786,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     long rowBytes = (long) (cols / GGUF_Q4_K_BLOCK_SIZE) * GGUF_Q4_K_BLOCK_BYTES;
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        qWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q4_K, qWeight.isMapped())) {
       GgufParallelSupport.forEachRow(
           qWeight,
           rows,
@@ -875,9 +873,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     long rowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        qWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q4_K, qWeight.isMapped())) {
       ggufQ4_KQ8_KLongOffsetBatchedMatmul(
           qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
       return;
@@ -1099,9 +1095,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q4_K,
+        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped())) {
       GgufParallelSupport.forEachRow(
           firstWeight,
           secondWeight,
@@ -1311,9 +1306,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q4_K,
+        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped())) {
       GgufParallelSupport.forEachRow(
           firstWeight,
           secondWeight,
@@ -1486,9 +1480,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
     long rowBytes = (long) (cols / GGUF_Q5_K_BLOCK_SIZE) * GGUF_Q5_K_BLOCK_BYTES;
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        qWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q5_K, qWeight.isMapped())) {
       GgufParallelSupport.forEachRow(
           qWeight,
           rows,
@@ -1728,9 +1720,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q5_K,
+        firstWeight.isMapped() && secondWeight.isMapped() && thirdWeight.isMapped())) {
       GgufParallelSupport.forEachRow(
           firstWeight,
           secondWeight,
@@ -2025,9 +2016,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, null);
     long rowBytes = (long) (cols / GGUF_Q6_K_BLOCK_SIZE) * GGUF_Q6_K_BLOCK_BYTES;
     if (PanamaConstants.useMappedKQuantLongOffsets(
-        Runtime.version().feature(),
-        qWeight.isMapped(),
-        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+        PanamaConstants.MappedKQuantFormat.Q6_K, qWeight.isMapped())) {
       GgufParallelSupport.forEachRow(
           qWeight,
           rows,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -874,6 +874,15 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
 
     long rowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
+    if (PanamaConstants.useMappedKQuantLongOffsets(
+        Runtime.version().feature(),
+        qWeight.isMapped(),
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY))) {
+      ggufQ4_KQ8_KLongOffsetBatchedMatmul(
+          qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
+      return;
+    }
+
     GgufParallelSupport.forEachRow(
         qWeight,
         rows,
@@ -886,6 +895,78 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           long rowOffset = row * rowBytes;
           for (int block = 0; block < blocks; block++) {
             long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            float weightMinScale =
+                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+            int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+
+            for (int batch = 0; batch < batchSize; batch++) {
+              int quantBatchOffset = batch * cols;
+              int scaleBatchOffset = batch * blocks;
+              int sumBatchOffset = batch * sumsPerBatch;
+              float q8Scale = q8Scales[scaleBatchOffset + block];
+              float d = weightScale * q8Scale;
+              float dMin = weightMinScale * q8Scale;
+              int quantizedSum = 0;
+              int minimumSum = 0;
+
+              for (int group = 0; group < 8; group++) {
+                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+                int shift = (group & 1) * 4;
+                int groupActivationOffset = blockActivationOffset + group * 32;
+                int groupDot =
+                    q4_KQ8_KIntegerDot(
+                        qWeight,
+                        packedOffset,
+                        shift,
+                        q8Quants,
+                        quantBatchOffset + groupActivationOffset);
+                quantizedSum += scale * groupDot;
+                int activationSumOffset =
+                    sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+                minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
+              }
+
+              int outputOffset = batch * rows + row;
+              float sum = out[outputOffset];
+              sum = MathUtil.fma(d, quantizedSum, sum);
+              sum = MathUtil.fma(-dMin, minimumSum, sum);
+              out[outputOffset] = sum;
+            }
+          }
+        });
+  }
+
+  static void ggufQ4_KQ8_KLongOffsetBatchedMatmul(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    long rowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        cols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+
+          long rowEnd = (row + 1L) * rowBytes;
+          int block = 0;
+          for (long blockOffset = row * rowBytes;
+              blockOffset < rowEnd;
+              blockOffset += GGUF_Q4_K_BLOCK_BYTES, block++) {
             float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
             float weightMinScale =
                 Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -123,33 +123,8 @@ public final class VectorizationProvider {
     String ggufChunksPerThread = System.getProperty("vectors.gguf.chunksPerThread");
     String mappedKQuantLongOffsets =
         System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY);
-    String mappedKQuantMode =
-        mappedKQuantLongOffsets == null || mappedKQuantLongOffsets.isBlank()
-            ? "auto"
-            : mappedKQuantLongOffsets.trim().toLowerCase(Locale.ROOT);
-    int runtimeFeature = Runtime.version().feature();
-    String architecture = System.getProperty("os.arch", "");
-    boolean mappedQ4LongOffsets =
-        PanamaConstants.useMappedKQuantLongOffsets(
-            runtimeFeature,
-            architecture,
-            true,
-            PanamaConstants.MappedKQuantFormat.Q4_K,
-            mappedKQuantLongOffsets);
-    boolean mappedQ5LongOffsets =
-        PanamaConstants.useMappedKQuantLongOffsets(
-            runtimeFeature,
-            architecture,
-            true,
-            PanamaConstants.MappedKQuantFormat.Q5_K,
-            mappedKQuantLongOffsets);
-    boolean mappedQ6LongOffsets =
-        PanamaConstants.useMappedKQuantLongOffsets(
-            runtimeFeature,
-            architecture,
-            true,
-            PanamaConstants.MappedKQuantFormat.Q6_K,
-            mappedKQuantLongOffsets);
+    PanamaConstants.MappedKQuantLongOffsetPolicy mappedKQuantPolicy =
+        PanamaConstants.mappedKQuantLongOffsetPolicy();
 
     StringBuilder sb = new StringBuilder("vectors-core: provider=");
     sb.append(impl.getClass().getSimpleName());
@@ -166,13 +141,13 @@ public final class VectorizationProvider {
     sb.append(" ggufThreads=").append(GgufParallelSupport.parallelism());
     sb.append(" ggufChunksPerThread=").append(GgufParallelSupport.chunksPerThread());
     sb.append(" mappedKQuantLongOffsets=")
-        .append(mappedKQuantMode)
+        .append(mappedKQuantPolicy.mode())
         .append("(q4=")
-        .append(mappedQ4LongOffsets)
+        .append(mappedKQuantPolicy.q4())
         .append(",q5=")
-        .append(mappedQ5LongOffsets)
+        .append(mappedKQuantPolicy.q5())
         .append(",q6=")
-        .append(mappedQ6LongOffsets)
+        .append(mappedKQuantPolicy.q6())
         .append(')');
     sb.append(" toggles=[");
     boolean first = true;

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -123,6 +123,33 @@ public final class VectorizationProvider {
     String ggufChunksPerThread = System.getProperty("vectors.gguf.chunksPerThread");
     String mappedKQuantLongOffsets =
         System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY);
+    String mappedKQuantMode =
+        mappedKQuantLongOffsets == null || mappedKQuantLongOffsets.isBlank()
+            ? "auto"
+            : mappedKQuantLongOffsets.trim().toLowerCase(Locale.ROOT);
+    int runtimeFeature = Runtime.version().feature();
+    String architecture = System.getProperty("os.arch", "");
+    boolean mappedQ4LongOffsets =
+        PanamaConstants.useMappedKQuantLongOffsets(
+            runtimeFeature,
+            architecture,
+            true,
+            PanamaConstants.MappedKQuantFormat.Q4_K,
+            mappedKQuantLongOffsets);
+    boolean mappedQ5LongOffsets =
+        PanamaConstants.useMappedKQuantLongOffsets(
+            runtimeFeature,
+            architecture,
+            true,
+            PanamaConstants.MappedKQuantFormat.Q5_K,
+            mappedKQuantLongOffsets);
+    boolean mappedQ6LongOffsets =
+        PanamaConstants.useMappedKQuantLongOffsets(
+            runtimeFeature,
+            architecture,
+            true,
+            PanamaConstants.MappedKQuantFormat.Q6_K,
+            mappedKQuantLongOffsets);
 
     StringBuilder sb = new StringBuilder("vectors-core: provider=");
     sb.append(impl.getClass().getSimpleName());
@@ -138,6 +165,15 @@ public final class VectorizationProvider {
         .append(GgufParallelSupport.executionMode().name().toLowerCase(Locale.ROOT));
     sb.append(" ggufThreads=").append(GgufParallelSupport.parallelism());
     sb.append(" ggufChunksPerThread=").append(GgufParallelSupport.chunksPerThread());
+    sb.append(" mappedKQuantLongOffsets=")
+        .append(mappedKQuantMode)
+        .append("(q4=")
+        .append(mappedQ4LongOffsets)
+        .append(",q5=")
+        .append(mappedQ5LongOffsets)
+        .append(",q6=")
+        .append(mappedQ6LongOffsets)
+        .append(')');
     sb.append(" toggles=[");
     boolean first = true;
     if (forceScalar != null) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -121,6 +121,8 @@ public final class VectorizationProvider {
     String ggufExecutor = System.getProperty("vectors.gguf.executor");
     String ggufThreads = System.getProperty("vectors.gguf.threads");
     String ggufChunksPerThread = System.getProperty("vectors.gguf.chunksPerThread");
+    String mappedKQuantLongOffsets =
+        System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY);
 
     StringBuilder sb = new StringBuilder("vectors-core: provider=");
     sb.append(impl.getClass().getSimpleName());
@@ -180,6 +182,13 @@ public final class VectorizationProvider {
     if (ggufChunksPerThread != null) {
       if (!first) sb.append(", ");
       sb.append("vectors.gguf.chunksPerThread=").append(ggufChunksPerThread);
+      first = false;
+    }
+    if (mappedKQuantLongOffsets != null) {
+      if (!first) sb.append(", ");
+      sb.append(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY)
+          .append('=')
+          .append(mappedKQuantLongOffsets);
       first = false;
     }
     if (first) sb.append("(defaults — no -Dvectors.* overrides)");

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -19,11 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
+import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Random;
 import java.util.function.IntUnaryOperator;
 import org.junit.jupiter.api.Tag;
@@ -139,6 +144,123 @@ class GgufQuantizedDotTest {
       float actual = VectorUtil.ggufQ6_KDotProduct(query, segment, 0, query.length);
 
       assertThat(actual).isCloseTo(expected, within(1e-5f));
+    }
+  }
+
+  @Test
+  void q6_KLongOffsetRowsMatchTheEstablishedMappedKernelExactly() throws IOException {
+    int rows = 2;
+    int cols = 512;
+    byte[] firstRow = repeat(q6KBlock(0.125f, i -> (i * 5 + 3) % 64 - 32, i -> i - 8), 2);
+    byte[] secondRow = repeat(q6KBlock(-0.25f, i -> 31 - (i % 64), i -> 7 - i), 2);
+    byte[] matrix = concat(firstRow, secondRow);
+    float[] query = patternedQuery(cols);
+    float[] expected = new float[rows];
+    byte[] q8Quants = new byte[cols];
+    float[] q8Scales = new float[cols / 256];
+    Path path = Files.createTempFile("vectors-q6-k-", ".bin");
+    Files.write(path, matrix);
+
+    try (Arena arena = Arena.ofConfined();
+        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      MemorySegment mapped = channel.map(FileChannel.MapMode.READ_ONLY, 0, matrix.length, arena);
+      assertThat(mapped.isMapped()).isTrue();
+
+      VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+          query, mapped, rows, cols, expected, q8Quants, q8Scales);
+      GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, null);
+
+      long rowBytes = firstRow.length;
+      float[] actual = {
+        PanamaVectorUtilSupport.ggufQ6_KQ8_KLongOffsetRowDot(
+            mapped, 0, rowBytes, q8Quants, q8Scales),
+        PanamaVectorUtilSupport.ggufQ6_KQ8_KLongOffsetRowDot(
+            mapped, rowBytes, rowBytes, q8Quants, q8Scales)
+      };
+
+      assertThat(actual).containsExactly(expected);
+    } finally {
+      Files.deleteIfExists(path);
+    }
+  }
+
+  @Test
+  void q4_KLongOffsetRowsMatchTheEstablishedMappedKernelExactly() throws IOException {
+    int rows = 2;
+    int cols = 512;
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstRow = repeat(q4KBlock(0.125f, 0.0625f, i -> (i * 5 + 3) & 0x0F, scales, mins), 2);
+    byte[] secondRow = repeat(q4KBlock(-0.25f, 0.03125f, i -> 15 - (i & 0x0F), scales, mins), 2);
+    byte[] matrix = concat(firstRow, secondRow);
+    float[] query = patternedQuery(cols);
+    float[] expected = new float[rows];
+    byte[] q8Quants = new byte[cols];
+    float[] q8Scales = new float[cols / 256];
+    short[] q8Sums = new short[cols / 16];
+    Path path = Files.createTempFile("vectors-q4-k-", ".bin");
+    Files.write(path, matrix);
+
+    try (Arena arena = Arena.ofConfined();
+        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      MemorySegment mapped = channel.map(FileChannel.MapMode.READ_ONLY, 0, matrix.length, arena);
+      assertThat(mapped.isMapped()).isTrue();
+
+      VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
+          query, mapped, rows, cols, expected, q8Quants, q8Scales, q8Sums);
+      GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+      long rowBytes = firstRow.length;
+      float[] actual = {
+        PanamaVectorUtilSupport.ggufQ4_KQ8_KLongOffsetRowDot(
+            mapped, 0, rowBytes, q8Quants, q8Scales, q8Sums),
+        PanamaVectorUtilSupport.ggufQ4_KQ8_KLongOffsetRowDot(
+            mapped, rowBytes, rowBytes, q8Quants, q8Scales, q8Sums)
+      };
+
+      assertThat(actual).containsExactly(expected);
+    } finally {
+      Files.deleteIfExists(path);
+    }
+  }
+
+  @Test
+  void q5_KLongOffsetRowsMatchTheEstablishedMappedKernelExactly() throws IOException {
+    int rows = 2;
+    int cols = 512;
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstRow = repeat(q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) & 0x1F, scales, mins), 2);
+    byte[] secondRow = repeat(q5KBlock(-0.25f, 0.03125f, i -> 31 - (i & 0x1F), scales, mins), 2);
+    byte[] matrix = concat(firstRow, secondRow);
+    float[] query = patternedQuery(cols);
+    float[] expected = new float[rows];
+    byte[] q8Quants = new byte[cols];
+    float[] q8Scales = new float[cols / 256];
+    short[] q8Sums = new short[cols / 16];
+    Path path = Files.createTempFile("vectors-q5-k-", ".bin");
+    Files.write(path, matrix);
+
+    try (Arena arena = Arena.ofConfined();
+        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      MemorySegment mapped = channel.map(FileChannel.MapMode.READ_ONLY, 0, matrix.length, arena);
+      assertThat(mapped.isMapped()).isTrue();
+
+      VectorUtil.ggufQ5_KQ8_KBatchDotProduct(
+          query, mapped, rows, cols, expected, q8Quants, q8Scales, q8Sums);
+      GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
+
+      long rowBytes = firstRow.length;
+      float[] actual = {
+        PanamaVectorUtilSupport.ggufQ5_KQ8_KLongOffsetRowDot(
+            mapped, 0, rowBytes, q8Quants, q8Scales, q8Sums),
+        PanamaVectorUtilSupport.ggufQ5_KQ8_KLongOffsetRowDot(
+            mapped, rowBytes, rowBytes, q8Quants, q8Scales, q8Sums)
+      };
+
+      assertThat(actual).containsExactly(expected);
+    } finally {
+      Files.deleteIfExists(path);
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -207,7 +207,7 @@ class GgufQuantizedDotTest {
       assertThat(mapped.isMapped()).isTrue();
 
       VectorUtil.ggufQ4_KQ8_KBatchDotProduct(
-          query, mapped, rows, cols, expected, q8Quants, q8Scales, q8Sums);
+          query, MemorySegment.ofArray(matrix), rows, cols, expected, q8Quants, q8Scales, q8Sums);
       GgufQuantizationSupport.quantizeQ8_K(query, cols, q8Quants, q8Scales, q8Sums);
 
       long rowBytes = firstRow.length;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -225,6 +225,52 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KLongOffsetBatchedMatmulMatchesTheEstablishedKernelExactly() throws IOException {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 512;
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstRow = repeat(q4KBlock(0.125f, 0.0625f, i -> (i * 5 + 3) & 0x0F, scales, mins), 2);
+    byte[] secondRow = repeat(q4KBlock(-0.25f, 0.03125f, i -> 15 - (i & 0x0F), scales, mins), 2);
+    byte[] matrix = concat(firstRow, secondRow);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = (float) Math.sin((index + 0.25) * 0.03125);
+    }
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    byte[] q8Quants = new byte[batchSize * cols];
+    float[] q8Scales = new float[batchSize * (cols / 256)];
+    short[] q8Sums = new short[batchSize * (cols / 16)];
+    Path path = Files.createTempFile("vectors-q4-k-batch-", ".bin");
+    Files.write(path, matrix);
+
+    try (Arena arena = Arena.ofConfined();
+        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      MemorySegment mapped = channel.map(FileChannel.MapMode.READ_ONLY, 0, matrix.length, arena);
+      assertThat(mapped.isMapped()).isTrue();
+
+      VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+          queries,
+          MemorySegment.ofArray(matrix),
+          batchSize,
+          rows,
+          cols,
+          expected,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      PanamaVectorUtilSupport.ggufQ4_KQ8_KLongOffsetBatchedMatmul(
+          mapped, batchSize, rows, cols, actual, q8Quants, q8Scales, q8Sums);
+
+      assertThat(actual).containsExactly(expected);
+    } finally {
+      Files.deleteIfExists(path);
+    }
+  }
+
+  @Test
   void q5_KLongOffsetRowsMatchTheEstablishedMappedKernelExactly() throws IOException {
     int rows = 2;
     int cols = 512;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
@@ -87,13 +87,43 @@ class PanamaConstantsTest {
   }
 
   @Test
-  void mappedKQuantLongOffsetCandidateRequiresMappedStorageAndAnExplicitOverride() {
-    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, true, "true")).isTrue();
-    assertThat(PanamaConstants.useMappedKQuantLongOffsets(25, true, "true")).isTrue();
-    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, true, "false")).isFalse();
-    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, true, null)).isFalse();
-    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, false, "true")).isFalse();
-    assertThatThrownBy(() -> PanamaConstants.useMappedKQuantLongOffsets(26, true, "sometimes"))
+  void mappedKQuantLongOffsetPolicyIsFormatRuntimeAndPlatformAware() {
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                25, "amd64", true, PanamaConstants.MappedKQuantFormat.Q4_K, null))
+        .isTrue();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                26, "amd64", true, PanamaConstants.MappedKQuantFormat.Q6_K, "auto"))
+        .isTrue();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                25, "amd64", true, PanamaConstants.MappedKQuantFormat.Q6_K, null))
+        .isFalse();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                26, "amd64", true, PanamaConstants.MappedKQuantFormat.Q5_K, null))
+        .isFalse();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                26, "arm64", true, PanamaConstants.MappedKQuantFormat.Q4_K, null))
+        .isFalse();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                25, "arm64", true, PanamaConstants.MappedKQuantFormat.Q5_K, "true"))
+        .isTrue();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                26, "amd64", true, PanamaConstants.MappedKQuantFormat.Q4_K, "false"))
+        .isFalse();
+    assertThat(
+            PanamaConstants.useMappedKQuantLongOffsets(
+                26, "amd64", false, PanamaConstants.MappedKQuantFormat.Q4_K, "true"))
+        .isFalse();
+    assertThatThrownBy(
+            () ->
+                PanamaConstants.useMappedKQuantLongOffsets(
+                    26, "amd64", true, PanamaConstants.MappedKQuantFormat.Q4_K, "sometimes"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("vectors.gguf.mappedKQuantLongOffsets");
   }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
@@ -128,6 +128,26 @@ class PanamaConstantsTest {
         .hasMessageContaining("vectors.gguf.mappedKQuantLongOffsets");
   }
 
+  @Test
+  void mappedKQuantLongOffsetPolicyResolvesAllHotPathDecisionsOnce() {
+    PanamaConstants.MappedKQuantLongOffsetPolicy jdk25 =
+        PanamaConstants.resolveMappedKQuantLongOffsetPolicy(25, "amd64", null);
+    PanamaConstants.MappedKQuantLongOffsetPolicy jdk26 =
+        PanamaConstants.resolveMappedKQuantLongOffsetPolicy(26, "amd64", "auto");
+    PanamaConstants.MappedKQuantLongOffsetPolicy forced =
+        PanamaConstants.resolveMappedKQuantLongOffsetPolicy(25, "arm64", "true");
+
+    assertThat(jdk25.q4()).isTrue();
+    assertThat(jdk25.q5()).isFalse();
+    assertThat(jdk25.q6()).isFalse();
+    assertThat(jdk26.q4()).isTrue();
+    assertThat(jdk26.q5()).isFalse();
+    assertThat(jdk26.q6()).isTrue();
+    assertThat(forced.q4()).isTrue();
+    assertThat(forced.q5()).isTrue();
+    assertThat(forced.q6()).isTrue();
+  }
+
   // ─── P3.5 SVE detection ────────────────────────────────────────────────────
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
@@ -16,6 +16,7 @@
 package com.integrallis.vectors.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -83,6 +84,18 @@ class PanamaConstantsTest {
     assertThat(PanamaConstants.hasFastVectorFma("aarch64", "Linux", nonAmd, 256)).isTrue();
     assertThat(PanamaConstants.hasFastVectorFma("arm64", "Mac OS X", nonAmd, 128)).isFalse();
     assertThat(PanamaConstants.hasFastVectorFma("riscv64", "Linux", nonAmd, 256)).isFalse();
+  }
+
+  @Test
+  void mappedKQuantLongOffsetCandidateRequiresMappedStorageAndAnExplicitOverride() {
+    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, true, "true")).isTrue();
+    assertThat(PanamaConstants.useMappedKQuantLongOffsets(25, true, "true")).isTrue();
+    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, true, "false")).isFalse();
+    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, true, null)).isFalse();
+    assertThat(PanamaConstants.useMappedKQuantLongOffsets(26, false, "true")).isFalse();
+    assertThatThrownBy(() -> PanamaConstants.useMappedKQuantLongOffsets(26, true, "sometimes"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("vectors.gguf.mappedKQuantLongOffsets");
   }
 
   // ─── P3.5 SVE detection ────────────────────────────────────────────────────

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -73,6 +73,24 @@ class VectorizationProviderTest {
   }
 
   @Test
+  void toggleSummaryReportsMappedKQuantLongOffsetProperty() {
+    String key = PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY;
+    String prior = System.getProperty(key);
+    System.setProperty(key, "true");
+    try {
+      String summary =
+          VectorizationProvider.buildToggleSummary(VectorizationProvider.getInstance());
+      assertThat(summary).contains(key + "=true");
+    } finally {
+      if (prior == null) {
+        System.clearProperty(key);
+      } else {
+        System.setProperty(key, prior);
+      }
+    }
+  }
+
+  @Test
   void isPanamaEnabledReturnsBooleanWithoutCrashing() {
     // On JDK 25+ with --add-modules jdk.incubator.vector, this should be true
     boolean enabled = VectorizationProvider.isPanamaEnabled();

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -48,6 +48,8 @@ class VectorizationProviderTest {
     assertThat(summary).contains("ggufExecutor=persistent");
     assertThat(summary).contains("ggufThreads=" + GgufParallelSupport.parallelism());
     assertThat(summary).contains("ggufChunksPerThread=2");
+    assertThat(summary).contains("mappedKQuantLongOffsets=auto(");
+    assertThat(summary).contains("q4=").contains("q5=").contains("q6=");
     assertThat(summary).contains("toggles=[");
     assertThat(summary).endsWith("]");
   }
@@ -80,7 +82,9 @@ class VectorizationProviderTest {
     try {
       String summary =
           VectorizationProvider.buildToggleSummary(VectorizationProvider.getInstance());
-      assertThat(summary).contains(key + "=true");
+      assertThat(summary)
+          .contains("mappedKQuantLongOffsets=true(q4=true,q5=true,q6=true)")
+          .contains(key + "=true");
     } finally {
       if (prior == null) {
         System.clearProperty(key);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -75,15 +75,23 @@ class VectorizationProviderTest {
   }
 
   @Test
-  void toggleSummaryReportsMappedKQuantLongOffsetProperty() {
+  void toggleSummaryReportsMappedKQuantLongOffsetPropertyWithoutChangingStartupPolicy() {
     String key = PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY;
     String prior = System.getProperty(key);
+    PanamaConstants.MappedKQuantLongOffsetPolicy startupPolicy =
+        PanamaConstants.mappedKQuantLongOffsetPolicy();
     System.setProperty(key, "true");
     try {
       String summary =
           VectorizationProvider.buildToggleSummary(VectorizationProvider.getInstance());
       assertThat(summary)
-          .contains("mappedKQuantLongOffsets=true(q4=true,q5=true,q6=true)")
+          .contains(
+              "mappedKQuantLongOffsets=%s(q4=%s,q5=%s,q6=%s)"
+                  .formatted(
+                      startupPolicy.mode(),
+                      startupPolicy.q4(),
+                      startupPolicy.q5(),
+                      startupPolicy.q6()))
           .contains(key + "=true");
     } finally {
       if (prior == null) {


### PR DESCRIPTION
## Summary
- add exact long-offset mapped kernels for Q4_K, Q5_K, Q6_K, and grouped projection paths
- add a row-reuse Q4_K batched prefill kernel and permanent shared-mapping JMH coverage
- select only benchmarked format/runtime combinations through an immutable startup policy
- preserve Java 25 source, bytecode, toolchain, tests, and minimum runtime

## Evidence
- Java 26 Q4_K GEMV: 9.7% lower latency
- Java 26 mixed MiniCPM QKV: 7.1% lower latency
- Java 26 Q4_K batch-32 prefill: 12.9% lower latency
- final MiniCPM auto-policy gate: +4.49% p50 decode, -10.68% p50 TTFT, -8.93% CPU cycles
- all corresponding full-model output hashes match exactly

## Verification
- ./gradlew :vectors-core:check
- ./gradlew :vectors-bench:jmhJar
- controlled Java 25 and Java 26 JMH runs
- ten-trial Java 26 full-model control/auto runs under perf stat

The property -Dvectors.gguf.mappedKQuantLongOffsets=false remains an immediate rollback.