### PR TITLE
feat(gguf): select Q4 kernels per invocation

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ4Kernel.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ4Kernel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+/** Arithmetic graph used by GGUF Q4_0 by Q8_0 kernels. */
+public enum GgufQ4Kernel {
+  /** Widens signed operands and multiplies them as integer lanes. */
+  WIDENED,
+
+  /** Uses signed-short pairwise multiply-add when the active vector shape supports it. */
+  SHORT_PAIRWISE
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaConstants.java
@@ -49,7 +49,6 @@ public final class PanamaConstants {
   private static final int SMALLEST_SIMD_BITS = 64;
   private static final int LARGEST_SIMD_BITS = 512;
   static final String MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY = "vectors.gguf.mappedKQuantLongOffsets";
-  static final String Q4_SHORT_PAIRWISE_PROPERTY = "vectors.gguf.q4ShortPairwise";
 
   enum MappedKQuantFormat {
     Q4_K,
@@ -76,8 +75,6 @@ public final class PanamaConstants {
   static final boolean USE_MAPPED_Q4_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q4();
   static final boolean USE_MAPPED_Q5_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q5();
   static final boolean USE_MAPPED_Q6_K_LONG_OFFSETS = MAPPED_K_QUANT_LONG_OFFSET_POLICY.q6();
-  static final boolean USE_Q4_SHORT_PAIRWISE =
-      resolveQ4ShortPairwise(System.getProperty(Q4_SHORT_PAIRWISE_PROPERTY));
 
   /**
    * The resolved SIMD register-width ceiling in bits. Defaults to {@link #DEFAULT_MAX_BITS};
@@ -181,19 +178,6 @@ public final class PanamaConstants {
 
   static MappedKQuantLongOffsetPolicy mappedKQuantLongOffsetPolicy() {
     return MAPPED_K_QUANT_LONG_OFFSET_POLICY;
-  }
-
-  static boolean resolveQ4ShortPairwise(String configured) {
-    if (configured == null || configured.isBlank()) {
-      return false;
-    }
-    return switch (configured.trim().toLowerCase(Locale.ROOT)) {
-      case "true" -> true;
-      case "false" -> false;
-      default ->
-          throw new IllegalArgumentException(
-              "-D" + Q4_SHORT_PAIRWISE_PROPERTY + " must be true or false; got: " + configured);
-    };
   }
 
   /**

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -18,6 +18,7 @@ package com.integrallis.vectors.core;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+import java.util.Objects;
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
@@ -102,12 +103,17 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
   }
 
-  static boolean useQ4ShortPairwise(boolean configured, int vectorBits, int blocks) {
-    return configured && vectorBits >= 256 && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
+  static boolean useQ4ShortPairwise(GgufQ4Kernel kernel, int vectorBits, int blocks) {
+    boolean requested =
+        switch (Objects.requireNonNull(kernel, "kernel")) {
+          case WIDENED -> false;
+          case SHORT_PAIRWISE -> true;
+        };
+    return requested && vectorBits >= 256 && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
   }
 
-  private static boolean useQ4ShortPairwise(int blocks) {
-    return useQ4ShortPairwise(PanamaConstants.USE_Q4_SHORT_PAIRWISE, VECTOR_BITSIZE, blocks);
+  private static boolean useQ4ShortPairwise(GgufQ4Kernel kernel, int blocks) {
+    return useQ4ShortPairwise(kernel, VECTOR_BITSIZE, blocks);
   }
 
   // --- Float dot product: 4x unrolled FMA (Lucene pattern) ---
@@ -376,16 +382,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
     long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     GgufParallelSupport.forEachRow(
         qWeight,
         rows,
         cols,
-        row -> out[row] = q4_0Q8_0RowDot(qWeight, row * rowBytes, blocks, q8Quants, q8Scales));
+        row ->
+            out[row] =
+                q4_0Q8_0RowDot(
+                    qWeight, row * rowBytes, blocks, q8Quants, q8Scales, useShortPairwise));
   }
 
   @Override
@@ -399,11 +410,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] secondOut,
       int cols,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
     long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     int totalRows = Math.addExact(firstRows, secondRows);
     GgufParallelSupport.forEachRow(
         firstWeight,
@@ -433,7 +446,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               float scale =
                   Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
               IntVector integerLanes =
-                  useQ4ShortPairwise(blocks)
+                  useShortPairwise
                       ? q4_0Q8_0ShortPairwiseIntegerLanes(
                           qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE)
                       : q4_0Q8_0IntegerLanes(
@@ -476,11 +489,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] thirdOut,
       int cols,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
     long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
@@ -517,7 +532,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               float scale =
                   Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
               IntVector integerLanes =
-                  useQ4ShortPairwise(blocks)
+                  useShortPairwise
                       ? q4_0Q8_0ShortPairwiseIntegerLanes(
                           qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE)
                       : q4_0Q8_0IntegerLanes(
@@ -556,19 +571,20 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     if (batchSize == 1) {
-      ggufQ4_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
+      ggufQ4_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales, kernel);
       return;
     }
     if (VECTOR_BITSIZE < 256) {
       VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmul(
-          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch);
+          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch, kernel);
       return;
     }
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
-    boolean useShortPairwise = useQ4ShortPairwise(blocks);
+    boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(
           queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
@@ -645,7 +661,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     if (batchSize == 1) {
       ggufQ4_0Q8_0DualMatVecDot(
           queries,
@@ -657,7 +674,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           secondOut,
           cols,
           q8Quants,
-          q8Scales);
+          q8Scales,
+          kernel);
       return;
     }
     ggufQ4_0Q8_0GroupedBatchedMatmul(
@@ -675,7 +693,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         q8Quants,
         q8Scales,
-        laneScratch);
+        laneScratch,
+        kernel);
   }
 
   @Override
@@ -694,7 +713,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     if (batchSize == 1) {
       ggufQ4_0Q8_0TripleMatVecDot(
           queries,
@@ -709,7 +729,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           thirdOut,
           cols,
           q8Quants,
-          q8Scales);
+          q8Scales,
+          kernel);
       return;
     }
     ggufQ4_0Q8_0GroupedBatchedMatmul(
@@ -727,7 +748,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         q8Quants,
         q8Scales,
-        laneScratch);
+        laneScratch,
+        kernel);
   }
 
   private void ggufQ4_0Q8_0GroupedBatchedMatmul(
@@ -745,7 +767,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     if (VECTOR_BITSIZE < 256) {
       if (thirdRows == 0) {
         VectorUtilSupport.super.ggufQ4_0Q8_0DualBatchedMatmul(
@@ -760,7 +783,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             cols,
             q8Quants,
             q8Scales,
-            laneScratch);
+            laneScratch,
+            kernel);
       } else {
         VectorUtilSupport.super.ggufQ4_0Q8_0TripleBatchedMatmul(
             queries,
@@ -777,13 +801,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             cols,
             q8Quants,
             q8Scales,
-            laneScratch);
+            laneScratch,
+            kernel);
       }
       return;
     }
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
-    boolean useShortPairwise = useQ4ShortPairwise(blocks);
+    boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(
           queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
@@ -932,7 +957,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   private static float q4_0Q8_0RowDot(
-      MemorySegment qWeight, long rowOffset, int blocks, byte[] q8Quants, float[] q8Scales) {
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      float[] q8Scales,
+      boolean useShortPairwise) {
     if (VECTOR_BITSIZE >= 256) {
       FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
       for (int block = 0; block < blocks; block++) {
@@ -940,7 +970,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         float scale =
             Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
         IntVector integerLanes =
-            useQ4ShortPairwise(blocks)
+            useShortPairwise
                 ? q4_0Q8_0ShortPairwiseIntegerLanes(
                     qWeight, blockOffset + Short.BYTES, q8Quants, block * GGUF_Q_BLOCK_SIZE)
                 : q4_0Q8_0IntegerLanes(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorRuntimeCapabilities.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorRuntimeCapabilities.java
@@ -25,7 +25,7 @@ public record VectorRuntimeCapabilities(
     boolean fastVectorFma,
     boolean fastScalarFma,
     boolean sve,
-    boolean q4ShortPairwise,
+    boolean q4ShortPairwiseSupported,
     boolean ggufParallel,
     String ggufExecutor,
     int ggufThreads,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -424,10 +424,32 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ4_0Q8_0BatchDotProduct(
+        query, qWeight, rows, cols, out, q8Quants, q8Scales, GgufQ4Kernel.WIDENED);
+  }
+
+  /** Q4_0 by Q8_0 GEMV with an explicit arithmetic-kernel policy. */
+  public static void ggufQ4_0Q8_0BatchDotProduct(
+      float[] query,
+      MemorySegment qWeight,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchArguments(
         query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
-    IMPL.ggufQ4_0Q8_0MatVecDot(query, qWeight, rows, cols, out, q8Quants, q8Scales);
+    IMPL.ggufQ4_0Q8_0MatVecDot(
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        Objects.requireNonNull(kernel, "kernel"));
   }
 
   /**
@@ -448,6 +470,33 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ4_0Q8_0DualBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        GgufQ4Kernel.WIDENED);
+  }
+
+  /** Two Q4_0 projections with an explicit arithmetic-kernel policy. */
+  public static void ggufQ4_0Q8_0DualBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchArguments(
         query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufQuantizedBatchArguments(
@@ -463,7 +512,8 @@ public final class VectorUtil {
         secondOut,
         cols,
         q8Quants,
-        q8Scales);
+        q8Scales,
+        Objects.requireNonNull(kernel, "kernel"));
   }
 
   /**
@@ -486,6 +536,39 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ4_0Q8_0TripleBatchDotProduct(
+        query,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        GgufQ4Kernel.WIDENED);
+  }
+
+  /** Three Q4_0 projections with an explicit arithmetic-kernel policy. */
+  public static void ggufQ4_0Q8_0TripleBatchDotProduct(
+      float[] query,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchArguments(
         query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufQuantizedBatchArguments(
@@ -506,7 +589,8 @@ public final class VectorUtil {
         thirdOut,
         cols,
         q8Quants,
-        q8Scales);
+        q8Scales,
+        Objects.requireNonNull(kernel, "kernel"));
   }
 
   /**
@@ -528,6 +612,21 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ4_0Q8_0BatchedMatmul(
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, GgufQ4Kernel.WIDENED);
+  }
+
+  /** Q4_0 batched matrix multiplication with an explicit arithmetic-kernel policy. */
+  public static void ggufQ4_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
     }
@@ -544,7 +643,8 @@ public final class VectorUtil {
         out,
         q8Quants,
         q8Scales,
-        new float[checkedProduct(outputEntries, 8, "Q4 lane scratch")]);
+        new float[checkedProduct(outputEntries, 8, "Q4 lane scratch")],
+        kernel);
   }
 
   /**
@@ -562,6 +662,31 @@ public final class VectorUtil {
       byte[] q8Quants,
       float[] q8Scales,
       float[] laneScratch) {
+    ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        laneScratch,
+        GgufQ4Kernel.WIDENED);
+  }
+
+  /** Allocation-free Q4_0 batched matrix multiplication with an explicit kernel policy. */
+  public static void ggufQ4_0Q8_0BatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
     }
@@ -605,7 +730,16 @@ public final class VectorUtil {
               + laneEntries);
     }
     IMPL.ggufQ4_0Q8_0BatchedMatmul(
-        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch);
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        laneScratch,
+        Objects.requireNonNull(kernel, "kernel"));
   }
 
   /** Two Q4_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
@@ -622,6 +756,37 @@ public final class VectorUtil {
       byte[] q8Quants,
       float[] q8Scales,
       float[] laneScratch) {
+    ggufQ4_0Q8_0DualBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        laneScratch,
+        GgufQ4Kernel.WIDENED);
+  }
+
+  /** Two Q4_0 batched projections with an explicit arithmetic-kernel policy. */
+  public static void ggufQ4_0Q8_0DualBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchedArguments(
         queries,
         firstWeight,
@@ -657,7 +822,8 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
-        laneScratch);
+        laneScratch,
+        Objects.requireNonNull(kernel, "kernel"));
   }
 
   /** Three Q4_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
@@ -677,6 +843,43 @@ public final class VectorUtil {
       byte[] q8Quants,
       float[] q8Scales,
       float[] laneScratch) {
+    ggufQ4_0Q8_0TripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        laneScratch,
+        GgufQ4Kernel.WIDENED);
+  }
+
+  /** Three Q4_0 batched projections with an explicit arithmetic-kernel policy. */
+  public static void ggufQ4_0Q8_0TripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchedArguments(
         queries,
         firstWeight,
@@ -724,7 +927,8 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
-        laneScratch);
+        laneScratch,
+        Objects.requireNonNull(kernel, "kernel"));
   }
 
   /** Batched row-major GEMV over GGUF Q4_K rows. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -538,7 +538,8 @@ public interface VectorUtilSupport {
       int cols,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
     long rowBytes = ggufQ4_0RowBytes(cols);
@@ -559,7 +560,8 @@ public interface VectorUtilSupport {
       float[] secondOut,
       int cols,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
     long rowBytes = ggufQ4_0RowBytes(cols);
@@ -588,7 +590,8 @@ public interface VectorUtilSupport {
       float[] thirdOut,
       int cols,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      GgufQ4Kernel kernel) {
     quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
     long rowBytes = ggufQ4_0RowBytes(cols);
@@ -651,7 +654,8 @@ public interface VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(
@@ -700,7 +704,8 @@ public interface VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(
@@ -750,7 +755,8 @@ public interface VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
-      float[] laneScratch) {
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_0(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -72,7 +72,7 @@ public final class VectorizationProvider {
         PanamaConstants.HAS_FAST_VECTOR_FMA,
         PanamaConstants.HAS_FAST_SCALAR_FMA,
         PanamaConstants.HAS_SVE,
-        PanamaConstants.USE_Q4_SHORT_PAIRWISE,
+        vectorApi && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256,
         GgufParallelSupport.enabled(),
         GgufParallelSupport.executionMode().name().toLowerCase(Locale.ROOT),
         GgufParallelSupport.parallelism(),
@@ -124,7 +124,6 @@ public final class VectorizationProvider {
     String ggufChunksPerThread = System.getProperty("vectors.gguf.chunksPerThread");
     String mappedKQuantLongOffsets =
         System.getProperty(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY);
-    String q4ShortPairwise = System.getProperty(PanamaConstants.Q4_SHORT_PAIRWISE_PROPERTY);
     PanamaConstants.MappedKQuantLongOffsetPolicy mappedKQuantPolicy =
         PanamaConstants.mappedKQuantLongOffsetPolicy();
 
@@ -151,7 +150,10 @@ public final class VectorizationProvider {
         .append(",q6=")
         .append(mappedKQuantPolicy.q6())
         .append(')');
-    sb.append(" q4ShortPairwise=").append(PanamaConstants.USE_Q4_SHORT_PAIRWISE);
+    sb.append(" q4ShortPairwiseSupported=")
+        .append(
+            impl instanceof PanamaVectorUtilSupport
+                && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256);
     sb.append(" toggles=[");
     boolean first = true;
     if (forceScalar != null) {
@@ -203,11 +205,6 @@ public final class VectorizationProvider {
       sb.append(PanamaConstants.MAPPED_K_QUANT_LONG_OFFSETS_PROPERTY)
           .append('=')
           .append(mappedKQuantLongOffsets);
-      first = false;
-    }
-    if (q4ShortPairwise != null) {
-      if (!first) sb.append(", ");
-      sb.append(PanamaConstants.Q4_SHORT_PAIRWISE_PROPERTY).append('=').append(q4ShortPairwise);
       first = false;
     }
     if (first) sb.append("(defaults — no -Dvectors.* overrides)");

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -492,21 +492,55 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0Q8_0ExplicitKernelModesMatchExactlyForModelSizedRows() {
+    int cols = 1024;
+    int rows = 3;
+    float[] query = patternedQuery(cols);
+    byte[] block = q4Block(0.125f, ones(cols), (low, high) -> (low * 11 + high * 7) & 0xFF);
+    byte[] weights = repeat(block, rows * (cols / 32));
+    float[] widened = new float[rows];
+    float[] pairwise = new float[rows];
+
+    MemorySegment segment = MemorySegment.ofArray(weights);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        segment,
+        rows,
+        cols,
+        widened,
+        new byte[cols],
+        new float[cols / 32],
+        GgufQ4Kernel.WIDENED);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        segment,
+        rows,
+        cols,
+        pairwise,
+        new byte[cols],
+        new float[cols / 32],
+        GgufQ4Kernel.SHORT_PAIRWISE);
+
+    assertThat(pairwise).containsExactly(widened);
+  }
+
+  @Test
   void q4_0Q8_0DualBatchDotProductMatchesSeparateMatmulsExactly() {
-    int cols = 64;
+    int cols = 1024;
     int firstRows = 2;
     int secondRows = 3;
     float[] query = patternedQuery(cols);
     byte[] firstWeights =
         concat(
-            repeat(q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), 2),
-            repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), 2));
+            repeat(q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), cols / 32),
+            repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32));
     byte[] secondWeights =
         concat(
             concat(
-                repeat(q4Block(0.5f, ones(cols), (lo, hi) -> (lo + hi * 11) & 0xFF), 2),
-                repeat(q4Block(-0.0625f, ones(cols), (lo, hi) -> (lo * 13 + hi) & 0xFF), 2)),
-            repeat(q4Block(0.03125f, ones(cols), (lo, hi) -> (lo * 3 + hi * 7) & 0xFF), 2));
+                repeat(q4Block(0.5f, ones(cols), (lo, hi) -> (lo + hi * 11) & 0xFF), cols / 32),
+                repeat(
+                    q4Block(-0.0625f, ones(cols), (lo, hi) -> (lo * 13 + hi) & 0xFF), cols / 32)),
+            repeat(q4Block(0.03125f, ones(cols), (lo, hi) -> (lo * 3 + hi * 7) & 0xFF), cols / 32));
     float[] expectedFirst = new float[firstRows];
     float[] expectedSecond = new float[secondRows];
     float[] actualFirst = new float[firstRows];
@@ -535,7 +569,8 @@ class GgufQuantizedDotTest {
         actualSecond,
         cols,
         new byte[cols],
-        new float[cols / 32]);
+        new float[cols / 32],
+        GgufQ4Kernel.SHORT_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);
@@ -543,7 +578,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q4_0Q8_0TripleBatchDotProductMatchesSeparateMatmulsExactly() {
-    int cols = 64;
+    int cols = 1024;
     int firstRows = 4;
     int secondRows = 2;
     int thirdRows = 3;
@@ -551,15 +586,18 @@ class GgufQuantizedDotTest {
     MemorySegment firstWeight =
         MemorySegment.ofArray(
             repeat(
-                q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), firstRows * 2));
+                q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF),
+                firstRows * (cols / 32)));
     MemorySegment secondWeight =
         MemorySegment.ofArray(
-            repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), secondRows * 2));
+            repeat(
+                q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF),
+                secondRows * (cols / 32)));
     MemorySegment thirdWeight =
         MemorySegment.ofArray(
             repeat(
                 q4Block(0.03125f, ones(cols), (lo, hi) -> (lo * 3 + hi * 7) & 0xFF),
-                thirdRows * 2));
+                thirdRows * (cols / 32)));
     float[] expectedFirst = new float[firstRows];
     float[] expectedSecond = new float[secondRows];
     float[] expectedThird = new float[thirdRows];
@@ -593,7 +631,8 @@ class GgufQuantizedDotTest {
         actualThird,
         cols,
         new byte[cols],
-        new float[cols / 32]);
+        new float[cols / 32],
+        GgufQ4Kernel.SHORT_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);
@@ -604,15 +643,16 @@ class GgufQuantizedDotTest {
   void q4_0Q8_0BatchedMatmulMatchesIndependentQueries() {
     int batchSize = 3;
     int rows = 2;
-    int cols = 32;
+    int cols = 1024;
     float[] queries = new float[batchSize * cols];
     for (int batch = 0; batch < batchSize; batch++) {
       for (int col = 0; col < cols; col++) {
         queries[batch * cols + col] = ((batch + 1) * (col - 13)) / 17.0f;
       }
     }
-    byte[] row0 = q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF);
-    byte[] row1 = q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF);
+    byte[] row0 =
+        repeat(q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), cols / 32);
+    byte[] row1 = repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32);
     float[] expected = new float[batchSize * rows];
     float[] actual = new float[batchSize * rows];
     byte[] q8Quants = new byte[batchSize * cols];
@@ -630,7 +670,15 @@ class GgufQuantizedDotTest {
       }
 
       VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
-          queries, segment, batchSize, rows, cols, actual, q8Quants, q8Scales);
+          queries,
+          segment,
+          batchSize,
+          rows,
+          cols,
+          actual,
+          q8Quants,
+          q8Scales,
+          GgufQ4Kernel.SHORT_PAIRWISE);
 
       assertThat(actual).containsExactly(expected);
       assertThat(q8Quants[0]).isNotZero();
@@ -640,12 +688,14 @@ class GgufQuantizedDotTest {
   @Test
   void q4_0Q8_0DualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
     int batchSize = 3;
-    int cols = 64;
+    int cols = 1024;
     int firstRows = 2;
     int secondRows = 3;
     float[] queries = patternedQueries(batchSize, cols);
-    byte[] firstRow = repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), 2);
-    byte[] secondRow = repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), 2);
+    byte[] firstRow =
+        repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), cols / 32);
+    byte[] secondRow =
+        repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32);
     MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
     MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
     float[] expectedFirst = new float[batchSize * firstRows];
@@ -688,7 +738,8 @@ class GgufQuantizedDotTest {
         cols,
         quants,
         scales,
-        new float[batchSize * (firstRows + secondRows) * 8]);
+        new float[batchSize * (firstRows + secondRows) * 8],
+        GgufQ4Kernel.SHORT_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);
@@ -697,14 +748,17 @@ class GgufQuantizedDotTest {
   @Test
   void q4_0Q8_0TripleBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
     int batchSize = 3;
-    int cols = 64;
+    int cols = 1024;
     int firstRows = 2;
     int secondRows = 3;
     int thirdRows = 1;
     float[] queries = patternedQueries(batchSize, cols);
-    byte[] firstRow = repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), 2);
-    byte[] secondRow = repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), 2);
-    byte[] thirdRow = repeat(q4Block(0.0625f, ones(32), (lo, hi) -> (lo * 11 + hi * 13) & 0xFF), 2);
+    byte[] firstRow =
+        repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), cols / 32);
+    byte[] secondRow =
+        repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32);
+    byte[] thirdRow =
+        repeat(q4Block(0.0625f, ones(32), (lo, hi) -> (lo * 11 + hi * 13) & 0xFF), cols / 32);
     MemorySegment firstWeight = MemorySegment.ofArray(repeat(firstRow, firstRows));
     MemorySegment secondWeight = MemorySegment.ofArray(repeat(secondRow, secondRows));
     MemorySegment thirdWeight = MemorySegment.ofArray(repeat(thirdRow, thirdRows));
@@ -763,7 +817,8 @@ class GgufQuantizedDotTest {
         cols,
         quants,
         scales,
-        new float[batchSize * (firstRows + secondRows + thirdRows) * 8]);
+        new float[batchSize * (firstRows + secondRows + thirdRows) * 8],
+        GgufQ4Kernel.SHORT_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaConstantsTest.java
@@ -148,17 +148,6 @@ class PanamaConstantsTest {
     assertThat(forced.q6()).isTrue();
   }
 
-  @Test
-  void q4ShortPairwisePolicyRequiresExplicitBooleanOptIn() {
-    assertThat(PanamaConstants.resolveQ4ShortPairwise(null)).isFalse();
-    assertThat(PanamaConstants.resolveQ4ShortPairwise(" ")).isFalse();
-    assertThat(PanamaConstants.resolveQ4ShortPairwise("false")).isFalse();
-    assertThat(PanamaConstants.resolveQ4ShortPairwise("TRUE")).isTrue();
-    assertThatThrownBy(() -> PanamaConstants.resolveQ4ShortPairwise("auto"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("vectors.gguf.q4ShortPairwise");
-  }
-
   // ─── P3.5 SVE detection ────────────────────────────────────────────────────
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -31,11 +31,25 @@ import org.junit.jupiter.api.Test;
 class PanamaGgufQuantizedDotTest {
 
   @Test
-  void q4ShortPairwiseRequiresOptInAvx2WidthAndModelSizedRows() {
-    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(false, 256, 64)).isFalse();
-    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(true, 128, 64)).isFalse();
-    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(true, 256, 31)).isFalse();
-    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(true, 256, 32)).isTrue();
+  void q4ShortPairwiseRequiresExplicitSelectionAvx2WidthAndModelSizedRows() {
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.WIDENED, 256, 64)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 128, 64))
+        .isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 256, 31))
+        .isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 256, 32))
+        .isTrue();
+  }
+
+  @Test
+  void explicitQ4KernelSelectionCannotBypassHardwareEligibility() {
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.WIDENED, 256, 64)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 256, 64))
+        .isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 128, 64))
+        .isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 256, 31))
+        .isFalse();
   }
 
   @Test
@@ -321,10 +335,24 @@ class PanamaGgufQuantizedDotTest {
 
     new ScalarVectorUtilSupport()
         .ggufQ4_0Q8_0MatVecDot(
-            query, weightSegment, rows, cols, expected, expectedQuants, expectedScales);
+            query,
+            weightSegment,
+            rows,
+            cols,
+            expected,
+            expectedQuants,
+            expectedScales,
+            GgufQ4Kernel.WIDENED);
     new PanamaVectorUtilSupport()
         .ggufQ4_0Q8_0MatVecDot(
-            query, weightSegment, rows, cols, actual, actualQuants, actualScales);
+            query,
+            weightSegment,
+            rows,
+            cols,
+            actual,
+            actualQuants,
+            actualScales,
+            GgufQ4Kernel.WIDENED);
 
     assertThat(actualQuants).containsExactly(expectedQuants);
     assertThat(actualScales).containsExactly(expectedScales);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -50,7 +50,7 @@ class VectorizationProviderTest {
     assertThat(summary).contains("ggufChunksPerThread=2");
     assertThat(summary).contains("mappedKQuantLongOffsets=auto(");
     assertThat(summary).contains("q4=").contains("q5=").contains("q6=");
-    assertThat(summary).contains("q4ShortPairwise=" + PanamaConstants.USE_Q4_SHORT_PAIRWISE);
+    assertThat(summary).contains("q4ShortPairwiseSupported=");
     assertThat(summary).contains("toggles=[");
     assertThat(summary).endsWith("]");
   }
@@ -129,7 +129,10 @@ class VectorizationProviderTest {
         .isEqualTo(
             VectorizationProvider.isPanamaEnabled() ? PanamaVectorUtilSupport.VECTOR_BITSIZE : 0);
     assertThat(capabilities.ggufExecutor()).isEqualTo("persistent");
-    assertThat(capabilities.q4ShortPairwise()).isEqualTo(PanamaConstants.USE_Q4_SHORT_PAIRWISE);
+    assertThat(capabilities.q4ShortPairwiseSupported())
+        .isEqualTo(
+            VectorizationProvider.isPanamaEnabled()
+                && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256);
     assertThat(capabilities.ggufThreads()).isEqualTo(GgufParallelSupport.parallelism());
     assertThat(capabilities.ggufChunksPerThread()).isEqualTo(GgufParallelSupport.chunksPerThread());
   }


### PR DESCRIPTION
## Summary
- expose explicit widened and signed-short pairwise Q4_0/Q8_0 kernel policies
- route all single, grouped, and batched Q4 operations through the selected policy
- remove the process-global pairwise switch and report support as a runtime capability

## Verification
- ./gradlew :vectors-core:test with the focused GGUF and provider suites
- ./gradlew :vectors-core:check