### PR TITLE
perf(core): group batched Q8 projections

### DIFF
--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -29,7 +29,9 @@ MiniCPM5 1B median TTFT from 8330.16 to 7948.31 ms.
 These results do not imply that every projection shape benefits from grouped dispatch. A subsequent
 SmolLM2 360M gate retained Q8_0 batched dual dispatch for gate/up: median TTFT improved from 2612.09
 to 2581.73 ms and prefill from 60.22 to 61.01 tok/s across 18 trials per mode, with exact paired
-outputs. Q8_0 triple Q/K/V dispatch remains disabled in Models until its independent gate passes.
+outputs. A direct dual-only versus dual-plus-triple Q/K/V gate produced only a 0.14% TTFT shift,
+three faster and three slower pairs, and 6.68 MB higher median RSS. Models therefore keeps Q8_0
+Q/K/V independent. The exact generic triple API remains available for other model-specific gates.
 
 ## Dependencies
 

--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -26,8 +26,10 @@ warmups measured a 9.99 MB total allocation difference for the complete process,
 steady per-prefill allocation penalty. The previously retained mixed Q4_K/Q4_K/Q6_K path improved
 MiniCPM5 1B median TTFT from 8330.16 to 7948.31 ms.
 
-These results do not imply that every quantization format benefits from grouped dispatch. Q8_0
-remains disabled for batched grouping until its independent gate passes.
+These results do not imply that every projection shape benefits from grouped dispatch. A subsequent
+SmolLM2 360M gate retained Q8_0 batched dual dispatch for gate/up: median TTFT improved from 2612.09
+to 2581.73 ms and prefill from 60.22 to 61.01 tok/s across 18 trials per mode, with exact paired
+outputs. Q8_0 triple Q/K/V dispatch remains disabled in Models until its independent gate passes.
 
 ## Dependencies
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -3052,6 +3052,177 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void ggufQ8_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize == 1) {
+      ggufQ8_0Q8_0DualMatVecDot(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          cols,
+          q8Quants,
+          q8Scales);
+      return;
+    }
+    ggufQ8_0Q8_0GroupedBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        secondWeight,
+        0,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  @Override
+  public void ggufQ8_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize == 1) {
+      ggufQ8_0Q8_0TripleMatVecDot(
+          queries,
+          firstWeight,
+          firstRows,
+          firstOut,
+          secondWeight,
+          secondRows,
+          secondOut,
+          thirdWeight,
+          thirdRows,
+          thirdOut,
+          cols,
+          q8Quants,
+          q8Scales);
+      return;
+    }
+    ggufQ8_0Q8_0GroupedBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  private static void ggufQ8_0Q8_0GroupedBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q8_0_BLOCK_BYTES;
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    int effectiveCols = Math.multiplyExact(cols, batchSize);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        effectiveCols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> {
+          MemorySegment qWeight;
+          float[] out;
+          int matrixRow;
+          int matrixRows;
+          if (row < secondStart) {
+            qWeight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+            matrixRows = firstRows;
+          } else if (row < thirdStart) {
+            qWeight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+            matrixRows = secondRows;
+          } else {
+            qWeight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+            matrixRows = thirdRows;
+          }
+
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * matrixRows + matrixRow] = 0.0f;
+          }
+
+          long rowOffset = matrixRow * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            long weightOffset = blockOffset + Short.BYTES;
+            int blockActivationOffset = block * GGUF_Q_BLOCK_SIZE;
+            for (int batch = 0; batch < batchSize; batch++) {
+              float scale = weightScale * q8Scales[batch * blocks + block];
+              int integerSum =
+                  q8_0Q8_0IntegerDot(
+                      qWeight, weightOffset, q8Quants, batch * cols + blockActivationOffset);
+              int outputIndex = batch * matrixRows + matrixRow;
+              out[outputIndex] = MathUtil.fma(scale, integerSum, out[outputIndex]);
+            }
+          }
+        });
+  }
+
+  @Override
   public void ggufQ8_0Q8_0DualMatVecDot(
       float[] query,
       MemorySegment firstWeight,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1476,6 +1476,117 @@ public final class VectorUtil {
         queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
   }
 
+  /** Two Q8_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
+  public static void ggufQ8_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    checkGgufActivationScratch(
+        q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ8_0Q8_0DualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  /** Three Q8_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
+  public static void ggufQ8_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        firstWeight,
+        batchSize,
+        firstRows,
+        cols,
+        firstOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        secondWeight,
+        batchSize,
+        secondRows,
+        cols,
+        secondOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    checkGgufQuantizedBatchedArguments(
+        queries,
+        thirdWeight,
+        batchSize,
+        thirdRows,
+        cols,
+        thirdOut,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    checkGgufActivationScratch(
+        q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    IMPL.ggufQ8_0Q8_0TripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
   /**
    * Multiplies two Q8_0 matrices by the same activation with one Q8_0 quantization and one row
    * dispatch.

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1695,6 +1695,137 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Two Q8_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
+  default void ggufQ8_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    ggufQ8_0Q8_0GroupedBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        secondWeight,
+        0,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  /** Three Q8_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
+  default void ggufQ8_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    ggufQ8_0Q8_0GroupedBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales);
+  }
+
+  private static void ggufQ8_0Q8_0GroupedBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = ggufQ8_0RowBytes(cols);
+    int secondStart = firstRows;
+    int thirdStart = Math.addExact(firstRows, secondRows);
+    int totalRows = Math.addExact(thirdStart, thirdRows);
+    int effectiveCols = Math.multiplyExact(cols, batchSize);
+    GgufParallelSupport.forEachRow(
+        firstWeight,
+        secondWeight,
+        thirdWeight,
+        totalRows,
+        effectiveCols,
+        GgufParallelSupport.Q8_MIN_ELEMENTS,
+        row -> {
+          MemorySegment weight;
+          float[] out;
+          int matrixRow;
+          int matrixRows;
+          if (row < secondStart) {
+            weight = firstWeight;
+            out = firstOut;
+            matrixRow = row;
+            matrixRows = firstRows;
+          } else if (row < thirdStart) {
+            weight = secondWeight;
+            out = secondOut;
+            matrixRow = row - secondStart;
+            matrixRows = secondRows;
+          } else {
+            weight = thirdWeight;
+            out = thirdOut;
+            matrixRow = row - thirdStart;
+            matrixRows = thirdRows;
+          }
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * matrixRows + matrixRow] =
+                ggufQ8_0Q8_0ScalarRowDot(
+                    weight,
+                    matrixRow * rowBytes,
+                    blocks,
+                    q8Quants,
+                    batch * cols,
+                    q8Scales,
+                    batch * blocks);
+          }
+        });
+  }
+
   /** Two Q8_0 projections sharing one Q8_0 activation quantization and row dispatch. */
   default void ggufQ8_0Q8_0DualMatVecDot(
       float[] query,

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1082,6 +1082,97 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0DualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
+    int batchSize = 3;
+    int cols = 64;
+    int firstRows = 2;
+    int secondRows = 3;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow = repeat(q8Block(0.125f, index -> index * 7 - 53), 2);
+    byte[] secondRow = repeat(q8Block(-0.25f, index -> 61 - index * 5), 2);
+    MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
+    MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
+    float[] expectedFirst = new float[batchSize * firstRows];
+    float[] expectedSecond = new float[batchSize * secondRows];
+    float[] actualFirst = new float[batchSize * firstRows];
+    float[] actualSecond = new float[batchSize * secondRows];
+    byte[] quants = new byte[batchSize * cols];
+    float[] scales = new float[batchSize * (cols / 32)];
+
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries, firstWeight, batchSize, firstRows, cols, expectedFirst, quants, scales);
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries, secondWeight, batchSize, secondRows, cols, expectedSecond, quants, scales);
+
+    VectorUtil.ggufQ8_0Q8_0DualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        batchSize,
+        cols,
+        quants,
+        scales);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+  }
+
+  @Test
+  void q8_0Q8_0TripleBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
+    int batchSize = 3;
+    int cols = 64;
+    int firstRows = 2;
+    int secondRows = 3;
+    int thirdRows = 1;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow = repeat(q8Block(0.125f, index -> index * 7 - 53), 2);
+    byte[] secondRow = repeat(q8Block(-0.25f, index -> 61 - index * 5), 2);
+    byte[] thirdRow = repeat(q8Block(0.03125f, index -> index * 3 - 41), 2);
+    MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
+    MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
+    MemorySegment thirdWeight = MemorySegment.ofArray(repeat(thirdRow, thirdRows));
+    float[] expectedFirst = new float[batchSize * firstRows];
+    float[] expectedSecond = new float[batchSize * secondRows];
+    float[] expectedThird = new float[batchSize * thirdRows];
+    float[] actualFirst = new float[batchSize * firstRows];
+    float[] actualSecond = new float[batchSize * secondRows];
+    float[] actualThird = new float[batchSize * thirdRows];
+    byte[] quants = new byte[batchSize * cols];
+    float[] scales = new float[batchSize * (cols / 32)];
+
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries, firstWeight, batchSize, firstRows, cols, expectedFirst, quants, scales);
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries, secondWeight, batchSize, secondRows, cols, expectedSecond, quants, scales);
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries, thirdWeight, batchSize, thirdRows, cols, expectedThird, quants, scales);
+
+    VectorUtil.ggufQ8_0Q8_0TripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        actualFirst,
+        secondWeight,
+        secondRows,
+        actualSecond,
+        thirdWeight,
+        thirdRows,
+        actualThird,
+        batchSize,
+        cols,
+        quants,
+        scales);
+
+    assertThat(actualFirst).containsExactly(expectedFirst);
+    assertThat(actualSecond).containsExactly(expectedSecond);
+    assertThat(actualThird).containsExactly(expectedThird);
+  }
+
+  @Test
   void q8_0Q8_0BatchedMatmulMatchesGemvAtProjectionScaleAfterWarmup() {
     int batchSize = 4;
     int rows = 512;


### PR DESCRIPTION
Summary:
- Add exact dual and triple batched Q8_0 projection APIs across scalar and Panama implementations.
- Quantize each activation batch once and dispatch combined projection rows without scratch allocation.
- Retain the generic triple primitive while documenting that Models rejected Q8 Q/K/V routing on its current real-model gate.

Verification:
- ./gradlew :vectors-core:check
- Exact scalar/Panama dual and triple equivalence tests.
- SmolLM2 360M controlled dual gate: TTFT -1.16%, prefill +1.30%, exact paired outputs.
- Direct triple Q/K/V follow-up rejected: only -0.14% TTFT with +6.68 MB median RSS.