### PR TITLE
perf(core): batch Q5_0 prompt projections

### DIFF
--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -33,6 +33,24 @@ outputs. A direct dual-only versus dual-plus-triple Q/K/V gate produced only a 0
 three faster and three slower pairs, and 6.68 MB higher median RSS. Models therefore keeps Q8_0
 Q/K/V independent. The exact generic triple API remains available for other model-specific gates.
 
+## Q5_0 batched prefill gate
+
+The Q5_0/Q8_0 batch-major kernel closes the last missing batched prefill format used by the tested
+mixed-quantized models. On Java 25 and the controlled eight-vCPU AMD EPYC-Milan host, a 1024x2048
+matrix with batch 32, three warmups, and five measurements produced:
+
+| Path | Time | Allocation |
+| --- | ---: | ---: |
+| 32 independent GEMVs | 4.231 ms/op | 1,521.8 B/op |
+| Row-local batched kernel | 2.142 ms/op | 471.5 B/op |
+
+The retained kernel is 49.4% faster and allocates 69.0% fewer bytes per operation. Scalar/Panama
+and independent-GEMV tests require bit-exact output. A follow-up that decoded each packed weight
+block into four `IntVector` values before traversing the activation batch regressed to 2.955 ms/op,
+37.9% slower than the retained helper-based loop, with effectively unchanged allocation. That form
+was removed; keeping the decoded vectors live across the batch loop creates a worse compiled shape
+on this JDK/CPU.
+
 ## Dependencies
 
 - All Vectors library modules

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ5BatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ5BatchedMatmulBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares row-local Q5_0 batched matmul with independent GEMV calls. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ5BatchedMatmulBenchmark {
+
+  @Param({"1", "2", "4", "8", "32"})
+  int batchSize;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] queries;
+  private float[][] independentQueries;
+  private MemorySegment weights;
+  private float[] batchedOut;
+  private float[] independentOut;
+  private byte[] batchedQuants;
+  private float[] batchedScales;
+  private byte[] independentQuants;
+  private float[] independentScales;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(50L);
+    queries = new float[batchSize * cols];
+    independentQueries = new float[batchSize][cols];
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int col = 0; col < cols; col++) {
+        float value = random.nextFloat() * 2.0f - 1.0f;
+        queries[batch * cols + col] = value;
+        independentQueries[batch][col] = value;
+      }
+    }
+
+    byte[] blocks = randomQ5Blocks(random, rows * (cols / 32) * 22);
+    weights = MemorySegment.ofArray(blocks);
+    batchedOut = new float[batchSize * rows];
+    independentOut = new float[rows];
+    batchedQuants = new byte[batchSize * cols];
+    batchedScales = new float[batchSize * (cols / 32)];
+    independentQuants = new byte[cols];
+    independentScales = new float[cols / 32];
+  }
+
+  private static byte[] randomQ5Blocks(Random random, int byteCount) {
+    byte[] blocks = new byte[byteCount];
+    random.nextBytes(blocks);
+    ByteBuffer buffer = ByteBuffer.wrap(blocks).order(ByteOrder.LITTLE_ENDIAN);
+    short scale = Float.floatToFloat16(0.01f);
+    for (int offset = 0; offset < blocks.length; offset += 22) {
+      buffer.putShort(offset, scale);
+    }
+    return blocks;
+  }
+
+  @Benchmark
+  public void batched(Blackhole blackhole) {
+    VectorUtil.ggufQ5_0Q8_0BatchedMatmul(
+        queries, weights, batchSize, rows, cols, batchedOut, batchedQuants, batchedScales);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void independent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ5_0Q8_0BatchDotProduct(
+          query, weights, rows, cols, independentOut, independentQuants, independentScales);
+      blackhole.consume(independentOut);
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -2547,6 +2547,63 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  /** SIMD Q5_0 by a batch of Q8_0 activations with row-local weight reuse. */
+  @Override
+  public void ggufQ5_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize == 1) {
+      ggufQ5_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = (long) blocks * GGUF_Q5_0_BLOCK_BYTES;
+    int effectiveCols = Math.multiplyExact(cols, batchSize);
+    GgufParallelSupport.forEachRow(
+        qWeight,
+        rows,
+        effectiveCols,
+        row -> {
+          for (int batch = 0; batch < batchSize; batch++) {
+            out[batch * rows + row] = 0.0f;
+          }
+
+          long rowOffset = row * rowBytes;
+          for (int block = 0; block < blocks; block++) {
+            long blockOffset = rowOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+            int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+            long packedOffset = blockOffset + Short.BYTES + Integer.BYTES;
+            int blockActivationOffset = block * GGUF_Q_BLOCK_SIZE;
+            for (int batch = 0; batch < batchSize; batch++) {
+              int integerSum =
+                  q5_0Q8_0IntegerLanes(
+                          qWeight,
+                          packedOffset,
+                          highBits,
+                          q8Quants,
+                          batch * cols + blockActivationOffset)
+                      .reduceLanes(VectorOperators.ADD);
+              int outputIndex = batch * rows + row;
+              float scale = weightScale * q8Scales[batch * blocks + block];
+              out[outputIndex] = MathUtil.fma(scale, integerSum, out[outputIndex]);
+            }
+          }
+        });
+  }
+
   static IntVector q5_0Q8_0IntegerLanes(
       MemorySegment qWeight, long packedOffset, int highBits, byte[] q8Quants, int quantOffset) {
     IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1383,6 +1383,68 @@ public final class VectorUtil {
     IMPL.ggufQ5_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
   }
 
+  /**
+   * Multiplies one Q5_0 matrix by a batch-major collection of activation vectors.
+   *
+   * <p>{@code queries} is laid out as {@code [batchSize][cols]} and {@code out} as {@code
+   * [batchSize][rows]}. Each activation row is quantized independently to Q8_0 in caller-owned
+   * scratch before the matrix rows are evaluated.
+   *
+   * @param q8Quants scratch space with at least {@code batchSize * cols} entries
+   * @param q8Scales scratch space with at least {@code batchSize * (cols / 32)} entries
+   */
+  public static void ggufQ5_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    Objects.requireNonNull(queries, "queries");
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(q8Quants, "q8Quants");
+    Objects.requireNonNull(q8Scales, "q8Scales");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q5_0_BLOCK_BYTES);
+    int queryEntries = checkedProduct(batchSize, cols, "batchSize * cols");
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    int scaleEntries =
+        checkedProduct(batchSize, cols / VectorUtilSupport.GGUF_Q_BLOCK_SIZE, "batch Q8_0 scales");
+    if (queries.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "queries.length must be >= batchSize * cols: " + queries.length + " < " + queryEntries);
+    }
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    if (q8Quants.length < queryEntries) {
+      throw new IllegalArgumentException(
+          "q8Quants.length must be >= batchSize * cols: " + q8Quants.length + " < " + queryEntries);
+    }
+    if (q8Scales.length < scaleEntries) {
+      throw new IllegalArgumentException(
+          "q8Scales.length must be >= batch Q8_0 scales: "
+              + q8Scales.length
+              + " < "
+              + scaleEntries);
+    }
+    IMPL.ggufQ5_0Q8_0BatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+  }
+
   /** Batched row-major GEMV over GGUF Q8_0 rows. */
   public static void ggufQ8_0BatchDotProduct(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1494,6 +1494,52 @@ public interface VectorUtilSupport {
         });
   }
 
+  /** Q5_0 matrix multiplication over batch-major Q8_0-quantized activation rows. */
+  default void ggufQ5_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      GgufQuantizationSupport.quantizeQ8_0(
+          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+    }
+
+    long rowBytes = ggufQ5_0RowBytes(cols);
+    for (int row = 0; row < rows; row++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        out[batch * rows + row] = 0.0f;
+      }
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+        float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+        int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+        long quantsOffset = blockOffset + Short.BYTES + Integer.BYTES;
+        int blockActivationOffset = block * GGUF_Q_BLOCK_SIZE;
+        for (int batch = 0; batch < batchSize; batch++) {
+          int activationOffset = batch * cols + blockActivationOffset;
+          int integerSum = 0;
+          for (int index = 0; index < 16; index++) {
+            int packed = qWeight.get(ValueLayout.JAVA_BYTE, quantsOffset + index) & 0xFF;
+            int low = (packed & 0x0F) | (((highBits >>> index) & 1) << 4);
+            int high = (packed >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
+            integerSum += (low - 16) * q8Quants[activationOffset + index];
+            integerSum += (high - 16) * q8Quants[activationOffset + index + 16];
+          }
+          int outputIndex = batch * rows + row;
+          float scale = weightScale * q8Scales[batch * blocks + block];
+          out[outputIndex] = MathUtil.fma(scale, integerSum, out[outputIndex]);
+        }
+      }
+    }
+  }
+
   /** Batched row-major GEMV over GGUF Q6_K rows. */
   default void ggufQ6_KMatVecDot(
       float[] query, MemorySegment qWeight, int rows, int cols, float[] out) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -2318,6 +2318,67 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_0Q8_0BatchedMatmulMatchesIndependentQueriesExactly() {
+    int batchSize = 3;
+    int rows = 2;
+    int cols = 64;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow =
+        concat(
+            q5Block(0.125f, index -> (index * 7) % 32 - 16),
+            q5Block(-0.25f, index -> 15 - (index * 5) % 32));
+    byte[] secondRow =
+        concat(
+            q5Block(0.0625f, index -> (index * 11) % 32 - 16),
+            q5Block(0.5f, index -> 15 - (index * 3) % 32));
+    MemorySegment weights = MemorySegment.ofArray(concat(firstRow, secondRow));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] query = new float[cols];
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      System.arraycopy(queries, batch * cols, query, 0, cols);
+      float[] result = new float[rows];
+      VectorUtil.ggufQ5_0Q8_0BatchDotProduct(
+          query, weights, rows, cols, result, new byte[cols], new float[cols / 32]);
+      System.arraycopy(result, 0, expected, batch * rows, rows);
+    }
+
+    VectorUtil.ggufQ5_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q5_0Q8_0BatchedMatmulRejectsUndersizedScaleScratch() {
+    int batchSize = 2;
+    int cols = 32;
+    MemorySegment weights = MemorySegment.ofArray(q5Block(1.0f, ignored -> 1));
+
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ5_0Q8_0BatchedMatmul(
+                    new float[batchSize * cols],
+                    weights,
+                    batchSize,
+                    1,
+                    cols,
+                    new float[batchSize],
+                    new byte[batchSize * cols],
+                    new float[batchSize - 1]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("q8Scales");
+  }
+
+  @Test
   void quantizedDotRejectsNonBlockAlignedDimensions() {
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment q4 = copy(arena, q4Block(1.0f, ones(32), null));

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -250,7 +250,7 @@ class PanamaGgufQuantizedDotTest {
   void panamaProviderOwnsQ5_0Q8_0Kernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
-        .contains("ggufQ5_0Q8_0MatVecDot");
+        .contains("ggufQ5_0Q8_0MatVecDot", "ggufQ5_0Q8_0BatchedMatmul");
   }
 
   @Test
@@ -505,6 +505,51 @@ class PanamaGgufQuantizedDotTest {
     new PanamaVectorUtilSupport()
         .ggufQ5_0Q8_0MatVecDot(
             query, weightSegment, rows, cols, actual, actualQuants, actualScales);
+
+    assertThat(actualQuants).containsExactly(expectedQuants);
+    assertThat(actualScales).containsExactly(expectedScales);
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q5_0Q8_0BatchedKernelMatchesScalarReferenceExactly() {
+    int batchSize = 4;
+    int rows = 17;
+    int cols = 256;
+    Random random = new Random(0xB515048L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 22];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 22) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    byte[] expectedQuants = new byte[batchSize * cols];
+    byte[] actualQuants = new byte[batchSize * cols];
+    float[] expectedScales = new float[batchSize * (cols / 32)];
+    float[] actualScales = new float[batchSize * (cols / 32)];
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+
+    new ScalarVectorUtilSupport()
+        .ggufQ5_0Q8_0BatchedMatmul(
+            queries,
+            weightSegment,
+            batchSize,
+            rows,
+            cols,
+            expected,
+            expectedQuants,
+            expectedScales);
+    new PanamaVectorUtilSupport()
+        .ggufQ5_0Q8_0BatchedMatmul(
+            queries, weightSegment, batchSize, rows, cols, actual, actualQuants, actualScales);
 
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);


### PR DESCRIPTION
## Summary

- add scalar and Panama Q5_0/Q8_0 batch-major matrix multiplication
- validate exact output against independent GEMVs and across providers
- add a Q5_0 JMH fixture and record the controlled Java 25 gate

## Why

Q5_0 was the last quantized projection format in the tested DeepSeek-Coder 1.3B graph without a
batched prefill operation. That omission forced the complete mixed-quantized model to process
prompt tokens sequentially.

## Performance

On the controlled eight-vCPU AMD EPYC-Milan host, the retained batch-32 kernel measured 2.142 ms/op
versus 4.231 ms/op for 32 independent GEMVs, a 49.4% reduction. Normalized allocation fell from
1,521.8 to 471.5 B/op with no collections. A predecoded-weight candidate regressed to 2.955 ms/op
and was removed.

## Validation

- `./gradlew :vectors-core:check`
- `./gradlew :vectors-bench:jmhClasses`
- scalar/Panama bit-exact batch tests
- controlled JMH with three warmups, five measurements, and GC profiling
