### PR TITLE
perf(core): group batched Q4 projections

### DIFF
--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -16,6 +16,19 @@ Benchmarks for the Vectors library.
 ./gradlew :vectors-bench:jmh
 ```
 
+## Grouped GGUF projection gates
+
+Grouped batched GGUF APIs are retained by quantization format only after an exact real-model gate
+in Models. On Java 25 and an eight-vCPU AMD EPYC-Milan host, the Q4_0 dual/triple path improved
+Qwen3 0.6B median TTFT from 3127.92 to 3096.45 ms across 18 trials per mode, with identical token
+counts and output hashes in every counterbalanced pair. A ten-prompt allocation JFR with five
+warmups measured a 9.99 MB total allocation difference for the complete process, ruling out a
+steady per-prefill allocation penalty. The previously retained mixed Q4_K/Q4_K/Q6_K path improved
+MiniCPM5 1B median TTFT from 8330.16 to 7948.31 ms.
+
+These results do not imply that every quantization format benefits from grouped dispatch. Q8_0
+remains disabled for batched grouping until its independent gate passes.
+
 ## Dependencies
 
 - All Vectors library modules

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -602,6 +602,246 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  @Override
+  public void ggufQ4_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    if (batchSize == 1) {
+      ggufQ4_0Q8_0DualMatVecDot(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          cols,
+          q8Quants,
+          q8Scales);
+      return;
+    }
+    ggufQ4_0Q8_0GroupedBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        secondWeight,
+        0,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        laneScratch);
+  }
+
+  @Override
+  public void ggufQ4_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    if (batchSize == 1) {
+      ggufQ4_0Q8_0TripleMatVecDot(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          thirdWeight,
+          thirdRows,
+          thirdOut,
+          cols,
+          q8Quants,
+          q8Scales);
+      return;
+    }
+    ggufQ4_0Q8_0GroupedBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        laneScratch);
+  }
+
+  private void ggufQ4_0Q8_0GroupedBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    if (VECTOR_BITSIZE < 256) {
+      if (thirdRows == 0) {
+        VectorUtilSupport.super.ggufQ4_0Q8_0DualBatchedMatmul(
+            queries,
+            firstWeight,
+            firstRows,
+            firstOut,
+            secondWeight,
+            secondRows,
+            secondOut,
+            batchSize,
+            cols,
+            q8Quants,
+            q8Scales,
+            laneScratch);
+      } else {
+        VectorUtilSupport.super.ggufQ4_0Q8_0TripleBatchedMatmul(
+            queries,
+            firstWeight,
+            firstRows,
+            firstOut,
+            secondWeight,
+            secondRows,
+            secondOut,
+            thirdWeight,
+            thirdRows,
+            thirdOut,
+            batchSize,
+            cols,
+            q8Quants,
+            q8Scales,
+            laneScratch);
+      }
+      return;
+    }
+
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q4_0_BLOCK_BYTES;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        // The combined row index gives every concurrent matrix row disjoint lane scratch.
+        row -> {
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          int matrixRows;
+          if (row < secondStart) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+            matrixRows = firstRows;
+          } else if (row < thirdStart) {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+            matrixRows = secondRows;
+          } else {
+            qWeight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+            matrixRows = thirdRows;
+          }
+
+          long rowOffset = matrixRow * rowBytes;
+          int rowLaneOffset = row * batchSize * FloatVector.SPECIES_256.length();
+          int rowLaneEnd = rowLaneOffset + batchSize * FloatVector.SPECIES_256.length();
+          for (int lane = rowLaneOffset; lane < rowLaneEnd; lane++) {
+            laneScratch[lane] = 0.0f;
+          }
+
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            ByteVector packed =
+                ByteVector.fromMemorySegment(
+                    ByteVector.SPECIES_128,
+                    qWeight,
+                    blockOffset + Short.BYTES,
+                    ByteOrder.LITTLE_ENDIAN);
+            ShortVector low =
+                (ShortVector)
+                    packed
+                        .and((byte) 0x0F)
+                        .sub((byte) 8)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+            ShortVector high =
+                (ShortVector)
+                    packed
+                        .lanewise(VectorOperators.LSHR, 4)
+                        .and((byte) 0x0F)
+                        .sub((byte) 8)
+                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+
+            for (int batch = 0; batch < batchSize; batch++) {
+              int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+              accumulateQ4_0BatchQuery(
+                  laneScratch,
+                  laneOffset,
+                  low,
+                  high,
+                  q8Quants,
+                  (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
+                  weightScale * q8Scales[batch * blocks + block]);
+            }
+          }
+
+          for (int batch = 0; batch < batchSize; batch++) {
+            int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+            out[batch * matrixRows + matrixRow] =
+                reduceAdd(FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
+          }
+        });
+  }
+
   private static void accumulateQ4_0BatchQuery(
       float[] laneScratch,
       int laneOffset,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -608,6 +608,125 @@ public final class VectorUtil {
         queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch);
   }
 
+  /** Two Q4_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
+  public static void ggufQ4_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    checkGgufActivationScratch(
+        q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    checkGgufQ4LaneScratch(
+        laneScratch, batchSize, Math.addExact(firstRows, secondRows), "dual Q4 lane scratch");
+    IMPL.ggufQ4_0Q8_0DualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        laneScratch);
+  }
+
+  /** Three Q4_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
+  public static void ggufQ4_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        thirdWeight,
+        batchSize,
+        thirdRows,
+        cols,
+        thirdOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    checkGgufActivationScratch(
+        q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    int totalRows = Math.addExact(Math.addExact(firstRows, secondRows), thirdRows);
+    checkGgufQ4LaneScratch(laneScratch, batchSize, totalRows, "triple Q4 lane scratch");
+    IMPL.ggufQ4_0Q8_0TripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        laneScratch);
+  }
+
   /** Batched row-major GEMV over GGUF Q4_K rows. */
   public static void ggufQ4_KBatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {
@@ -1941,6 +2060,20 @@ public final class VectorUtil {
               + q8Sums.length
               + " < "
               + requiredSums);
+    }
+  }
+
+  private static void checkGgufQ4LaneScratch(
+      float[] laneScratch, int batchSize, int rows, String label) {
+    Objects.requireNonNull(laneScratch, "laneScratch");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int required = checkedProduct(outputEntries, 8, label);
+    if (laneScratch.length < required) {
+      throw new IllegalArgumentException(
+          "lane scratch length must be >= batchSize * rows * 8: "
+              + laneScratch.length
+              + " < "
+              + required);
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -609,12 +609,25 @@ public interface VectorUtilSupport {
 
   private static float ggufQ4_0Q8_0ScalarRowDot(
       MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+    return ggufQ4_0Q8_0ScalarRowDot(qWeight, rowOffset, blocks, q8Quants, 0, q8Scales, 0);
+  }
+
+  private static float ggufQ4_0Q8_0ScalarRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      int quantBatchOffset,
+      float[] q8Scales,
+      int scaleBatchOffset) {
     float sum = 0.0f;
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
-      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      float scale =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset))
+              * q8Scales[scaleBatchOffset + block];
       long nibbleOffset = blockOffset + Short.BYTES;
-      int quantOffset = block * GGUF_Q_BLOCK_SIZE;
+      int quantOffset = quantBatchOffset + block * GGUF_Q_BLOCK_SIZE;
       int integerSum = 0;
       for (int index = 0; index < 16; index++) {
         int packed = qWeight.get(ValueLayout.JAVA_BYTE, nibbleOffset + index) & 0xFF;
@@ -672,6 +685,121 @@ public interface VectorUtilSupport {
         out[batch * rows + row] = sum;
       }
     }
+  }
+
+  /** Two Q4_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
+  default void ggufQ4_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    int totalRows = Math.addExact(firstRows, secondRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        totalRows,
+        cols,
+        row -> {
+          boolean first = row < firstRows;
+          MemorySegment weight = first ? firstWeight : secondWeight;
+          int matrixRow = first ? row : row - firstRows;
+          int matrixRows = first ? firstRows : secondRows;
+          float[] out = first ? firstOut : secondOut;
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * matrixRows + matrixRow] =
+                ggufQ4_0Q8_0ScalarRowDot(
+                    weight,
+                    matrixRow * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks);
+          }
+        });
+  }
+
+  /** Three Q4_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
+  default void ggufQ4_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        cols,
+        row -> {
+          MemorySegment weight;
+          float[] out;
+          int matrixRow;
+          int matrixRows;
+          if (row < secondStart) {
+            weight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+            matrixRows = firstRows;
+          } else if (row < thirdStart) {
+            weight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+            matrixRows = secondRows;
+          } else {
+            weight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+            matrixRows = thirdRows;
+          }
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * matrixRows + matrixRow] =
+                ggufQ4_0Q8_0ScalarRowDot(
+                    weight,
+                    matrixRow * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks);
+          }
+        });
   }
 
   /** Batched row-major GEMV over GGUF Q4_K rows. */

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -638,6 +638,139 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0DualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
+    int batchSize = 3;
+    int cols = 64;
+    int firstRows = 2;
+    int secondRows = 3;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow = repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), 2);
+    byte[] secondRow = repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), 2);
+    MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
+    MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
+    float[] expectedFirst = new float[batchSize * firstRows];
+    float[] expectedSecond = new float[batchSize * secondRows];
+    float[] actualFirst = new float[batchSize * firstRows];
+    float[] actualSecond = new float[batchSize * secondRows];
+    byte[] quants = new byte[batchSize * cols];
+    float[] scales = new float[batchSize * (cols / 32)];
+
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        expectedFirst,
+        quants,
+        scales,
+        new float[batchSize * firstRows * 8]);
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        expectedSecond,
+        quants,
+        scales,
+        new float[batchSize * secondRows * 8]);
+
+    VectorUtil.ggufQ4_0Q8_0DualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        batchSize,
+        cols,
+        quants,
+        scales,
+        new float[batchSize * (firstRows + secondRows) * 8]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
+  void q4_0Q8_0TripleBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
+    int batchSize = 3;
+    int cols = 64;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 1;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow = repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), 2);
+    byte[] secondRow = repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), 2);
+    byte[] thirdRow = repeat(q4Block(0.0625f, ones(32), (lo, hi) -> (lo * 11 + hi * 13) & 0xFF), 2);
+    MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
+    MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
+    MemorySegment thirdWeight = MemorySegment.ofArray(repeat(thirdRow, thirdRows));
+    float[] expectedFirst = new float[batchSize * firstRows];
+    float[] expectedSecond = new float[batchSize * secondRows];
+    float[] expectedThird = new float[batchSize * thirdRows];
+    float[] actualFirst = new float[batchSize * firstRows];
+    float[] actualSecond = new float[batchSize * secondRows];
+    float[] actualThird = new float[batchSize * thirdRows];
+    byte[] quants = new byte[batchSize * cols];
+    float[] scales = new float[batchSize * (cols / 32)];
+
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        expectedFirst,
+        quants,
+        scales,
+        new float[batchSize * firstRows * 8]);
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        expectedSecond,
+        quants,
+        scales,
+        new float[batchSize * secondRows * 8]);
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        thirdWeight,
+        batchSize,
+        thirdRows,
+        cols,
+        expectedThird,
+        quants,
+        scales,
+        new float[batchSize * thirdRows * 8]);
+
+    VectorUtil.ggufQ4_0Q8_0TripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        batchSize,
+        cols,
+        quants,
+        scales,
+        new float[batchSize * (firstRows + secondRows + thirdRows) * 8]);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q4_0Q8_0SingleQueryBatchMatchesGemvExactly() {
     int rows = 2;
     int cols = 32;


### PR DESCRIPTION
## Summary
- add exact dual and triple batched Q4_0/Q8_0 projection primitives
- quantize each activation batch once and share one combined row dispatch
- keep concurrent rows on disjoint caller-owned lane scratch
- document the retained Qwen3 real-model gate

## Validation
- ./gradlew :vectors-core:check
- Qwen3 0.6B Q4_0, Java 25, 18 trials per mode: median TTFT 3127.92 -> 3096.45 ms; prefill 49.59 -> 50.19 tok/s
- exact token counts and output hashes in all six counterbalanced pairs
- five-warmup allocation JFR: 9.99 MB total process allocation delta over ten prompts