### PR TITLE
perf(core): batch weighted row accumulation

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/WeightedRowsBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/WeightedRowsBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.util.Arrays;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares repeated SAXPY calls with the four-row weighted accumulation kernel. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 4, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class WeightedRowsBenchmark {
+
+  @Param({"64", "192", "512"})
+  int rows;
+
+  @Param({"128"})
+  int columns;
+
+  private int rowStride;
+  private float[] matrix;
+  private float[] weights;
+  private float[] out;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    rowStride = 1024;
+    SplittableRandom random = new SplittableRandom(42L);
+    matrix = new float[rows * rowStride];
+    weights = new float[rows];
+    out = new float[columns];
+    for (int index = 0; index < matrix.length; index++) {
+      matrix[index] = (float) random.nextDouble(-1.0, 1.0);
+    }
+    for (int index = 0; index < weights.length; index++) {
+      weights[index] = (float) random.nextDouble(-1.0, 1.0);
+    }
+  }
+
+  @Benchmark
+  public void repeatedAddScaled(Blackhole blackhole) {
+    Arrays.fill(out, 0.0f);
+    for (int row = 0; row < rows; row++) {
+      VectorUtil.addScaledInPlace(out, 0, matrix, row * rowStride, columns, weights[row]);
+    }
+    blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void fourRowWeightedSum(Blackhole blackhole) {
+    Arrays.fill(out, 0.0f);
+    VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, rowStride, weights, 0, rows, columns);
+    blackhole.consume(out);
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -4123,6 +4123,60 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void addWeightedRowsInPlace(
+      float[] out,
+      int outOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      float[] weights,
+      int weightsOffset,
+      int rows,
+      int columns) {
+    int row = 0;
+    int fourRowLimit = rows & ~3;
+    int vectorLimit = FLOAT_SPECIES.loopBound(columns);
+    for (; row < fourRowLimit; row += 4) {
+      int row0 = matrixOffset + row * rowStride;
+      int row1 = row0 + rowStride;
+      int row2 = row1 + rowStride;
+      int row3 = row2 + rowStride;
+      FloatVector weight0 = FloatVector.broadcast(FLOAT_SPECIES, weights[weightsOffset + row]);
+      FloatVector weight1 = FloatVector.broadcast(FLOAT_SPECIES, weights[weightsOffset + row + 1]);
+      FloatVector weight2 = FloatVector.broadcast(FLOAT_SPECIES, weights[weightsOffset + row + 2]);
+      FloatVector weight3 = FloatVector.broadcast(FLOAT_SPECIES, weights[weightsOffset + row + 3]);
+
+      int column = 0;
+      for (; column < vectorLimit; column += FLOAT_SPECIES.length()) {
+        FloatVector result = FloatVector.fromArray(FLOAT_SPECIES, out, outOffset + column);
+        result = fma(FloatVector.fromArray(FLOAT_SPECIES, matrix, row0 + column), weight0, result);
+        result = fma(FloatVector.fromArray(FLOAT_SPECIES, matrix, row1 + column), weight1, result);
+        result = fma(FloatVector.fromArray(FLOAT_SPECIES, matrix, row2 + column), weight2, result);
+        result = fma(FloatVector.fromArray(FLOAT_SPECIES, matrix, row3 + column), weight3, result);
+        result.intoArray(out, outOffset + column);
+      }
+      for (; column < columns; column++) {
+        int outIndex = outOffset + column;
+        float result = out[outIndex];
+        result = MathUtil.fma(matrix[row0 + column], weights[weightsOffset + row], result);
+        result = MathUtil.fma(matrix[row1 + column], weights[weightsOffset + row + 1], result);
+        result = MathUtil.fma(matrix[row2 + column], weights[weightsOffset + row + 2], result);
+        result = MathUtil.fma(matrix[row3 + column], weights[weightsOffset + row + 3], result);
+        out[outIndex] = result;
+      }
+    }
+    for (; row < rows; row++) {
+      addScaledInPlace(
+          out,
+          outOffset,
+          matrix,
+          matrixOffset + row * rowStride,
+          columns,
+          weights[weightsOffset + row]);
+    }
+  }
+
+  @Override
   public void subInPlace(float[] v1, float[] v2) {
     int i = 0;
     int limit = FLOAT_SPECIES.loopBound(v1.length);

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/ScalarVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/ScalarVectorUtilSupport.java
@@ -246,6 +246,28 @@ final class ScalarVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void addWeightedRowsInPlace(
+      float[] out,
+      int outOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      float[] weights,
+      int weightsOffset,
+      int rows,
+      int columns) {
+    for (int row = 0; row < rows; row++) {
+      addScaledInPlace(
+          out,
+          outOffset,
+          matrix,
+          matrixOffset + row * rowStride,
+          columns,
+          weights[weightsOffset + row]);
+    }
+  }
+
+  @Override
   public void subInPlace(float[] v1, float[] v2) {
     for (int i = 0; i < v1.length; i++) {
       v1[i] -= v2[i];

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -140,6 +140,26 @@ public final class VectorUtil {
     IMPL.addScaledInPlace(out, outOffset, vector, vectorOffset, length, scale);
   }
 
+  /**
+   * Adds a weighted sum of flat, strided matrix rows to {@code out} in ascending row order. Inputs
+   * must not alias {@code out}.
+   */
+  public static void addWeightedRowsInPlace(
+      float[] out,
+      int outOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      float[] weights,
+      int weightsOffset,
+      int rows,
+      int columns) {
+    checkWeightedRowsArguments(
+        out, outOffset, matrix, matrixOffset, rowStride, weights, weightsOffset, rows, columns);
+    IMPL.addWeightedRowsInPlace(
+        out, outOffset, matrix, matrixOffset, rowStride, weights, weightsOffset, rows, columns);
+  }
+
   /** Subtracts v2 from v1 element-wise in place. */
   public static void subInPlace(float[] v1, float[] v2) {
     checkDimensions(v1.length, v2.length);
@@ -2291,6 +2311,45 @@ public final class VectorUtil {
               + length
               + " > "
               + vector.length);
+    }
+  }
+
+  private static void checkWeightedRowsArguments(
+      float[] out,
+      int outOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      float[] weights,
+      int weightsOffset,
+      int rows,
+      int columns) {
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(matrix, "matrix");
+    Objects.requireNonNull(weights, "weights");
+    if (out == matrix || out == weights) {
+      throw new IllegalArgumentException("matrix and weights must not alias out");
+    }
+    if (outOffset < 0 || matrixOffset < 0 || weightsOffset < 0) {
+      throw new IllegalArgumentException("offsets must be >= 0");
+    }
+    if (rows < 0 || columns < 0) {
+      throw new IllegalArgumentException("rows and columns must be >= 0");
+    }
+    if (rowStride < columns) {
+      throw new IllegalArgumentException(
+          "rowStride must be >= columns: " + rowStride + " < " + columns);
+    }
+    if ((long) outOffset + columns > out.length) {
+      throw new IllegalArgumentException("output range exceeds out.length");
+    }
+    if ((long) weightsOffset + rows > weights.length) {
+      throw new IllegalArgumentException("weight range exceeds weights.length");
+    }
+    long matrixEnd =
+        rows == 0 ? matrixOffset : (long) matrixOffset + (long) (rows - 1) * rowStride + columns;
+    if (matrixEnd > matrix.length) {
+      throw new IllegalArgumentException("matrix range exceeds matrix.length");
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -114,6 +114,21 @@ public interface VectorUtilSupport {
     }
   }
 
+  /**
+   * Adds a weighted sum of flat, strided matrix rows to {@code out} in ascending row order.
+   * Implementations must preserve that row order for each output element.
+   */
+  void addWeightedRowsInPlace(
+      float[] out,
+      int outOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      float[] weights,
+      int weightsOffset,
+      int rows,
+      int columns);
+
   /** Subtracts v2 from v1 element-wise, storing the result in v1. */
   void subInPlace(float[] v1, float[] v2);
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
@@ -591,6 +591,23 @@ class VectorUtilSupportTest {
 
     @ParameterizedTest(name = "dim={0}")
     @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
+    void addWeightedRowsInPlacePanamaMatchesScalarExactly(int dim) {
+      Random rng = new Random(SEED);
+      int rows = 7;
+      int rowStride = dim + 3;
+      float[] matrix = randomFloats(2 + rows * rowStride, rng);
+      float[] weights = randomFloats(rows + 2, rng);
+      float[] expected = randomFloats(dim + 2, rng);
+      float[] actual = expected.clone();
+
+      scalar.addWeightedRowsInPlace(expected, 1, matrix, 2, rowStride, weights, 1, rows, dim);
+      panama.addWeightedRowsInPlace(actual, 1, matrix, 2, rowStride, weights, 1, rows, dim);
+
+      assertThat(actual).containsExactly(expected);
+    }
+
+    @ParameterizedTest(name = "dim={0}")
+    @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
     void subInPlacePanamaMatchesScalar(int dim) {
       Random rng = new Random(SEED);
       float[] a1 = randomFloats(dim, rng);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilTest.java
@@ -109,6 +109,66 @@ class VectorUtilTest {
   }
 
   @Test
+  void addWeightedRowsInPlace_withOffsetsAndStride() {
+    float[] out = {99.0f, 1.0f, 2.0f, 98.0f};
+    float[] matrix = {
+      97.0f, 2.0f, 4.0f, 96.0f, 95.0f, 6.0f, 8.0f, 94.0f, 93.0f, 10.0f, 12.0f, 92.0f
+    };
+    float[] weights = {91.0f, 0.5f, -1.0f, 2.0f, 90.0f};
+
+    VectorUtil.addWeightedRowsInPlace(out, 1, matrix, 1, 4, weights, 1, 3, 2);
+
+    assertThat(out).containsExactly(99.0f, 16.0f, 20.0f, 98.0f);
+  }
+
+  @Test
+  void addWeightedRowsInPlace_rejectsInvalidArguments() {
+    float[] out = {1.0f, 2.0f};
+    float[] matrix = {3.0f, 4.0f, 5.0f, 6.0f};
+    float[] weights = {0.5f, 1.5f};
+
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(null, 0, matrix, 0, 2, weights, 0, 2, 2))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, null, 0, 2, weights, 0, 2, 2))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 2, null, 0, 2, 2))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, -1, matrix, 0, 2, weights, 0, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, -1, 2, weights, 0, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 2, weights, -1, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 2, weights, 0, -1, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 2, weights, 0, 2, -1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 1, weights, 0, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 1, matrix, 0, 2, weights, 0, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 1, 2, weights, 0, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 2, weights, 1, 2, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> VectorUtil.addWeightedRowsInPlace(out, 0, out, 0, 2, weights, 0, 1, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> VectorUtil.addWeightedRowsInPlace(out, 0, matrix, 0, 2, out, 0, 1, 2))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void addScaledInPlace_rejectsInvalidArguments() {
     float[] out = {1.0f, 2.0f};
     float[] vector = {3.0f, 4.0f};


### PR DESCRIPTION
## Summary
- add a generic strided weighted-row accumulation primitive
- implement an order-preserving four-row Panama kernel and explicit scalar reference
- require exact scalar/Panama agreement across vector widths and tails
- add a production-shaped JMH comparison for attention-style cache layouts

## Local JDK 25 evidence
- 64x128: 1.572 to 1.048 us/op
- 512x128: 16.186 to 11.946 us/op
- 192x128 candidate: stable 3.904 us/op; baseline contained an OS-noise outlier and will be repeated on the controlled AMD host

## Verification
- ./gradlew :vectors-core:test --tests com.integrallis.vectors.core.VectorUtilTest --tests com.integrallis.vectors.core.VectorUtilSupportTest
- ./gradlew :vectors-bench:spotbugsJmh :vectors-core:check
- ./gradlew :vectors-bench:jmh -Pjmh.includes=WeightedRowsBenchmark