### PR TITLE
perf(core): group batched K-quant projections

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1008,6 +1008,73 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void ggufQ4_KQ8_KDualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (batchSize == 1) {
+      ggufQ4_KQ8_KDualMatVecDot(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          cols,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    quantizeQ8_KBatch(queries, batchSize, cols, blocks, sumsPerBatch, q8Quants, q8Scales, q8Sums);
+    long rowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
+    int totalRows = Math.addExact(firstRows, secondRows);
+    boolean useLongOffsets =
+        firstWeight.isMapped()
+            && secondWeight.isMapped()
+            && PanamaConstants.USE_MAPPED_Q4_K_LONG_OFFSETS;
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
+        row -> {
+          boolean first = row < firstRows;
+          MemorySegment weight = first ? firstWeight : secondWeight;
+          int matrixRow = first ? row : row - firstRows;
+          int matrixRows = first ? firstRows : secondRows;
+          float[] out = first ? firstOut : secondOut;
+          ggufQ4_KQ8_KBatchedRowDot(
+              weight,
+              matrixRow * rowBytes,
+              useLongOffsets,
+              batchSize,
+              matrixRows,
+              matrixRow,
+              cols,
+              blocks,
+              sumsPerBatch,
+              out,
+              q8Quants,
+              q8Scales,
+              q8Sums);
+        });
+  }
+
+  @Override
   public void ggufQ4_KQ8_KDualMatVecDot(
       float[] query,
       MemorySegment firstWeight,
@@ -1357,6 +1424,283 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     thirdWeight, matrixRow * q6RowBytes, blocks, q8Quants, q8Scales);
           }
         });
+  }
+
+  @Override
+  public void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    if (batchSize == 1) {
+      ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          thirdWeight,
+          thirdRows,
+          thirdOut,
+          cols,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      return;
+    }
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          thirdWeight,
+          thirdRows,
+          thirdOut,
+          batchSize,
+          cols,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    quantizeQ8_KBatch(queries, batchSize, cols, blocks, sumsPerBatch, q8Quants, q8Scales, q8Sums);
+    long q4RowBytes = (long) blocks * GGUF_Q4_K_BLOCK_BYTES;
+    long q6RowBytes = (long) blocks * GGUF_Q6_K_BLOCK_BYTES;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    boolean useLongQ4Offsets =
+        firstWeight.isMapped()
+            && secondWeight.isMapped()
+            && PanamaConstants.USE_MAPPED_Q4_K_LONG_OFFSETS;
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          if (row < secondStart) {
+            ggufQ4_KQ8_KBatchedRowDot(
+                firstWeight,
+                row * q4RowBytes,
+                useLongQ4Offsets,
+                batchSize,
+                firstRows,
+                row,
+                cols,
+                blocks,
+                sumsPerBatch,
+                firstOut,
+                q8Quants,
+                q8Scales,
+                q8Sums);
+          } else if (row < thirdStart) {
+            int matrixRow = row - secondStart;
+            ggufQ4_KQ8_KBatchedRowDot(
+                secondWeight,
+                matrixRow * q4RowBytes,
+                useLongQ4Offsets,
+                batchSize,
+                secondRows,
+                matrixRow,
+                cols,
+                blocks,
+                sumsPerBatch,
+                secondOut,
+                q8Quants,
+                q8Scales,
+                q8Sums);
+          } else {
+            int matrixRow = row - thirdStart;
+            ggufQ6_KQ8_KBatchedRowDot(
+                thirdWeight,
+                matrixRow * q6RowBytes,
+                batchSize,
+                thirdRows,
+                matrixRow,
+                cols,
+                blocks,
+                thirdOut,
+                q8Quants,
+                q8Scales);
+          }
+        });
+  }
+
+  private static void quantizeQ8_KBatch(
+      float[] queries,
+      int batchSize,
+      int cols,
+      int blocks,
+      int sumsPerBatch,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+  }
+
+  private static void ggufQ4_KQ8_KBatchedRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      boolean useLongOffsets,
+      int batchSize,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      int sumsPerBatch,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    for (int batch = 0; batch < batchSize; batch++) {
+      out[batch * rows + row] = 0.0f;
+    }
+
+    long blockOffset = rowOffset;
+    for (int block = 0; block < blocks; block++) {
+      if (!useLongOffsets) {
+        blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+      }
+      float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float weightMinScale =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+
+      for (int batch = 0; batch < batchSize; batch++) {
+        int quantBatchOffset = batch * cols;
+        int scaleBatchOffset = batch * blocks;
+        int sumBatchOffset = batch * sumsPerBatch;
+        float q8Scale = q8Scales[scaleBatchOffset + block];
+        float d = weightScale * q8Scale;
+        float dMin = weightMinScale * q8Scale;
+        int quantizedSum = 0;
+        int minimumSum = 0;
+
+        for (int group = 0; group < 8; group++) {
+          int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+          int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+          long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+          int shift = (group & 1) * 4;
+          int groupActivationOffset = blockActivationOffset + group * 32;
+          int groupDot =
+              q4_KQ8_KIntegerDot(
+                  qWeight, packedOffset, shift, q8Quants, quantBatchOffset + groupActivationOffset);
+          quantizedSum += scale * groupDot;
+          int activationSumOffset =
+              sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+          minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
+        }
+
+        int outputOffset = batch * rows + row;
+        float sum = out[outputOffset];
+        sum = MathUtil.fma(d, quantizedSum, sum);
+        sum = MathUtil.fma(-dMin, minimumSum, sum);
+        out[outputOffset] = sum;
+      }
+      if (useLongOffsets) {
+        blockOffset += GGUF_Q4_K_BLOCK_BYTES;
+      }
+    }
+  }
+
+  private static void ggufQ6_KQ8_KBatchedRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int batchSize,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    for (int batch = 0; batch < batchSize; batch++) {
+      out[batch * rows + row] = 0.0f;
+    }
+
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float weightScale =
+          Float.float16ToFloat(
+              qWeight.get(
+                  GGUF_LE_SHORT,
+                  blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES));
+      long qlOffset = blockOffset;
+      long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+      long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+      int blockActivationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+
+      for (int batch = 0; batch < batchSize; batch++) {
+        int quantBatchOffset = batch * cols;
+        int scaleBatchOffset = batch * blocks;
+        int blockSum = 0;
+
+        for (int superBlock = 0; superBlock < 2; superBlock++) {
+          long qlBase = qlOffset + (long) superBlock * 64;
+          long qhBase = qhOffset + (long) superBlock * 32;
+          long scaleBase = scaleOffset + (long) superBlock * 8;
+          int quantBase = quantBatchOffset + blockActivationOffset + superBlock * 128;
+          for (int chunk = 0; chunk < 32; chunk += 16) {
+            int scaleIndex = chunk / 16;
+            int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+            int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+            int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+            int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+            blockSum +=
+                q6_KQ8_KIntegerDot(
+                    qWeight,
+                    qlBase + chunk,
+                    qlBase + 32L + chunk,
+                    qhBase + chunk,
+                    q8Quants,
+                    quantBase + chunk,
+                    s1,
+                    s2,
+                    s3,
+                    s4);
+          }
+        }
+
+        int outputOffset = batch * rows + row;
+        float d = weightScale * q8Scales[scaleBatchOffset + block];
+        out[outputOffset] = MathUtil.fma(d, blockSum, out[outputOffset]);
+      }
+    }
   }
 
   static int q4_KQ8_KIntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -727,6 +727,60 @@ public final class VectorUtil {
         queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, q8Sums);
   }
 
+  /**
+   * Multiplies two Q4_K matrices by a batch of activations with one Q8_K quantization pass and one
+   * row dispatch.
+   */
+  public static void ggufQ4_KQ8_KDualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    checkGgufActivationScratch(
+        q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, activationEntries);
+    IMPL.ggufQ4_KQ8_KDualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
   /** Multiplies two Q4_K matrices by one shared Q8_K activation quantization and row dispatch. */
   public static void ggufQ4_KQ8_KDualBatchDotProduct(
       float[] query,
@@ -887,6 +941,75 @@ public final class VectorUtil {
         thirdWeight,
         thirdRows,
         thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums);
+  }
+
+  /**
+   * Multiplies two Q4_K matrices and one Q6_K matrix by a batch of activations with one Q8_K
+   * quantization pass and one row dispatch.
+   */
+  public static void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_K_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        thirdWeight,
+        batchSize,
+        thirdRows,
+        cols,
+        thirdOut,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q6_K_BLOCK_BYTES);
+    int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    checkGgufActivationScratch(
+        q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q4_K_BLOCK_SIZE);
+    checkGgufQ8KSums(q8Sums, activationEntries);
+    IMPL.ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
         cols,
         q8Quants,
         q8Scales,
@@ -1725,6 +1848,33 @@ public final class VectorUtil {
     if (out.length < rows) {
       throw new IllegalArgumentException(
           "out.length must be >= rows: " + out.length + " < " + rows);
+    }
+  }
+
+  private static void checkGgufQuantizedBatchedArguments(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      int blockSize,
+      int blockBytes) {
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    checkGgufQuantizedMatrixArguments(qWeight, rows, cols, blockSize, blockBytes);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -755,6 +755,64 @@ public interface VectorUtilSupport {
         });
   }
 
+  /** Two Q4_K projections over an activation batch sharing Q8_K quantization and row dispatch. */
+  default void ggufQ4_KQ8_KDualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+
+    long rowBytes = ggufQ4_KRowBytes(cols);
+    int totalRows = Math.addExact(firstRows, secondRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
+        row -> {
+          boolean first = row < firstRows;
+          MemorySegment weight = first ? firstWeight : secondWeight;
+          int matrixRow = first ? row : row - firstRows;
+          int matrixRows = first ? firstRows : secondRows;
+          float[] out = first ? firstOut : secondOut;
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * matrixRows + matrixRow] =
+                ggufQ4_KQ8_KScalarRowDot(
+                    weight,
+                    matrixRow * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks,
+                    q8Sums,
+                    batch * sumsPerBatch);
+          }
+        });
+  }
+
   /** Two Q4_K projections sharing one Q8_K activation quantization and row dispatch. */
   default void ggufQ4_KQ8_KDualMatVecDot(
       float[] query,
@@ -886,6 +944,99 @@ public interface VectorUtilSupport {
             thirdOut[matrixRow] =
                 ggufQ6_KQ8_KScalarRowDot(
                     thirdWeight, matrixRow * q6RowBytes, blocks, q8Quants, 0, q8Scales, 0);
+          }
+        });
+  }
+
+  /**
+   * Two Q4_K projections and one Q6_K projection over an activation batch sharing Q8_K quantization
+   * and row dispatch.
+   */
+  default void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
+    int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_K(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8Sums,
+          batch * sumsPerBatch);
+    }
+
+    long q4RowBytes = ggufQ4_KRowBytes(cols);
+    long q6RowBytes = ggufQ6_KRowBytes(cols);
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          if (row < secondStart) {
+            for (int batch = 0; batch < batchSize; batch++) {
+              firstOut[batch * firstRows + row] =
+                  ggufQ4_KQ8_KScalarRowDot(
+                      firstWeight,
+                      row * q4RowBytes,
+                      blocks,
+                      q8Quants,
+                      batch * cols,
+                      q8Scales,
+                      batch * blocks,
+                      q8Sums,
+                      batch * sumsPerBatch);
+            }
+          } else if (row < thirdStart) {
+            int matrixRow = row - secondStart;
+            for (int batch = 0; batch < batchSize; batch++) {
+              secondOut[batch * secondRows + matrixRow] =
+                  ggufQ4_KQ8_KScalarRowDot(
+                      secondWeight,
+                      matrixRow * q4RowBytes,
+                      blocks,
+                      q8Quants,
+                      batch * cols,
+                      q8Scales,
+                      batch * blocks,
+                      q8Sums,
+                      batch * sumsPerBatch);
+            }
+          } else {
+            int matrixRow = row - thirdStart;
+            for (int batch = 0; batch < batchSize; batch++) {
+              thirdOut[batch * thirdRows + matrixRow] =
+                  ggufQ6_KQ8_KScalarRowDot(
+                      thirdWeight,
+                      matrixRow * q6RowBytes,
+                      blocks,
+                      q8Quants,
+                      batch * cols,
+                      q8Scales,
+                      batch * blocks);
+            }
           }
         });
   }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1436,6 +1436,69 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_KQ8_KDualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
+    int batchSize = 3;
+    int cols = 512;
+    int firstRows = 2;
+    int secondRows = 3;
+    float[] queries = patternedQueries(batchSize, cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstRow =
+        concat(
+            q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins),
+            q4KBlock(-0.25f, 0.03125f, i -> 15 - i % 16, scales, mins));
+    byte[] secondRow =
+        concat(
+            q4KBlock(0.5f, -0.015625f, i -> i * 3 % 16, scales, mins),
+            q4KBlock(0.0625f, 0.125f, i -> i * 5 % 16, scales, mins));
+    MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
+    MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
+    float[] expectedFirst = new float[batchSize * firstRows];
+    float[] expectedSecond = new float[batchSize * secondRows];
+    float[] actualFirst = new float[batchSize * firstRows];
+    float[] actualSecond = new float[batchSize * secondRows];
+
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        expectedSecond,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+
+    VectorUtil.ggufQ4_KQ8_KDualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        batchSize,
+        cols,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        new short[batchSize * (cols / 16)]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
   void q4_KQ8_KDualBatchDotProductMatchesSeparateMatmulsExactly() {
     int cols = 256;
     int firstRows = 3;
@@ -1625,6 +1688,80 @@ class GgufQuantizedDotTest {
         new byte[cols],
         new float[cols / 256],
         new short[cols / 16]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
+  void q4_KQ4_KQ6_KQ8_KTripleBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
+    int batchSize = 3;
+    int cols = 256;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 2;
+    float[] queries = patternedQueries(batchSize, cols);
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    MemorySegment firstWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(0.125f, 0.0625f, i -> i % 16, scales, mins), firstRows));
+    MemorySegment secondWeight =
+        MemorySegment.ofArray(
+            repeat(q4KBlock(-0.25f, 0.03125f, i -> 15 - i % 16, scales, mins), secondRows));
+    MemorySegment thirdWeight =
+        MemorySegment.ofArray(
+            repeat(q6KBlock(0.25f, i -> (i * 5 + 3) % 64 - 32, i -> i - 8), thirdRows));
+    float[] expectedFirst = new float[batchSize * firstRows];
+    float[] expectedSecond = new float[batchSize * secondRows];
+    float[] expectedThird = new float[batchSize * thirdRows];
+    float[] actualFirst = new float[batchSize * firstRows];
+    float[] actualSecond = new float[batchSize * secondRows];
+    float[] actualThird = new float[batchSize * thirdRows];
+    byte[] quants = new byte[batchSize * cols];
+    float[] quantScales = new float[batchSize * (cols / 256)];
+    short[] quantSums = new short[batchSize * (cols / 16)];
+
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        expectedFirst,
+        quants,
+        quantScales,
+        quantSums);
+    VectorUtil.ggufQ4_KQ8_KBatchedMatmul(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        expectedSecond,
+        quants,
+        quantScales,
+        quantSums);
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries, thirdWeight, batchSize, thirdRows, cols, expectedThird, quants, quantScales);
+
+    VectorUtil.ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        batchSize,
+        cols,
+        quants,
+        quantScales,
+        quantSums);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);
@@ -2166,6 +2303,16 @@ class GgufQuantizedDotTest {
     float[] out = new float[length];
     for (int i = 0; i < length; i++) {
       out[i] = (i % 11) * 0.25f - 1.25f;
+    }
+    return out;
+  }
+
+  private static float[] patternedQueries(int batchSize, int cols) {
+    float[] out = new float[batchSize * cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        out[batch * cols + col] = (float) Math.sin((batch + 1.0) * (col + 0.25)) * (batch + 0.5f);
+      }
     }
     return out;
   }


### PR DESCRIPTION
## Summary

- add allocation-free dual Q4_K batched projection primitives
- add mixed Q4_K/Q4_K/Q6_K triple batched projection primitives
- quantize each activation batch once and use one persistent row dispatch per projection group
- preserve the established block-major Panama accumulation order and scalar fallback semantics

## Why

MiniCPM5 batched prefill independently quantized and dispatched Q, K, V, gate, and up projections. A controlled batch sweep showed that this erased the grouped-kernel advantage available to the single-token path and made MiniCPM batch 1 faster than batches 8-512.

## Validation

- `./gradlew :vectors-core:check`
- exact dual Q4_K batched parity against independent batched kernels
- exact mixed Q4_K/Q4_K/Q6_K batched parity against independent batched kernels
- downstream Models nano-model prefill and autoregressive-state parity
- controlled Java 25 MiniCPM5 A/B on an 8-vCPU AMD EPYC-Milan host: median long-prompt TTFT 8330.16 ms to 7948.31 ms (-4.58%), median prefill 17.95 to 18.78 tok/s (+4.61%), identical output hashes across 12 trials per mode
