### PR TITLE
perf(core): add opt-in Graal Q4 pairwise kernel

### DIFF
--- a/docs/content/modules/ROOT/pages/architecture.adoc
+++ b/docs/content/modules/ROOT/pages/architecture.adoc
@@ -171,6 +171,14 @@ Set `-Dvectors.gguf.parallel=false` to force serial GGUF execution, or raise the
 with `-Dvectors.gguf.parallelThreshold=<elements>`. The active values are included in the
 `vectors-core` startup diagnostic line.
 
+An experimental Q4_0/Q8_0 signed-short pairwise kernel is available for measured GraalVM
+deployments. It is disabled by default and activates only for 256-bit vectors and rows of at least
+1,024 dimensions. The accepted Qwen3 profile uses both
+`-Djdk.graal.MaximumInliningSize=10000` and `-Dvectors.gguf.q4ShortPairwise=true`; enabling only the
+Vectors property can create substantial temporary Vector API allocations. See
+`vectors-bench/jmh-results/graal-q4-short-pairwise.md` in the source repository for the exact JVM
+revision, correctness gate, performance evidence, and rollback procedure.
+
 == Memory Model
 
 * **Vectors** are stored off-heap via `MemorySegment` in persistent mode, or as `float[][]` on the heap in memory mode.

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -85,6 +85,14 @@
         <Class name="com.integrallis.vectors.core.GgufRowDispatchBenchmark"/>
         <Bug pattern="URF_UNREAD_FIELD"/>
     </Match>
+    <!-- vectors-bench: GgufQ4PairwiseDotBenchmark's mapped weights and Q8 activation state are
+         written by @Setup and read by rowDot(), which is reached by both @Benchmark methods.
+         The getfield instructions are present in the compiled bytecode, but SpotBugs misses the
+         reads while analyzing the generated JMH source set, as with GgufRowDispatchBenchmark. -->
+    <Match>
+        <Class name="com.integrallis.vectors.core.GgufQ4PairwiseDotBenchmark"/>
+        <Bug pattern="URF_UNREAD_FIELD"/>
+    </Match>
     <!-- HNSW: SearchResult record exposes/stores arrays intentionally for zero-copy access -->
     <Match>
         <Class name="com.integrallis.vectors.hnsw.SearchResult"/>

--- a/vectors-bench/jmh-results/graal-q4-short-pairwise.md
+++ b/vectors-bench/jmh-results/graal-q4-short-pairwise.md
@@ -1,0 +1,114 @@
+# Graal Q4_0 Signed-Short Pairwise Gate
+
+Date: 2026-07-19 (America/Phoenix; measurements completed 2026-07-20 UTC)
+
+This report records the acceptance evidence for the experimental
+`vectors.gguf.q4ShortPairwise` kernel. The default remains `false`. The retained deployment
+profile requires a post-fix Graal compiler and a larger per-callee exploration limit:
+
+```text
+-Djdk.graal.MaximumInliningSize=10000
+-Dvectors.gguf.q4ShortPairwise=true
+```
+
+It does not require `CompileCommand`, internal JDK annotations, or a higher Java bytecode level.
+Vectors continues to compile, test, and publish for Java 25.
+
+To roll back, remove `vectors.gguf.q4ShortPairwise` or set it to `false`; the established widened
+kernel remains the default. The Graal inlining limit can then also be removed.
+
+## Environment
+
+- Vectors candidate: `b3aece4`
+- Models control: `ab12fff`
+- Controlled host: AMD EPYC Milan, 4 physical cores / 8 vCPUs, AVX2, 30 GiB
+- JVM: GraalVM CE 25.0.3+9-jvmci-25.1-b19, development build from 2026-07-17
+- Vector width: 256 bits
+- Model: Qwen3-0.6B-Q4_0, SHA-256
+  `da2572f16c06133561ce56accaa822216f2391ef4d37fba427801cd6736417d4`
+- Prompt SHA-256: `2db2d875631cc7e3af3f6e4471ae4c9b2b7dfdb31ab561a41ef78182a31532e6`
+
+## Kernel
+
+The candidate preserves Q4_0's signed nibble decode and Q8_0's full signed-byte domain. It widens
+both operands to signed shorts, expresses adjacent short multiply-add as the expanded Vector API
+graph recognized by Graal's `AMD64SimdPairwiseMultiplyAddNode`, and then combines adjacent integer
+pairs into the established four-product lanes. Graal lowers the central graph to `VPMADDWD`.
+
+The production route is admitted only when all of these conditions hold:
+
+- `vectors.gguf.q4ShortPairwise=true` was set before Vectors initializes;
+- the active Vector API width is at least 256 bits; and
+- the row has at least 32 Q4 blocks, or 1,024 dimensions.
+
+The widened kernel remains active for every other shape. Ten thousand randomized blocks, including
+`Byte.MIN_VALUE` Q8 values and nibble-boundary cases, matched the widened kernel lane for lane.
+
+## Kernel Gate
+
+The final production GEMV benchmark used a 1024x2048 Q4_0 matrix, three forks, five one-second
+warmups, five three-second measurements, eight persistent workers, and the final two-property
+profile above. Neither mode collected a GC.
+
+| Production GEMV | Widened | Short pairwise | Change |
+| --- | ---: | ---: | ---: |
+| Average time | 0.094 +/- 0.003 ms/op | 0.073 +/- 0.004 ms/op | -22.3% |
+| Normalized allocation | 51.67 B/op | 47.22 B/op | no material change |
+
+The 99.9% confidence intervals do not overlap. The result uses the public production entry point,
+not only a package-private arithmetic helper.
+
+## Full Model Gate
+
+Qwen used a 2,048-token context, eight threads, batch-32 prompt processing, final-layer K/V-only
+prompt rows, two warmups, and three measured 64-token greedy trials in each of four counterbalanced
+process pairs. Both modes used `-Djdk.graal.MaximumInliningSize=10000`; the only difference was the
+Vectors kernel property.
+
+| Qwen3 Q4_0 metric | Widened | Short pairwise | Change |
+| --- | ---: | ---: | ---: |
+| Median decode | 28.7519 tok/s | 34.8445 tok/s | +21.19% |
+| Median prefill | 70.0064 tok/s | 88.5120 tok/s | +26.43% |
+| Median TTFT | 2,220.8 ms | 1,757.5 ms | -20.86% |
+| Mean trial CPU | 29,690.8 ms | 23,250.8 ms | -21.69% |
+
+All 12 paired trials matched input-token count, output-token count, and output SHA-256. Peak RSS
+was lifecycle-sensitive and varied by several hundred MiB between otherwise equivalent processes;
+no memory-capacity claim is made from the process high-water marks.
+
+## Rejected Configurations
+
+- Unsigned-byte/signed-byte 256-bit graphs were exact but shape expansion prevented scalar
+  replacement and created roughly 10 KiB per block invocation.
+- Signed and offset-corrected 128-bit byte-pairwise graphs were allocation-free only after extra
+  activation sums, then remained 37-50% slower than widening.
+- The retained signed-short graph without a larger Graal inlining limit allocated approximately
+  117 MiB per 1024x2048 GEMV and took about 3.58 ms/op. This is why the Vectors property is not an
+  independent tuning switch.
+- Raising `TrivialInliningSize`, `MaximumInliningSize`, and the global desired graph budget together
+  made full-model performance bimodal and drove otherwise unchanged Qwen processes to about
+  9 tok/s. Global aggressive inlining is rejected.
+- `CompileCommand=inline` for only the helper methods worked in several processes but remained
+  nondeterministic across JMH forks until `MaximumInliningSize` was raised. The commands are not
+  part of the final profile.
+- `jdk.internal.vm.annotation.ForceInline` on application methods was ignored by this Graal build.
+  It left all three candidate forks at about 3.58 ms/op and 117 MiB/op, so no internal JDK API or
+  module export is retained.
+
+## Reproduction
+
+Build the Java 25 benchmark JAR:
+
+```bash
+./gradlew :vectors-core:check :vectors-bench:jmhJar
+```
+
+Run the widened control, then repeat with `vectors.gguf.q4ShortPairwise=true`:
+
+```bash
+java -jar vectors-bench/build/libs/vectors-bench-0.1.0-SNAPSHOT-jmh.jar \
+  GgufQuantizedMatVecBenchmark.q4_0WithQ8_0Activation \
+  -p rows=1024 -p cols=2048 -wi 5 -i 5 -w 1s -r 3s -f 3 -prof gc \
+  -jvmArgsAppend \
+  '-Djdk.graal.MaximumInliningSize=10000 -Dvectors.gguf.q4ShortPairwise=false'
+```

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -94,11 +94,12 @@ public class GgufQ4PairwiseDotBenchmark {
     float offsetPairwise = offsetPairwise();
     float offsetPairwise128 = offsetPairwise128();
     float precomputedOffsetPairwise128 = precomputedOffsetPairwise128();
+    float pairwise128 = pairwise128();
     if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)
         || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)
         || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise128)
-        || Float.floatToRawIntBits(widened)
-            != Float.floatToRawIntBits(precomputedOffsetPairwise128)) {
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(precomputedOffsetPairwise128)
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise128)) {
       throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
     }
   }
@@ -193,6 +194,41 @@ public class GgufQ4PairwiseDotBenchmark {
               q8GroupSums,
               sumOffset + 4,
               true);
+      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
+      lowAccumulator =
+          PanamaVectorUtilSupport.fma(
+              (FloatVector) lowLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              lowAccumulator);
+      highAccumulator =
+          PanamaVectorUtilSupport.fma(
+              (FloatVector) highLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              highAccumulator);
+    }
+    float even =
+        (highAccumulator.lane(0) + lowAccumulator.lane(0))
+            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
+    float odd =
+        (highAccumulator.lane(1) + lowAccumulator.lane(1))
+            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
+    return even + odd;
+  }
+
+  @Benchmark
+  public float pairwise128() {
+    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      int quantOffset = block * BLOCK_SIZE;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      IntVector lowLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(
+              weights, blockOffset + Short.BYTES, q8Quants, quantOffset, false);
+      IntVector highLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(
+              weights, blockOffset + Short.BYTES, q8Quants, quantOffset + 16, true);
       FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
       lowAccumulator =
           PanamaVectorUtilSupport.fma(

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -83,8 +83,10 @@ public class GgufQ4PairwiseDotBenchmark {
     float widened = widened();
     float pairwise = pairwise();
     float offsetPairwise = offsetPairwise();
+    float offsetPairwise128 = offsetPairwise128();
     if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)) {
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise128)) {
       throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
     }
   }
@@ -115,6 +117,41 @@ public class GgufQ4PairwiseDotBenchmark {
               products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
     }
     return accumulator.reduceLanes(VectorOperators.ADD);
+  }
+
+  @Benchmark
+  public float offsetPairwise128() {
+    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      int quantOffset = block * BLOCK_SIZE;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      IntVector lowLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
+              weights, blockOffset + Short.BYTES, q8Quants, quantOffset, false);
+      IntVector highLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
+              weights, blockOffset + Short.BYTES, q8Quants, quantOffset + 16, true);
+      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
+      lowAccumulator =
+          PanamaVectorUtilSupport.fma(
+              (FloatVector) lowLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              lowAccumulator);
+      highAccumulator =
+          PanamaVectorUtilSupport.fma(
+              (FloatVector) highLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              highAccumulator);
+    }
+    float even =
+        (highAccumulator.lane(0) + lowAccumulator.lane(0))
+            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
+    float odd =
+        (highAccumulator.lane(1) + lowAccumulator.lane(1))
+            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
+    return even + odd;
   }
 
   private float rowDot(boolean usePairwise) {

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -82,7 +82,9 @@ public class GgufQ4PairwiseDotBenchmark {
 
     float widened = widened();
     float pairwise = pairwise();
-    if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)) {
+    float offsetPairwise = offsetPairwise();
+    if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)) {
       throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
     }
   }
@@ -95,6 +97,24 @@ public class GgufQ4PairwiseDotBenchmark {
   @Benchmark
   public float pairwise() {
     return rowDot(true);
+  }
+
+  @Benchmark
+  public float offsetPairwise() {
+    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      IntVector integerLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwiseIntegerLanes(
+              weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE);
+      FloatVector products =
+          (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+      accumulator =
+          PanamaVectorUtilSupport.fma(
+              products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+    }
+    return accumulator.reduceLanes(VectorOperators.ADD);
   }
 
   private float rowDot(boolean usePairwise) {

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -36,7 +36,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-/** Compares widened and packed-pairwise Q4_0 by Q8_0 row kernels. */
+/** Compares widened and signed-short pairwise Q4_0 by Q8_0 row kernels. */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
@@ -57,7 +57,6 @@ public class GgufQ4PairwiseDotBenchmark {
 
   private MemorySegment weights;
   private byte[] q8Quants;
-  private int[] q8GroupSums;
   private float[] q8Scales;
 
   @Setup(Level.Trial)
@@ -65,7 +64,6 @@ public class GgufQ4PairwiseDotBenchmark {
     Random random = new Random(0x514750414952L);
     byte[] weightBytes = new byte[blocks * BLOCK_BYTES];
     q8Quants = new byte[blocks * BLOCK_SIZE];
-    q8GroupSums = new int[blocks * 8];
     q8Scales = new float[blocks];
     for (int block = 0; block < blocks; block++) {
       int weightOffset = block * BLOCK_BYTES;
@@ -78,30 +76,13 @@ public class GgufQ4PairwiseDotBenchmark {
       for (int index = 0; index < BLOCK_SIZE; index++) {
         q8Quants[block * BLOCK_SIZE + index] = (byte) random.nextInt(-127, 128);
       }
-      for (int group = 0; group < 8; group++) {
-        int sum = 0;
-        for (int index = 0; index < 4; index++) {
-          sum += q8Quants[block * BLOCK_SIZE + group * 4 + index];
-        }
-        q8GroupSums[block * 8 + group] = sum;
-      }
       q8Scales[block] = 0.001f + random.nextFloat() * 0.05f;
     }
     weights = MemorySegment.ofArray(weightBytes);
 
     float widened = widened();
-    float pairwise = pairwise();
-    float offsetPairwise = offsetPairwise();
-    float offsetPairwise128 = offsetPairwise128();
-    float precomputedOffsetPairwise128 = precomputedOffsetPairwise128();
-    float pairwise128 = pairwise128();
     float shortPairwise = shortPairwise();
-    if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise128)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(precomputedOffsetPairwise128)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise128)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(shortPairwise)) {
+    if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(shortPairwise)) {
       throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
     }
   }
@@ -112,172 +93,18 @@ public class GgufQ4PairwiseDotBenchmark {
   }
 
   @Benchmark
-  public float pairwise() {
+  public float shortPairwise() {
     return rowDot(true);
   }
 
-  @Benchmark
-  public float offsetPairwise() {
+  private float rowDot(boolean useShortPairwise) {
     FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
     for (int block = 0; block < blocks; block++) {
       long blockOffset = (long) block * BLOCK_BYTES;
       float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
       IntVector integerLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwiseIntegerLanes(
-              weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE);
-      FloatVector products =
-          (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-      accumulator =
-          PanamaVectorUtilSupport.fma(
-              products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
-    }
-    return reduce256(accumulator);
-  }
-
-  @Benchmark
-  public float offsetPairwise128() {
-    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    for (int block = 0; block < blocks; block++) {
-      long blockOffset = (long) block * BLOCK_BYTES;
-      int quantOffset = block * BLOCK_SIZE;
-      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      IntVector lowLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
-              weights, blockOffset + Short.BYTES, q8Quants, quantOffset, false);
-      IntVector highLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
-              weights, blockOffset + Short.BYTES, q8Quants, quantOffset + 16, true);
-      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
-      lowAccumulator =
-          PanamaVectorUtilSupport.fma(
-              (FloatVector) lowLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              lowAccumulator);
-      highAccumulator =
-          PanamaVectorUtilSupport.fma(
-              (FloatVector) highLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              highAccumulator);
-    }
-    float even =
-        (highAccumulator.lane(0) + lowAccumulator.lane(0))
-            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
-    float odd =
-        (highAccumulator.lane(1) + lowAccumulator.lane(1))
-            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
-    return even + odd;
-  }
-
-  @Benchmark
-  public float precomputedOffsetPairwise128() {
-    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    for (int block = 0; block < blocks; block++) {
-      long blockOffset = (long) block * BLOCK_BYTES;
-      int quantOffset = block * BLOCK_SIZE;
-      int sumOffset = block * 8;
-      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      IntVector lowLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
-              weights,
-              blockOffset + Short.BYTES,
-              q8Quants,
-              quantOffset,
-              q8GroupSums,
-              sumOffset,
-              false);
-      IntVector highLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
-              weights,
-              blockOffset + Short.BYTES,
-              q8Quants,
-              quantOffset + 16,
-              q8GroupSums,
-              sumOffset + 4,
-              true);
-      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
-      lowAccumulator =
-          PanamaVectorUtilSupport.fma(
-              (FloatVector) lowLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              lowAccumulator);
-      highAccumulator =
-          PanamaVectorUtilSupport.fma(
-              (FloatVector) highLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              highAccumulator);
-    }
-    float even =
-        (highAccumulator.lane(0) + lowAccumulator.lane(0))
-            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
-    float odd =
-        (highAccumulator.lane(1) + lowAccumulator.lane(1))
-            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
-    return even + odd;
-  }
-
-  @Benchmark
-  public float pairwise128() {
-    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    for (int block = 0; block < blocks; block++) {
-      long blockOffset = (long) block * BLOCK_BYTES;
-      int quantOffset = block * BLOCK_SIZE;
-      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      IntVector lowLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(
-              weights, blockOffset + Short.BYTES, q8Quants, quantOffset, false);
-      IntVector highLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(
-              weights, blockOffset + Short.BYTES, q8Quants, quantOffset + 16, true);
-      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
-      lowAccumulator =
-          PanamaVectorUtilSupport.fma(
-              (FloatVector) lowLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              lowAccumulator);
-      highAccumulator =
-          PanamaVectorUtilSupport.fma(
-              (FloatVector) highLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              highAccumulator);
-    }
-    float even =
-        (highAccumulator.lane(0) + lowAccumulator.lane(0))
-            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
-    float odd =
-        (highAccumulator.lane(1) + lowAccumulator.lane(1))
-            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
-    return even + odd;
-  }
-
-  @Benchmark
-  public float shortPairwise() {
-    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
-    for (int block = 0; block < blocks; block++) {
-      long blockOffset = (long) block * BLOCK_BYTES;
-      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      IntVector integerLanes =
-          PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
-              weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE);
-      FloatVector products =
-          (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
-      accumulator =
-          PanamaVectorUtilSupport.fma(
-              products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
-    }
-    return reduce256(accumulator);
-  }
-
-  private float rowDot(boolean usePairwise) {
-    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
-    for (int block = 0; block < blocks; block++) {
-      long blockOffset = (long) block * BLOCK_BYTES;
-      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      IntVector integerLanes =
-          usePairwise
-              ? PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(
+          useShortPairwise
+              ? PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
                   weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE)
               : PanamaVectorUtilSupport.q4_0Q8_0IntegerLanes(
                   weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE);

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -95,11 +95,13 @@ public class GgufQ4PairwiseDotBenchmark {
     float offsetPairwise128 = offsetPairwise128();
     float precomputedOffsetPairwise128 = precomputedOffsetPairwise128();
     float pairwise128 = pairwise128();
+    float shortPairwise = shortPairwise();
     if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)
         || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)
         || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise128)
         || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(precomputedOffsetPairwise128)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise128)) {
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise128)
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(shortPairwise)) {
       throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
     }
   }
@@ -248,6 +250,24 @@ public class GgufQ4PairwiseDotBenchmark {
         (highAccumulator.lane(1) + lowAccumulator.lane(1))
             + (highAccumulator.lane(3) + lowAccumulator.lane(3));
     return even + odd;
+  }
+
+  @Benchmark
+  public float shortPairwise() {
+    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      IntVector integerLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
+              weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE);
+      FloatVector products =
+          (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+      accumulator =
+          PanamaVectorUtilSupport.fma(
+              products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+    }
+    return reduce256(accumulator);
   }
 
   private float rowDot(boolean usePairwise) {

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -57,6 +57,7 @@ public class GgufQ4PairwiseDotBenchmark {
 
   private MemorySegment weights;
   private byte[] q8Quants;
+  private int[] q8GroupSums;
   private float[] q8Scales;
 
   @Setup(Level.Trial)
@@ -64,6 +65,7 @@ public class GgufQ4PairwiseDotBenchmark {
     Random random = new Random(0x514750414952L);
     byte[] weightBytes = new byte[blocks * BLOCK_BYTES];
     q8Quants = new byte[blocks * BLOCK_SIZE];
+    q8GroupSums = new int[blocks * 8];
     q8Scales = new float[blocks];
     for (int block = 0; block < blocks; block++) {
       int weightOffset = block * BLOCK_BYTES;
@@ -76,6 +78,13 @@ public class GgufQ4PairwiseDotBenchmark {
       for (int index = 0; index < BLOCK_SIZE; index++) {
         q8Quants[block * BLOCK_SIZE + index] = (byte) random.nextInt(-127, 128);
       }
+      for (int group = 0; group < 8; group++) {
+        int sum = 0;
+        for (int index = 0; index < 4; index++) {
+          sum += q8Quants[block * BLOCK_SIZE + group * 4 + index];
+        }
+        q8GroupSums[block * 8 + group] = sum;
+      }
       q8Scales[block] = 0.001f + random.nextFloat() * 0.05f;
     }
     weights = MemorySegment.ofArray(weightBytes);
@@ -84,9 +93,12 @@ public class GgufQ4PairwiseDotBenchmark {
     float pairwise = pairwise();
     float offsetPairwise = offsetPairwise();
     float offsetPairwise128 = offsetPairwise128();
+    float precomputedOffsetPairwise128 = precomputedOffsetPairwise128();
     if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)
         || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise)
-        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise128)) {
+        || Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(offsetPairwise128)
+        || Float.floatToRawIntBits(widened)
+            != Float.floatToRawIntBits(precomputedOffsetPairwise128)) {
       throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
     }
   }
@@ -133,6 +145,54 @@ public class GgufQ4PairwiseDotBenchmark {
       IntVector highLanes =
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
               weights, blockOffset + Short.BYTES, q8Quants, quantOffset + 16, true);
+      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
+      lowAccumulator =
+          PanamaVectorUtilSupport.fma(
+              (FloatVector) lowLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              lowAccumulator);
+      highAccumulator =
+          PanamaVectorUtilSupport.fma(
+              (FloatVector) highLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              highAccumulator);
+    }
+    float even =
+        (highAccumulator.lane(0) + lowAccumulator.lane(0))
+            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
+    float odd =
+        (highAccumulator.lane(1) + lowAccumulator.lane(1))
+            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
+    return even + odd;
+  }
+
+  @Benchmark
+  public float precomputedOffsetPairwise128() {
+    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      int quantOffset = block * BLOCK_SIZE;
+      int sumOffset = block * 8;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      IntVector lowLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
+              weights,
+              blockOffset + Short.BYTES,
+              q8Quants,
+              quantOffset,
+              q8GroupSums,
+              sumOffset,
+              false);
+      IntVector highLanes =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
+              weights,
+              blockOffset + Short.BYTES,
+              q8Quants,
+              quantOffset + 16,
+              q8GroupSums,
+              sumOffset + 4,
+              true);
       FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
       lowAccumulator =
           PanamaVectorUtilSupport.fma(

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorOperators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Compares widened and packed-pairwise Q4_0 by Q8_0 row kernels. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ4PairwiseDotBenchmark {
+
+  private static final int BLOCK_BYTES = 18;
+  private static final int BLOCK_SIZE = 32;
+  private static final ValueLayout.OfShort LE_SHORT =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  @Param({"1", "32", "64"})
+  int blocks;
+
+  private MemorySegment weights;
+  private byte[] q8Quants;
+  private float[] q8Scales;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(0x514750414952L);
+    byte[] weightBytes = new byte[blocks * BLOCK_BYTES];
+    q8Quants = new byte[blocks * BLOCK_SIZE];
+    q8Scales = new float[blocks];
+    for (int block = 0; block < blocks; block++) {
+      int weightOffset = block * BLOCK_BYTES;
+      short scale = Float.floatToFloat16(0.001f + random.nextFloat() * 0.05f);
+      weightBytes[weightOffset] = (byte) scale;
+      weightBytes[weightOffset + 1] = (byte) (scale >>> 8);
+      for (int index = 0; index < 16; index++) {
+        weightBytes[weightOffset + Short.BYTES + index] = (byte) random.nextInt();
+      }
+      for (int index = 0; index < BLOCK_SIZE; index++) {
+        q8Quants[block * BLOCK_SIZE + index] = (byte) random.nextInt(-127, 128);
+      }
+      q8Scales[block] = 0.001f + random.nextFloat() * 0.05f;
+    }
+    weights = MemorySegment.ofArray(weightBytes);
+
+    float widened = widened();
+    float pairwise = pairwise();
+    if (Float.floatToRawIntBits(widened) != Float.floatToRawIntBits(pairwise)) {
+      throw new IllegalStateException("Q4 pairwise benchmark kernels disagree");
+    }
+  }
+
+  @Benchmark
+  public float widened() {
+    return rowDot(false);
+  }
+
+  @Benchmark
+  public float pairwise() {
+    return rowDot(true);
+  }
+
+  private float rowDot(boolean usePairwise) {
+    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      IntVector integerLanes =
+          usePairwise
+              ? PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(
+                  weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE)
+              : PanamaVectorUtilSupport.q4_0Q8_0IntegerLanes(
+                  weights, blockOffset + Short.BYTES, q8Quants, block * BLOCK_SIZE);
+      FloatVector products =
+          (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+      accumulator =
+          PanamaVectorUtilSupport.fma(
+              products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
+    }
+    return accumulator.reduceLanes(VectorOperators.ADD);
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4PairwiseDotBenchmark.java
@@ -116,7 +116,7 @@ public class GgufQ4PairwiseDotBenchmark {
           PanamaVectorUtilSupport.fma(
               products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
     }
-    return accumulator.reduceLanes(VectorOperators.ADD);
+    return reduce256(accumulator);
   }
 
   @Benchmark
@@ -171,6 +171,12 @@ public class GgufQ4PairwiseDotBenchmark {
           PanamaVectorUtilSupport.fma(
               products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator);
     }
-    return accumulator.reduceLanes(VectorOperators.ADD);
+    return reduce256(accumulator);
+  }
+
+  private static float reduce256(FloatVector vector) {
+    float even = (vector.lane(4) + vector.lane(0)) + (vector.lane(6) + vector.lane(2));
+    float odd = (vector.lane(5) + vector.lane(1)) + (vector.lane(7) + vector.lane(3));
+    return even + odd;
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
@@ -49,6 +49,7 @@ public final class PanamaConstants {
   private static final int SMALLEST_SIMD_BITS = 64;
   private static final int LARGEST_SIMD_BITS = 512;
   static final String MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY = "vectors.gguf.mappedKQuantLongOffsets";
+  static final String Q4_SHORT_PAIRWISE_PROPERTY = "vectors.gguf.q4ShortPairwise";
 
   enum MappedKQuantFormat {
     Q4_K,
@@ -75,6 +76,8 @@ public final class PanamaConstants {
   static final boolean USE_MAPPED_Q4_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q4();
   static final boolean USE_MAPPED_Q5_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q5();
   static final boolean USE_MAPPED_Q6_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q6();
+  static final boolean USE_Q4_SHORT_PAIRWISE =
+      resolveQ4ShortPairwise(System.getProperty(Q4_SHORT_PAIRWISE_PROPERTY));
 
   /**
    * The resolved SIMD register-width ceiling in bits. Defaults to {@link #DEFAULT_MAX_BITS};
@@ -178,6 +181,19 @@ public final class PanamaConstants {
 
   static MappedKQuantLongOffsetPolicy mappedKQuantLongOffsetPolicy() {
     return MAPPED_K_QUANT_LONG_OFFSET_POLICY;
+  }
+
+  static boolean resolveQ4ShortPairwise(String configured) {
+    if (configured == null || configured.isBlank()) {
+      return false;
+    }
+    return switch (configured.trim().toLowerCase(Locale.ROOT)) {
+      case "true" -> true;
+      case "false" -> false;
+      default ->
+          throw new IllegalArgumentException(
+              "-D" + Q4_SHORT_PAIRWISE_PROPERTY + " must be true or false; got: " + configured);
+    };
   }
 
   /**

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1076,6 +1076,25 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return offsetPairwise128IntegerLanes(nibbles, q8);
   }
 
+  static IntVector q4_0Q8_0Pairwise128IntegerLanes(
+      MemorySegment qWeight,
+      long nibbleOffset,
+      byte[] q8Quants,
+      int quantOffset,
+      boolean highNibble) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector q4 =
+        highNibble
+            ? packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8)
+            : packed.and((byte) 0x0F).sub((byte) 8);
+    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset);
+    VectorMask<Byte> negativeQ4 = q4.compare(VectorOperators.LT, (byte) 0);
+    ByteVector signedQ8 = q8.blend(q8.lanewise(VectorOperators.NEG), negativeQ4);
+    return pairwise128IntegerLanes(q4.lanewise(VectorOperators.ABS), signedQ8);
+  }
+
   static IntVector q4_0Q8_0OffsetPairwise128IntegerLanes(
       MemorySegment qWeight,
       long nibbleOffset,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1076,13 +1076,38 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return offsetPairwise128IntegerLanes(nibbles, q8);
   }
 
+  static IntVector q4_0Q8_0OffsetPairwise128IntegerLanes(
+      MemorySegment qWeight,
+      long nibbleOffset,
+      byte[] q8Quants,
+      int quantOffset,
+      int[] q8GroupSums,
+      int sumOffset,
+      boolean highNibble) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector nibbles =
+        highNibble
+            ? packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F)
+            : packed.and((byte) 0x0F);
+    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset);
+    IntVector weighted = pairwise128IntegerLanes(nibbles, q8);
+    IntVector q8Sums = IntVector.fromArray(IntVector.SPECIES_128, q8GroupSums, sumOffset);
+    return weighted.sub(q8Sums.mul(8));
+  }
+
   private static IntVector offsetPairwise128IntegerLanes(
       ByteVector unsignedNibbles, ByteVector q8) {
-    ShortVector weightedPairs = multiplyAddUnsignedSignedBytesSaturating128(unsignedNibbles, q8);
-    IntVector weighted = multiplyAddSignedShorts128(weightedPairs, SHORT_128_ONES);
+    IntVector weighted = pairwise128IntegerLanes(unsignedNibbles, q8);
     ShortVector q8Pairs = multiplyAddUnsignedSignedBytesSaturating128(BYTE_128_ONES, q8);
     IntVector q8Sums = multiplyAddSignedShorts128(q8Pairs, SHORT_128_ONES);
     return weighted.sub(q8Sums.mul(8));
+  }
+
+  private static IntVector pairwise128IntegerLanes(ByteVector unsignedNibbles, ByteVector q8) {
+    ShortVector weightedPairs = multiplyAddUnsignedSignedBytesSaturating128(unsignedNibbles, q8);
+    return multiplyAddSignedShorts128(weightedPairs, SHORT_128_ONES);
   }
 
   private static ShortVector multiplyAddUnsignedSignedBytesSaturating128(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -84,6 +84,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 1);
   private static final ShortVector SHORT_256_ONES =
       ShortVector.broadcast(ShortVector.SPECIES_256, (short) 1);
+  private static final ByteVector BYTE_256_ONES =
+      ByteVector.broadcast(ByteVector.SPECIES_256, (byte) 1);
   private static final ByteVector Q5_HIGH_BIT_MASKS =
       ByteVector.fromArray(
           ByteVector.SPECIES_64, new byte[] {1, 2, 4, 8, 16, 32, 64, (byte) 0x80}, 0);
@@ -1025,6 +1027,24 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     ShortVector pairSums =
         multiplyAddUnsignedSignedBytesSaturating256(q4.lanewise(VectorOperators.ABS), signedQ8);
     return multiplyAddSignedShorts256(pairSums, SHORT_256_ONES);
+  }
+
+  static IntVector q4_0Q8_0OffsetPairwiseIntegerLanes(
+      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector low = packed.and((byte) 0x0F);
+    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+    ByteVector low256 = (ByteVector) low.reinterpretShape(ByteVector.SPECIES_256, 0);
+    ByteVector high256 = (ByteVector) high.reinterpretShape(ByteVector.SPECIES_256, -1);
+    ByteVector q4 = low256.or(high256);
+    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_256, q8Quants, quantOffset);
+    ShortVector weightedPairs = multiplyAddUnsignedSignedBytesSaturating256(q4, q8);
+    IntVector weighted = multiplyAddSignedShorts256(weightedPairs, SHORT_256_ONES);
+    ShortVector q8Pairs = multiplyAddUnsignedSignedBytesSaturating256(BYTE_256_ONES, q8);
+    IntVector q8Sums = multiplyAddSignedShorts256(q8Pairs, SHORT_256_ONES);
+    return weighted.sub(q8Sums.mul(8));
   }
 
   private static ShortVector multiplyAddUnsignedSignedBytesSaturating256(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -44,6 +44,8 @@ import jdk.incubator.vector.VectorSpecies;
  */
 final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
+  private static final int Q4_SHORT_PAIRWISE_MIN_BLOCKS = 32;
+
   // Species are capped to PanamaConstants.MAX_BITS (default 256) to avoid AVX-512 frequency
   // downclock; opt into wider with -Dvectors.maxBits=512. The cap only ever narrows below the
   // hardware-preferred width, so every loop below stays correct (they are written generically
@@ -82,30 +84,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       VectorShuffle.fromValues(IntVector.SPECIES_256, 0, 0, 0, 0, 0, 2, 4, 6);
   private static final VectorMask<Integer> HIGH_INT_GROUP_LANES =
       VectorMask.fromLong(IntVector.SPECIES_256, 0xF0L);
-  private static final VectorShuffle<Byte> BYTE_128_EVEN_LANES =
-      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 0);
-  private static final VectorShuffle<Byte> BYTE_128_ODD_LANES =
-      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 1);
-  private static final VectorShuffle<Byte> BYTE_256_EVEN_LANES =
-      VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 0);
-  private static final VectorShuffle<Byte> BYTE_256_ODD_LANES =
-      VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 1);
   private static final VectorShuffle<Short> SHORT_256_EVEN_LANES =
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 0);
   private static final VectorShuffle<Short> SHORT_256_ODD_LANES =
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 1);
-  private static final VectorShuffle<Short> SHORT_128_EVEN_LANES =
-      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 0);
-  private static final VectorShuffle<Short> SHORT_128_ODD_LANES =
-      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 1);
-  private static final ShortVector SHORT_128_ONES =
-      ShortVector.broadcast(ShortVector.SPECIES_128, (short) 1);
-  private static final ShortVector SHORT_256_ONES =
-      ShortVector.broadcast(ShortVector.SPECIES_256, (short) 1);
-  private static final ByteVector BYTE_128_ONES =
-      ByteVector.broadcast(ByteVector.SPECIES_128, (byte) 1);
-  private static final ByteVector BYTE_256_ONES =
-      ByteVector.broadcast(ByteVector.SPECIES_256, (byte) 1);
   private static final ByteVector Q5_HIGH_BIT_MASKS =
       ByteVector.fromArray(
           ByteVector.SPECIES_64, new byte[] {1, 2, 4, 8, 16, 32, 64, (byte) 0x80}, 0);
@@ -118,6 +100,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     } else {
       return a.mul(b).add(c);
     }
+  }
+
+  static boolean useQ4ShortPairwise(boolean configured, int vectorBits, int blocks) {
+    return configured && vectorBits >= 256 && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
+  }
+
+  private static boolean useQ4ShortPairwise(int blocks) {
+    return useQ4ShortPairwise(PanamaConstants.USE_Q4_SHORT_PAIRWISE, VECTOR_BITSIZE, blocks);
   }
 
   // --- Float dot product: 4x unrolled FMA (Lucene pattern) ---
@@ -443,8 +433,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               float scale =
                   Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
               IntVector integerLanes =
-                  q4_0Q8_0IntegerLanes(
-                      qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+                  useQ4ShortPairwise(blocks)
+                      ? q4_0Q8_0ShortPairwiseIntegerLanes(
+                          qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE)
+                      : q4_0Q8_0IntegerLanes(
+                          qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
               FloatVector products =
                   (FloatVector)
                       integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
@@ -524,8 +517,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               float scale =
                   Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
               IntVector integerLanes =
-                  q4_0Q8_0IntegerLanes(
-                      qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+                  useQ4ShortPairwise(blocks)
+                      ? q4_0Q8_0ShortPairwiseIntegerLanes(
+                          qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE)
+                      : q4_0Q8_0IntegerLanes(
+                          qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
               FloatVector products =
                   (FloatVector)
                       integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
@@ -572,6 +568,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    boolean useShortPairwise = useQ4ShortPairwise(blocks);
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(
           queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
@@ -622,7 +619,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                   high,
                   q8Quants,
                   (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
-                  weightScale * q8Scales[batch * blocks + block]);
+                  weightScale * q8Scales[batch * blocks + block],
+                  useShortPairwise);
             }
           }
 
@@ -785,6 +783,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    boolean useShortPairwise = useQ4ShortPairwise(blocks);
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(
           queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
@@ -862,7 +861,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                   high,
                   q8Quants,
                   (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
-                  weightScale * q8Scales[batch * blocks + block]);
+                  weightScale * q8Scales[batch * blocks + block],
+                  useShortPairwise);
             }
           }
 
@@ -881,7 +881,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       ShortVector high,
       byte[] q8Quants,
       int quantOffset,
-      float scale) {
+      float scale,
+      boolean useShortPairwise) {
     ShortVector lowQuants =
         (ShortVector)
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
@@ -890,7 +891,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         (ShortVector)
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
                 .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    IntVector integerLanes = fourProductLanes(low.mul(lowQuants), high.mul(highQuants));
+    IntVector integerLanes =
+        useShortPairwise
+            ? fourProductLanesFromShortPairs(low, high, lowQuants, highQuants)
+            : fourProductLanes(low.mul(lowQuants), high.mul(highQuants));
     FloatVector products =
         (FloatVector) integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
     FloatVector accumulator =
@@ -936,8 +940,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         float scale =
             Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
         IntVector integerLanes =
-            q4_0Q8_0IntegerLanes(
-                qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
+            useQ4ShortPairwise(blocks)
+                ? q4_0Q8_0ShortPairwiseIntegerLanes(
+                    qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE)
+                : q4_0Q8_0IntegerLanes(
+                    qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE);
         FloatVector products =
             (FloatVector)
                 integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
@@ -1050,177 +1057,18 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         (ShortVector)
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
                 .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    IntVector lowPairs = multiplyAddSignedShorts256(low16, qLow16);
-    IntVector highPairs = multiplyAddSignedShorts256(high16, qHigh16);
+    return fourProductLanesFromShortPairs(low16, high16, qLow16, qHigh16);
+  }
+
+  private static IntVector fourProductLanesFromShortPairs(
+      ShortVector low, ShortVector high, ShortVector qLow, ShortVector qHigh) {
+    IntVector lowPairs = multiplyAddSignedShorts256(low, qLow);
+    IntVector highPairs = multiplyAddSignedShorts256(high, qHigh);
     IntVector lowGroups =
         lowPairs.add(lowPairs.rearrange(SWAP_ADJACENT_INTS)).rearrange(SELECT_LOW_INT_GROUPS);
     IntVector highGroups =
         highPairs.add(highPairs.rearrange(SWAP_ADJACENT_INTS)).rearrange(SELECT_HIGH_INT_GROUPS);
     return lowGroups.blend(highGroups, HIGH_INT_GROUP_LANES);
-  }
-
-  static IntVector q4_0Q8_0PairwiseIntegerLanes(
-      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
-    ByteVector packed =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
-    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
-    ByteVector low256 = (ByteVector) low.reinterpretShape(ByteVector.SPECIES_256, 0);
-    ByteVector high256 = (ByteVector) high.reinterpretShape(ByteVector.SPECIES_256, -1);
-    ByteVector q4 = low256.or(high256);
-    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_256, q8Quants, quantOffset);
-    VectorMask<Byte> negativeQ4 = q4.compare(VectorOperators.LT, (byte) 0);
-    ByteVector signedQ8 = q8.blend(q8.lanewise(VectorOperators.NEG), negativeQ4);
-    ShortVector pairSums =
-        multiplyAddUnsignedSignedBytesSaturating256(q4.lanewise(VectorOperators.ABS), signedQ8);
-    return multiplyAddSignedShorts256(pairSums, SHORT_256_ONES);
-  }
-
-  static IntVector q4_0Q8_0OffsetPairwiseIntegerLanes(
-      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
-    ByteVector packed =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector low = packed.and((byte) 0x0F);
-    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
-    ByteVector low256 = (ByteVector) low.reinterpretShape(ByteVector.SPECIES_256, 0);
-    ByteVector high256 = (ByteVector) high.reinterpretShape(ByteVector.SPECIES_256, -1);
-    ByteVector q4 = low256.or(high256);
-    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_256, q8Quants, quantOffset);
-    ShortVector weightedPairs = multiplyAddUnsignedSignedBytesSaturating256(q4, q8);
-    IntVector weighted = multiplyAddSignedShorts256(weightedPairs, SHORT_256_ONES);
-    ShortVector q8Pairs = multiplyAddUnsignedSignedBytesSaturating256(BYTE_256_ONES, q8);
-    IntVector q8Sums = multiplyAddSignedShorts256(q8Pairs, SHORT_256_ONES);
-    return weighted.sub(q8Sums.mul(8));
-  }
-
-  static IntVector q4_0Q8_0OffsetPairwise128IntegerLanes(
-      MemorySegment qWeight,
-      long nibbleOffset,
-      byte[] q8Quants,
-      int quantOffset,
-      boolean highNibble) {
-    ByteVector packed =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector nibbles =
-        highNibble
-            ? packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F)
-            : packed.and((byte) 0x0F);
-    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset);
-    return offsetPairwise128IntegerLanes(nibbles, q8);
-  }
-
-  static IntVector q4_0Q8_0Pairwise128IntegerLanes(
-      MemorySegment qWeight,
-      long nibbleOffset,
-      byte[] q8Quants,
-      int quantOffset,
-      boolean highNibble) {
-    ByteVector packed =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector q4 =
-        highNibble
-            ? packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8)
-            : packed.and((byte) 0x0F).sub((byte) 8);
-    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset);
-    VectorMask<Byte> negativeQ4 = q4.compare(VectorOperators.LT, (byte) 0);
-    ByteVector signedQ8 = q8.blend(q8.lanewise(VectorOperators.NEG), negativeQ4);
-    return pairwise128IntegerLanes(q4.lanewise(VectorOperators.ABS), signedQ8);
-  }
-
-  static IntVector q4_0Q8_0OffsetPairwise128IntegerLanes(
-      MemorySegment qWeight,
-      long nibbleOffset,
-      byte[] q8Quants,
-      int quantOffset,
-      int[] q8GroupSums,
-      int sumOffset,
-      boolean highNibble) {
-    ByteVector packed =
-        ByteVector.fromMemorySegment(
-            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
-    ByteVector nibbles =
-        highNibble
-            ? packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F)
-            : packed.and((byte) 0x0F);
-    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset);
-    IntVector weighted = pairwise128IntegerLanes(nibbles, q8);
-    IntVector q8Sums = IntVector.fromArray(IntVector.SPECIES_128, q8GroupSums, sumOffset);
-    return weighted.sub(q8Sums.mul(8));
-  }
-
-  private static IntVector offsetPairwise128IntegerLanes(
-      ByteVector unsignedNibbles, ByteVector q8) {
-    IntVector weighted = pairwise128IntegerLanes(unsignedNibbles, q8);
-    ShortVector q8Pairs = multiplyAddUnsignedSignedBytesSaturating128(BYTE_128_ONES, q8);
-    IntVector q8Sums = multiplyAddSignedShorts128(q8Pairs, SHORT_128_ONES);
-    return weighted.sub(q8Sums.mul(8));
-  }
-
-  private static IntVector pairwise128IntegerLanes(ByteVector unsignedNibbles, ByteVector q8) {
-    ShortVector weightedPairs = multiplyAddUnsignedSignedBytesSaturating128(unsignedNibbles, q8);
-    return multiplyAddSignedShorts128(weightedPairs, SHORT_128_ONES);
-  }
-
-  private static ShortVector multiplyAddUnsignedSignedBytesSaturating128(
-      ByteVector unsigned, ByteVector signed) {
-    ByteVector unsignedEven = unsigned.rearrange(BYTE_128_EVEN_LANES);
-    ByteVector unsignedOdd = unsigned.rearrange(BYTE_128_ODD_LANES);
-    ByteVector signedEven = signed.rearrange(BYTE_128_EVEN_LANES);
-    ByteVector signedOdd = signed.rearrange(BYTE_128_ODD_LANES);
-    ShortVector unsignedEvenShorts =
-        (ShortVector)
-            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
-    ShortVector unsignedOddShorts =
-        (ShortVector)
-            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
-    ShortVector signedEvenShorts =
-        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
-    ShortVector signedOddShorts =
-        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
-    return unsignedEvenShorts
-        .mul(signedEvenShorts)
-        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
-  }
-
-  private static IntVector multiplyAddSignedShorts128(ShortVector left, ShortVector right) {
-    ShortVector leftEven = left.rearrange(SHORT_128_EVEN_LANES);
-    ShortVector leftOdd = left.rearrange(SHORT_128_ODD_LANES);
-    ShortVector rightEven = right.rearrange(SHORT_128_EVEN_LANES);
-    ShortVector rightOdd = right.rearrange(SHORT_128_ODD_LANES);
-    IntVector leftEvenInts =
-        (IntVector) leftEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
-    IntVector leftOddInts =
-        (IntVector) leftOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
-    IntVector rightEvenInts =
-        (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
-    IntVector rightOddInts =
-        (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
-    return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
-  }
-
-  private static ShortVector multiplyAddUnsignedSignedBytesSaturating256(
-      ByteVector unsigned, ByteVector signed) {
-    ByteVector unsignedEven = unsigned.rearrange(BYTE_256_EVEN_LANES);
-    ByteVector unsignedOdd = unsigned.rearrange(BYTE_256_ODD_LANES);
-    ByteVector signedEven = signed.rearrange(BYTE_256_EVEN_LANES);
-    ByteVector signedOdd = signed.rearrange(BYTE_256_ODD_LANES);
-    ShortVector unsignedEvenShorts =
-        (ShortVector)
-            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_256, 0);
-    ShortVector unsignedOddShorts =
-        (ShortVector)
-            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_256, 0);
-    ShortVector signedEvenShorts =
-        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    ShortVector signedOddShorts =
-        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-    return unsignedEvenShorts
-        .mul(signedEvenShorts)
-        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
   }
 
   private static IntVector multiplyAddSignedShorts256(ShortVector left, ShortVector right) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -74,6 +74,16 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ShortVector.SPECIES_256, 0, 0, 0, 0, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorMask<Short> HIGH_GROUP_LANES =
       VectorMask.fromLong(ShortVector.SPECIES_256, 0xF0L);
+  private static final VectorShuffle<Byte> BYTE_256_EVEN_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 0);
+  private static final VectorShuffle<Byte> BYTE_256_ODD_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 1);
+  private static final VectorShuffle<Short> SHORT_256_EVEN_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 0);
+  private static final VectorShuffle<Short> SHORT_256_ODD_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 1);
+  private static final ShortVector SHORT_256_ONES =
+      ShortVector.broadcast(ShortVector.SPECIES_256, (short) 1);
   private static final ByteVector Q5_HIGH_BIT_MASKS =
       ByteVector.fromArray(
           ByteVector.SPECIES_64, new byte[] {1, 2, 4, 8, 16, 32, 64, (byte) 0x80}, 0);
@@ -997,6 +1007,61 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
 
     return fourProductLanes(lowProducts, highProducts);
+  }
+
+  static IntVector q4_0Q8_0PairwiseIntegerLanes(
+      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
+    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+    ByteVector low256 = (ByteVector) low.reinterpretShape(ByteVector.SPECIES_256, 0);
+    ByteVector high256 = (ByteVector) high.reinterpretShape(ByteVector.SPECIES_256, -1);
+    ByteVector q4 = low256.or(high256);
+    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_256, q8Quants, quantOffset);
+    VectorMask<Byte> negativeQ4 = q4.compare(VectorOperators.LT, (byte) 0);
+    ByteVector signedQ8 = q8.blend(q8.lanewise(VectorOperators.NEG), negativeQ4);
+    ShortVector pairSums =
+        multiplyAddUnsignedSignedBytesSaturating256(q4.lanewise(VectorOperators.ABS), signedQ8);
+    return multiplyAddSignedShorts256(pairSums, SHORT_256_ONES);
+  }
+
+  private static ShortVector multiplyAddUnsignedSignedBytesSaturating256(
+      ByteVector unsigned, ByteVector signed) {
+    ByteVector unsignedEven = unsigned.rearrange(BYTE_256_EVEN_LANES);
+    ByteVector unsignedOdd = unsigned.rearrange(BYTE_256_ODD_LANES);
+    ByteVector signedEven = signed.rearrange(BYTE_256_EVEN_LANES);
+    ByteVector signedOdd = signed.rearrange(BYTE_256_ODD_LANES);
+    ShortVector unsignedEvenShorts =
+        (ShortVector)
+            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_256, 0);
+    ShortVector unsignedOddShorts =
+        (ShortVector)
+            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_256, 0);
+    ShortVector signedEvenShorts =
+        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector signedOddShorts =
+        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    return unsignedEvenShorts
+        .mul(signedEvenShorts)
+        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
+  }
+
+  private static IntVector multiplyAddSignedShorts256(ShortVector left, ShortVector right) {
+    ShortVector leftEven = left.rearrange(SHORT_256_EVEN_LANES);
+    ShortVector leftOdd = left.rearrange(SHORT_256_ODD_LANES);
+    ShortVector rightEven = right.rearrange(SHORT_256_EVEN_LANES);
+    ShortVector rightOdd = right.rearrange(SHORT_256_ODD_LANES);
+    IntVector leftEvenInts =
+        (IntVector) leftEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    IntVector leftOddInts =
+        (IntVector) leftOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    IntVector rightEvenInts =
+        (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    IntVector rightOddInts =
+        (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
   }
 
   private static ShortVector sumGroupsOfFour(ShortVector products) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -74,6 +74,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ShortVector.SPECIES_256, 0, 0, 0, 0, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorMask<Short> HIGH_GROUP_LANES =
       VectorMask.fromLong(ShortVector.SPECIES_256, 0xF0L);
+  private static final VectorShuffle<Byte> BYTE_128_EVEN_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 0);
+  private static final VectorShuffle<Byte> BYTE_128_ODD_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 1);
   private static final VectorShuffle<Byte> BYTE_256_EVEN_LANES =
       VectorShuffle.makeUnzip(ByteVector.SPECIES_256, 0);
   private static final VectorShuffle<Byte> BYTE_256_ODD_LANES =
@@ -82,8 +86,16 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 0);
   private static final VectorShuffle<Short> SHORT_256_ODD_LANES =
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 1);
+  private static final VectorShuffle<Short> SHORT_128_EVEN_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 0);
+  private static final VectorShuffle<Short> SHORT_128_ODD_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 1);
+  private static final ShortVector SHORT_128_ONES =
+      ShortVector.broadcast(ShortVector.SPECIES_128, (short) 1);
   private static final ShortVector SHORT_256_ONES =
       ShortVector.broadcast(ShortVector.SPECIES_256, (short) 1);
+  private static final ByteVector BYTE_128_ONES =
+      ByteVector.broadcast(ByteVector.SPECIES_128, (byte) 1);
   private static final ByteVector BYTE_256_ONES =
       ByteVector.broadcast(ByteVector.SPECIES_256, (byte) 1);
   private static final ByteVector Q5_HIGH_BIT_MASKS =
@@ -1045,6 +1057,69 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     ShortVector q8Pairs = multiplyAddUnsignedSignedBytesSaturating256(BYTE_256_ONES, q8);
     IntVector q8Sums = multiplyAddSignedShorts256(q8Pairs, SHORT_256_ONES);
     return weighted.sub(q8Sums.mul(8));
+  }
+
+  static IntVector q4_0Q8_0OffsetPairwise128IntegerLanes(
+      MemorySegment qWeight,
+      long nibbleOffset,
+      byte[] q8Quants,
+      int quantOffset,
+      boolean highNibble) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector nibbles =
+        highNibble
+            ? packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F)
+            : packed.and((byte) 0x0F);
+    ByteVector q8 = ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset);
+    return offsetPairwise128IntegerLanes(nibbles, q8);
+  }
+
+  private static IntVector offsetPairwise128IntegerLanes(
+      ByteVector unsignedNibbles, ByteVector q8) {
+    ShortVector weightedPairs = multiplyAddUnsignedSignedBytesSaturating128(unsignedNibbles, q8);
+    IntVector weighted = multiplyAddSignedShorts128(weightedPairs, SHORT_128_ONES);
+    ShortVector q8Pairs = multiplyAddUnsignedSignedBytesSaturating128(BYTE_128_ONES, q8);
+    IntVector q8Sums = multiplyAddSignedShorts128(q8Pairs, SHORT_128_ONES);
+    return weighted.sub(q8Sums.mul(8));
+  }
+
+  private static ShortVector multiplyAddUnsignedSignedBytesSaturating128(
+      ByteVector unsigned, ByteVector signed) {
+    ByteVector unsignedEven = unsigned.rearrange(BYTE_128_EVEN_LANES);
+    ByteVector unsignedOdd = unsigned.rearrange(BYTE_128_ODD_LANES);
+    ByteVector signedEven = signed.rearrange(BYTE_128_EVEN_LANES);
+    ByteVector signedOdd = signed.rearrange(BYTE_128_ODD_LANES);
+    ShortVector unsignedEvenShorts =
+        (ShortVector)
+            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
+    ShortVector unsignedOddShorts =
+        (ShortVector)
+            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
+    ShortVector signedEvenShorts =
+        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+    ShortVector signedOddShorts =
+        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+    return unsignedEvenShorts
+        .mul(signedEvenShorts)
+        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
+  }
+
+  private static IntVector multiplyAddSignedShorts128(ShortVector left, ShortVector right) {
+    ShortVector leftEven = left.rearrange(SHORT_128_EVEN_LANES);
+    ShortVector leftOdd = left.rearrange(SHORT_128_ODD_LANES);
+    ShortVector rightEven = right.rearrange(SHORT_128_EVEN_LANES);
+    ShortVector rightOdd = right.rearrange(SHORT_128_ODD_LANES);
+    IntVector leftEvenInts =
+        (IntVector) leftEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector leftOddInts =
+        (IntVector) leftOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector rightEvenInts =
+        (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector rightOddInts =
+        (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
   }
 
   private static ShortVector multiplyAddUnsignedSignedBytesSaturating256(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -74,6 +74,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ShortVector.SPECIES_256, 0, 0, 0, 0, 0, 4, 8, 12, 0, 0, 0, 0, 0, 0, 0, 0);
   private static final VectorMask<Short> HIGH_GROUP_LANES =
       VectorMask.fromLong(ShortVector.SPECIES_256, 0xF0L);
+  private static final VectorShuffle<Integer> SWAP_ADJACENT_INTS =
+      VectorShuffle.fromValues(IntVector.SPECIES_256, 1, 0, 3, 2, 5, 4, 7, 6);
+  private static final VectorShuffle<Integer> SELECT_LOW_INT_GROUPS =
+      VectorShuffle.fromValues(IntVector.SPECIES_256, 0, 2, 4, 6, 0, 0, 0, 0);
+  private static final VectorShuffle<Integer> SELECT_HIGH_INT_GROUPS =
+      VectorShuffle.fromValues(IntVector.SPECIES_256, 0, 0, 0, 0, 0, 2, 4, 6);
+  private static final VectorMask<Integer> HIGH_INT_GROUP_LANES =
+      VectorMask.fromLong(IntVector.SPECIES_256, 0xF0L);
   private static final VectorShuffle<Byte> BYTE_128_EVEN_LANES =
       VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 0);
   private static final VectorShuffle<Byte> BYTE_128_ODD_LANES =
@@ -1021,6 +1029,34 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0));
 
     return fourProductLanes(lowProducts, highProducts);
+  }
+
+  static IntVector q4_0Q8_0ShortPairwiseIntegerLanes(
+      MemorySegment qWeight, long nibbleOffset, byte[] q8Quants, int quantOffset) {
+    ByteVector packed =
+        ByteVector.fromMemorySegment(
+            ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
+    ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
+    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+    ShortVector low16 =
+        (ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector high16 =
+        (ShortVector) high.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector qLow16 =
+        (ShortVector)
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    ShortVector qHigh16 =
+        (ShortVector)
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16)
+                .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+    IntVector lowPairs = multiplyAddSignedShorts256(low16, qLow16);
+    IntVector highPairs = multiplyAddSignedShorts256(high16, qHigh16);
+    IntVector lowGroups =
+        lowPairs.add(lowPairs.rearrange(SWAP_ADJACENT_INTS)).rearrange(SELECT_LOW_INT_GROUPS);
+    IntVector highGroups =
+        highPairs.add(highPairs.rearrange(SWAP_ADJACENT_INTS)).rearrange(SELECT_HIGH_INT_GROUPS);
+    return lowGroups.blend(highGroups, HIGH_INT_GROUP_LANES);
   }
 
   static IntVector q4_0Q8_0PairwiseIntegerLanes(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorRuntimeCapabilities.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorRuntimeCapabilities.java
@@ -25,6 +25,7 @@ public record VectorRuntimeCapabilities(
     boolean fastVectorFma,
     boolean fastScalarFma,
     boolean sve,
+    boolean q4ShortPairwise,
     boolean ggufParallel,
     String ggufExecutor,
     int ggufThreads,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -72,6 +72,7 @@ public final class VectorizationProvider {
         PanamaConstants.HAS_FAST_VECTOR_FMA,
         PanamaConstants.HAS_FAST_SCALAR_FMA,
         PanamaConstants.HAS_SVE,
+        PanamaConstants.USE_Q4_SHORT_PAIRWISE,
         GgufParallelSupport.enabled(),
         GgufParallelSupport.executionMode().name().toLowerCase(Locale.ROOT),
         GgufParallelSupport.parallelism(),
@@ -123,6 +124,7 @@ public final class VectorizationProvider {
     String ggufChunksPerThread = System.getProperty("vectors.gguf.chunksPerThread");
     String mappedKQuantLongOffsets =
         System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY);
+    String q4ShortPairwise = System.getProperty(PanamaConstants.Q4_SHORT_PAIRWISE_PROPERTY);
     PanamaConstants.MappedKQuantLongOffsetPolicy mappedKQuantPolicy =
         PanamaConstants.mappedKQuantLongOffsetPolicy();
 
@@ -149,6 +151,7 @@ public final class VectorizationProvider {
         .append(",q6=")
         .append(mappedKQuantPolicy.q6())
         .append(')');
+    sb.append(" q4ShortPairwise=").append(PanamaConstants.USE_Q4_SHORT_PAIRWISE);
     sb.append(" toggles=[");
     boolean first = true;
     if (forceScalar != null) {
@@ -200,6 +203,11 @@ public final class VectorizationProvider {
       sb.append(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY)
           .append('=')
           .append(mappedKQuantLongOffsets);
+      first = false;
+    }
+    if (q4ShortPairwise != null) {
+      if (!first) sb.append(", ");
+      sb.append(PanamaConstants.Q4_SHORT_PAIRWISE_PROPERTY).append('=').append(q4ShortPairwise);
       first = false;
     }
     if (first) sb.append("(defaults — no -Dvectors.* overrides)");

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
@@ -148,6 +148,17 @@ class PanamaConstantsTest {
     assertThat(forced.q6()).isTrue();
   }
 
+  @Test
+  void q4ShortPairwisePolicyRequiresExplicitBooleanOptIn() {
+    assertThat(PanamaConstants.resolveQ4ShortPairwise(null)).isFalse();
+    assertThat(PanamaConstants.resolveQ4ShortPairwise(" ")).isFalse();
+    assertThat(PanamaConstants.resolveQ4ShortPairwise("false")).isFalse();
+    assertThat(PanamaConstants.resolveQ4ShortPairwise("TRUE")).isTrue();
+    assertThatThrownBy(() -> PanamaConstants.resolveQ4ShortPairwise("auto"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("vectors.gguf.q4ShortPairwise");
+  }
+
   // ─── P3.5 SVE detection ────────────────────────────────────────────────────
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -92,6 +92,8 @@ class PanamaGgufQuantizedDotTest {
       IntVector actual = PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(weights, 0, q8, 0);
       IntVector offsetActual =
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwiseIntegerLanes(weights, 0, q8, 0);
+      IntVector shortPairwise =
+          PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(weights, 0, q8, 0);
       IntVector low128 =
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 0, false);
       IntVector high128 =
@@ -115,6 +117,7 @@ class PanamaGgufQuantizedDotTest {
 
       assertThat(actual.toArray()).containsExactly(expected.toArray());
       assertThat(offsetActual.toArray()).containsExactly(expected.toArray());
+      assertThat(shortPairwise.toArray()).containsExactly(expected.toArray());
       assertThat(low128.toArray())
           .containsExactly(expected.lane(0), expected.lane(1), expected.lane(2), expected.lane(3));
       assertThat(high128.toArray())

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -92,9 +92,17 @@ class PanamaGgufQuantizedDotTest {
       IntVector actual = PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(weights, 0, q8, 0);
       IntVector offsetActual =
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwiseIntegerLanes(weights, 0, q8, 0);
+      IntVector low128 =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 0, false);
+      IntVector high128 =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 16, true);
 
       assertThat(actual.toArray()).containsExactly(expected.toArray());
       assertThat(offsetActual.toArray()).containsExactly(expected.toArray());
+      assertThat(low128.toArray())
+          .containsExactly(expected.lane(0), expected.lane(1), expected.lane(2), expected.lane(3));
+      assertThat(high128.toArray())
+          .containsExactly(expected.lane(4), expected.lane(5), expected.lane(6), expected.lane(7));
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -59,6 +59,43 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0PairwiseIntegerLanesMatchWidenedKernelExactly() {
+    byte[] packed = new byte[16];
+    byte[] q8 = new byte[32];
+    Random random = new Random(0x514750414952L);
+
+    for (int iteration = 0; iteration < 10_000; iteration++) {
+      random.nextBytes(packed);
+      random.nextBytes(q8);
+      for (int index = 0; index < q8.length; index++) {
+        if (q8[index] == Byte.MIN_VALUE) {
+          q8[index] = -127;
+        }
+      }
+      if (iteration == 0) {
+        for (int index = 0; index < packed.length; index++) {
+          packed[index] = (byte) (index | ((15 - index) << 4));
+        }
+        for (int index = 0; index < q8.length; index++) {
+          q8[index] =
+              switch (index & 3) {
+                case 0 -> -127;
+                case 1 -> -1;
+                case 2 -> 0;
+                default -> 127;
+              };
+        }
+      }
+
+      MemorySegment weights = MemorySegment.ofArray(packed);
+      IntVector expected = PanamaVectorUtilSupport.q4_0Q8_0IntegerLanes(weights, 0, q8, 0);
+      IntVector actual = PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(weights, 0, q8, 0);
+
+      assertThat(actual.toArray()).containsExactly(expected.toArray());
+    }
+  }
+
+  @Test
   void q4_KQ8_KIntegerDotDecodesBothNibbleHalves() {
     byte[] packed = new byte[32];
     byte[] q8 = new byte[32];

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -96,6 +96,18 @@ class PanamaGgufQuantizedDotTest {
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 0, false);
       IntVector high128 =
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 16, true);
+      int[] q8GroupSums = new int[8];
+      for (int lane = 0; lane < q8GroupSums.length; lane++) {
+        for (int index = 0; index < 4; index++) {
+          q8GroupSums[lane] += q8[lane * 4 + index];
+        }
+      }
+      IntVector precomputedLow128 =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
+              weights, 0, q8, 0, q8GroupSums, 0, false);
+      IntVector precomputedHigh128 =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
+              weights, 0, q8, 16, q8GroupSums, 4, true);
 
       assertThat(actual.toArray()).containsExactly(expected.toArray());
       assertThat(offsetActual.toArray()).containsExactly(expected.toArray());
@@ -103,6 +115,8 @@ class PanamaGgufQuantizedDotTest {
           .containsExactly(expected.lane(0), expected.lane(1), expected.lane(2), expected.lane(3));
       assertThat(high128.toArray())
           .containsExactly(expected.lane(4), expected.lane(5), expected.lane(6), expected.lane(7));
+      assertThat(precomputedLow128.toArray()).containsExactly(low128.toArray());
+      assertThat(precomputedHigh128.toArray()).containsExactly(high128.toArray());
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -96,6 +96,10 @@ class PanamaGgufQuantizedDotTest {
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 0, false);
       IntVector high128 =
           PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 16, true);
+      IntVector signedLow128 =
+          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(weights, 0, q8, 0, false);
+      IntVector signedHigh128 =
+          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(weights, 0, q8, 16, true);
       int[] q8GroupSums = new int[8];
       for (int lane = 0; lane < q8GroupSums.length; lane++) {
         for (int index = 0; index < 4; index++) {
@@ -115,6 +119,8 @@ class PanamaGgufQuantizedDotTest {
           .containsExactly(expected.lane(0), expected.lane(1), expected.lane(2), expected.lane(3));
       assertThat(high128.toArray())
           .containsExactly(expected.lane(4), expected.lane(5), expected.lane(6), expected.lane(7));
+      assertThat(signedLow128.toArray()).containsExactly(low128.toArray());
+      assertThat(signedHigh128.toArray()).containsExactly(high128.toArray());
       assertThat(precomputedLow128.toArray()).containsExactly(low128.toArray());
       assertThat(precomputedHigh128.toArray()).containsExactly(high128.toArray());
     }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -90,8 +90,11 @@ class PanamaGgufQuantizedDotTest {
       MemorySegment weights = MemorySegment.ofArray(packed);
       IntVector expected = PanamaVectorUtilSupport.q4_0Q8_0IntegerLanes(weights, 0, q8, 0);
       IntVector actual = PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(weights, 0, q8, 0);
+      IntVector offsetActual =
+          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwiseIntegerLanes(weights, 0, q8, 0);
 
       assertThat(actual.toArray()).containsExactly(expected.toArray());
+      assertThat(offsetActual.toArray()).containsExactly(expected.toArray());
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -31,6 +31,14 @@ import org.junit.jupiter.api.Test;
 class PanamaGgufQuantizedDotTest {
 
   @Test
+  void q4ShortPairwiseRequiresOptInAvx2WidthAndModelSizedRows() {
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(false, 256, 64)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(true, 128, 64)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(true, 256, 31)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(true, 256, 32)).isTrue();
+  }
+
+  @Test
   void q4_0Q8_0IntegerLanesSumFourProductsPerLane() {
     byte[] packed = new byte[16];
     byte[] q8 = new byte[32];
@@ -59,7 +67,7 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q4_0Q8_0PairwiseIntegerLanesMatchWidenedKernelExactly() {
+  void q4_0Q8_0ShortPairwiseIntegerLanesMatchWidenedKernelExactly() {
     byte[] packed = new byte[16];
     byte[] q8 = new byte[32];
     Random random = new Random(0x514750414952L);
@@ -67,11 +75,6 @@ class PanamaGgufQuantizedDotTest {
     for (int iteration = 0; iteration < 10_000; iteration++) {
       random.nextBytes(packed);
       random.nextBytes(q8);
-      for (int index = 0; index < q8.length; index++) {
-        if (q8[index] == Byte.MIN_VALUE) {
-          q8[index] = -127;
-        }
-      }
       if (iteration == 0) {
         for (int index = 0; index < packed.length; index++) {
           packed[index] = (byte) (index | ((15 - index) << 4));
@@ -79,7 +82,7 @@ class PanamaGgufQuantizedDotTest {
         for (int index = 0; index < q8.length; index++) {
           q8[index] =
               switch (index & 3) {
-                case 0 -> -127;
+                case 0 -> Byte.MIN_VALUE;
                 case 1 -> -1;
                 case 2 -> 0;
                 default -> 127;
@@ -89,43 +92,9 @@ class PanamaGgufQuantizedDotTest {
 
       MemorySegment weights = MemorySegment.ofArray(packed);
       IntVector expected = PanamaVectorUtilSupport.q4_0Q8_0IntegerLanes(weights, 0, q8, 0);
-      IntVector actual = PanamaVectorUtilSupport.q4_0Q8_0PairwiseIntegerLanes(weights, 0, q8, 0);
-      IntVector offsetActual =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwiseIntegerLanes(weights, 0, q8, 0);
       IntVector shortPairwise =
           PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(weights, 0, q8, 0);
-      IntVector low128 =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 0, false);
-      IntVector high128 =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(weights, 0, q8, 16, true);
-      IntVector signedLow128 =
-          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(weights, 0, q8, 0, false);
-      IntVector signedHigh128 =
-          PanamaVectorUtilSupport.q4_0Q8_0Pairwise128IntegerLanes(weights, 0, q8, 16, true);
-      int[] q8GroupSums = new int[8];
-      for (int lane = 0; lane < q8GroupSums.length; lane++) {
-        for (int index = 0; index < 4; index++) {
-          q8GroupSums[lane] += q8[lane * 4 + index];
-        }
-      }
-      IntVector precomputedLow128 =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
-              weights, 0, q8, 0, q8GroupSums, 0, false);
-      IntVector precomputedHigh128 =
-          PanamaVectorUtilSupport.q4_0Q8_0OffsetPairwise128IntegerLanes(
-              weights, 0, q8, 16, q8GroupSums, 4, true);
-
-      assertThat(actual.toArray()).containsExactly(expected.toArray());
-      assertThat(offsetActual.toArray()).containsExactly(expected.toArray());
       assertThat(shortPairwise.toArray()).containsExactly(expected.toArray());
-      assertThat(low128.toArray())
-          .containsExactly(expected.lane(0), expected.lane(1), expected.lane(2), expected.lane(3));
-      assertThat(high128.toArray())
-          .containsExactly(expected.lane(4), expected.lane(5), expected.lane(6), expected.lane(7));
-      assertThat(signedLow128.toArray()).containsExactly(low128.toArray());
-      assertThat(signedHigh128.toArray()).containsExactly(high128.toArray());
-      assertThat(precomputedLow128.toArray()).containsExactly(low128.toArray());
-      assertThat(precomputedHigh128.toArray()).containsExactly(high128.toArray());
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -50,6 +50,7 @@ class VectorizationProviderTest {
     assertThat(summary).contains("ggufChunksPerThread=2");
     assertThat(summary).contains("mappedKQuantLongOffsets=auto(");
     assertThat(summary).contains("q4=").contains("q5=").contains("q6=");
+    assertThat(summary).contains("q4ShortPairwise=" + PanamaConstants.USE_Q4_SHORT_PAIRWISE);
     assertThat(summary).contains("toggles=[");
     assertThat(summary).endsWith("]");
   }
@@ -128,6 +129,7 @@ class VectorizationProviderTest {
         .isEqualTo(
             VectorizationProvider.isPanamaEnabled() ? PanamaVectorUtilSupport.VECTOR_BITSIZE : 0);
     assertThat(capabilities.ggufExecutor()).isEqualTo("persistent");
+    assertThat(capabilities.q4ShortPairwise()).isEqualTo(PanamaConstants.USE_Q4_SHORT_PAIRWISE);
     assertThat(capabilities.ggufThreads()).isEqualTo(GgufParallelSupport.parallelism());
     assertThat(capabilities.ggufChunksPerThread()).isEqualTo(GgufParallelSupport.chunksPerThread());
   }


### PR DESCRIPTION
## What changed

- add an exact signed-short pairwise Q4_0 x Q8_0 kernel that Graal lowers to `VPMADDWD`
- route single, dual, triple, and batched Q4_0 projections through the kernel only when explicitly enabled, the effective SIMD width is at least 256 bits, and rows contain at least 32 blocks
- expose the resolved switch in runtime capabilities and startup diagnostics
- add randomized exactness, routing-policy, production GEMV, and helper benchmarks
- document the accepted Graal deployment profile and rejected experiments

The widened Java 25 kernel remains the default. The measured profile is:

```text
-Djdk.graal.MaximumInliningSize=10000
-Dvectors.gguf.q4ShortPairwise=true
```

## Why

Graal's post-fix Vector API implementation recognizes the signed-short pairwise graph and emits the AVX2 pairwise multiply-add instruction that the established widened kernel cannot express efficiently. The larger per-callee inlining limit is required for scalar replacement; enabling the Vectors property alone is intentionally not the default because it can allocate heavily on affected Graal builds.

## Performance gate

Controlled AMD EPYC Milan host, GraalVM CE 25.0.3+9-jvmci-25.1-b19 development build, Qwen3 0.6B Q4_0, 12 measured trials per mode:

| Metric | Widened | Pairwise | Change |
| --- | ---: | ---: | ---: |
| Decode | 28.7519 tok/s | 34.8445 tok/s | +21.19% |
| Prefill | 70.0064 tok/s | 88.5120 tok/s | +26.43% |
| TTFT | 2,220.8 ms | 1,757.5 ms | -20.86% |
| Mean CPU | 29,690.8 ms | 23,250.8 ms | -21.69% |

All paired trials matched input count, output count, and output SHA-256. The production 1024x2048 GEMV JMH gate improved from `0.094 +/- 0.003 ms/op` to `0.073 +/- 0.004 ms/op`, with no material allocation and no GC in either mode.

## Validation

- `./gradlew :vectors-core:check :vectors-bench:jmhJar`
- 10,000 randomized Q4/Q8 blocks across the complete signed Q8 byte domain
- four counterbalanced full-model process pairs with two warmups and three measured trials per mode
- rejected byte-pairwise, 128-bit, broad inlining, `CompileCommand`, and internal `ForceInline` variants recorded in the benchmark report

Vectors still compiles, tests, and publishes for Java 25. The new kernel is opt-in and has an immediate property-based rollback.
