### PR TITLE
perf(core): batch exact strided dot products

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/ExactStridedBatchDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/ExactStridedBatchDotBenchmark.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.bench;
+
+import com.integrallis.vectors.core.VectorUtil;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Compares exact strided key-row batching with independent offset dot products. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 4, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class ExactStridedBatchDotBenchmark {
+
+  @Param({"64", "192", "512"})
+  int rows;
+
+  @Param({"128"})
+  int columns;
+
+  private int queryOffset;
+  private int matrixOffset;
+  private int rowStride;
+  private int outOffset;
+  private float[] query;
+  private float[] matrix;
+  private float[] out;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    queryOffset = 7;
+    matrixOffset = 11;
+    rowStride = 1024;
+    outOffset = 3;
+    SplittableRandom random = new SplittableRandom(42L);
+    query = randomFloats(random, queryOffset + columns + 5);
+    matrix = randomFloats(random, matrixOffset + (rows - 1) * rowStride + columns + 5);
+    out = new float[outOffset + rows + 5];
+  }
+
+  @Benchmark
+  public void independentDots(Blackhole blackhole) {
+    for (int row = 0; row < rows; row++) {
+      out[outOffset + row] =
+          VectorUtil.dotProduct(
+              query, queryOffset, matrix, matrixOffset + row * rowStride, columns);
+    }
+    blackhole.consume(out);
+  }
+
+  @Benchmark
+  public void exactTwoRowBatch(Blackhole blackhole) {
+    VectorUtil.batchDotProductExact(
+        query, queryOffset, matrix, matrixOffset, rowStride, rows, columns, out, outOffset);
+    blackhole.consume(out);
+  }
+
+  private static float[] randomFloats(SplittableRandom random, int length) {
+    float[] values = new float[length];
+    for (int index = 0; index < values.length; index++) {
+      values[index] = (float) random.nextDouble(-1.0, 1.0);
+    }
+    return values;
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -4278,6 +4278,117 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   // --- Fused batch matrix-vector kernels (GEMV) ---
 
+  /** Two-row strided GEMV with the same accumulator chains as the independent dot kernel. */
+  @Override
+  public void matVecDotExact(
+      float[] query,
+      int queryOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      int rows,
+      int columns,
+      float[] out,
+      int outOffset) {
+    int pairedRows = rows & ~1;
+    int speciesLength = FLOAT_SPECIES.length();
+
+    for (int row = 0; row < pairedRows; row += 2) {
+      int base0 = matrixOffset + row * rowStride;
+      int base1 = base0 + rowStride;
+      int column = 0;
+      float sum0 = 0.0f;
+      float sum1 = 0.0f;
+
+      if (columns > 2 * speciesLength) {
+        int vectorLimit = FLOAT_SPECIES.loopBound(columns);
+        int unrolledLimit = vectorLimit - 3 * speciesLength;
+        FloatVector acc00 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc01 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc02 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc03 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc10 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc11 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc12 = FloatVector.zero(FLOAT_SPECIES);
+        FloatVector acc13 = FloatVector.zero(FLOAT_SPECIES);
+
+        for (; column < unrolledLimit; column += 4 * speciesLength) {
+          FloatVector query0 = FloatVector.fromArray(FLOAT_SPECIES, query, queryOffset + column);
+          acc00 = fma(query0, FloatVector.fromArray(FLOAT_SPECIES, matrix, base0 + column), acc00);
+          acc10 = fma(query0, FloatVector.fromArray(FLOAT_SPECIES, matrix, base1 + column), acc10);
+
+          FloatVector query1 =
+              FloatVector.fromArray(FLOAT_SPECIES, query, queryOffset + column + speciesLength);
+          acc01 =
+              fma(
+                  query1,
+                  FloatVector.fromArray(FLOAT_SPECIES, matrix, base0 + column + speciesLength),
+                  acc01);
+          acc11 =
+              fma(
+                  query1,
+                  FloatVector.fromArray(FLOAT_SPECIES, matrix, base1 + column + speciesLength),
+                  acc11);
+
+          FloatVector query2 =
+              FloatVector.fromArray(FLOAT_SPECIES, query, queryOffset + column + 2 * speciesLength);
+          acc02 =
+              fma(
+                  query2,
+                  FloatVector.fromArray(FLOAT_SPECIES, matrix, base0 + column + 2 * speciesLength),
+                  acc02);
+          acc12 =
+              fma(
+                  query2,
+                  FloatVector.fromArray(FLOAT_SPECIES, matrix, base1 + column + 2 * speciesLength),
+                  acc12);
+
+          FloatVector query3 =
+              FloatVector.fromArray(FLOAT_SPECIES, query, queryOffset + column + 3 * speciesLength);
+          acc03 =
+              fma(
+                  query3,
+                  FloatVector.fromArray(FLOAT_SPECIES, matrix, base0 + column + 3 * speciesLength),
+                  acc03);
+          acc13 =
+              fma(
+                  query3,
+                  FloatVector.fromArray(FLOAT_SPECIES, matrix, base1 + column + 3 * speciesLength),
+                  acc13);
+        }
+
+        for (; column < vectorLimit; column += speciesLength) {
+          FloatVector queryVector =
+              FloatVector.fromArray(FLOAT_SPECIES, query, queryOffset + column);
+          acc00 =
+              fma(queryVector, FloatVector.fromArray(FLOAT_SPECIES, matrix, base0 + column), acc00);
+          acc10 =
+              fma(queryVector, FloatVector.fromArray(FLOAT_SPECIES, matrix, base1 + column), acc10);
+        }
+
+        FloatVector row0First = acc00.add(acc01);
+        FloatVector row0Second = acc02.add(acc03);
+        FloatVector row1First = acc10.add(acc11);
+        FloatVector row1Second = acc12.add(acc13);
+        sum0 += reduceAdd(row0First.add(row0Second));
+        sum1 += reduceAdd(row1First.add(row1Second));
+      }
+
+      for (; column < columns; column++) {
+        float queryValue = query[queryOffset + column];
+        sum0 = MathUtil.fma(queryValue, matrix[base0 + column], sum0);
+        sum1 = MathUtil.fma(queryValue, matrix[base1 + column], sum1);
+      }
+      out[outOffset + row] = sum0;
+      out[outOffset + row + 1] = sum1;
+    }
+
+    for (int row = pairedRows; row < rows; row++) {
+      out[outOffset + row] =
+          dotProduct(query, queryOffset, matrix, matrixOffset + row * rowStride, columns);
+    }
+  }
+
   /**
    * SIMD 4-row-unrolled fused GEMV for dot product.
    *

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/ScalarVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/ScalarVectorUtilSupport.java
@@ -59,6 +59,23 @@ final class ScalarVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void matVecDotExact(
+      float[] query,
+      int queryOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      int rows,
+      int columns,
+      float[] out,
+      int outOffset) {
+    for (int row = 0; row < rows; row++) {
+      out[outOffset + row] =
+          dotProduct(query, queryOffset, matrix, matrixOffset + row * rowStride, columns);
+    }
+  }
+
+  @Override
   public float squareDistance(float[] a, float[] b) {
     return squareDistance(a, 0, b, 0, a.length);
   }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -215,6 +215,29 @@ public final class VectorUtil {
   }
 
   /**
+   * Fills an output range from offset query and strided matrix rows. Every result is bit-identical
+   * to calling this provider's offset {@link #dotProduct(float[], int, float[], int, int)} for that
+   * row independently.
+   *
+   * <p>The output must not alias either input array.
+   */
+  public static void batchDotProductExact(
+      float[] query,
+      int queryOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      int rows,
+      int columns,
+      float[] out,
+      int outOffset) {
+    checkExactStridedBatchArguments(
+        query, queryOffset, matrix, matrixOffset, rowStride, rows, columns, out, outOffset);
+    IMPL.matVecDotExact(
+        query, queryOffset, matrix, matrixOffset, rowStride, rows, columns, out, outOffset);
+  }
+
+  /**
    * Fused GEMV over a little-endian GGUF F32 matrix stored in mapped or off-heap memory.
    *
    * <p>This avoids copying the full matrix to a temporary heap array before each projection.
@@ -2252,6 +2275,45 @@ public final class VectorUtil {
     if (out.length < rows) {
       throw new IllegalArgumentException(
           "out.length must be >= rows: " + out.length + " < " + rows);
+    }
+  }
+
+  private static void checkExactStridedBatchArguments(
+      float[] query,
+      int queryOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      int rows,
+      int columns,
+      float[] out,
+      int outOffset) {
+    Objects.requireNonNull(query, "query");
+    Objects.requireNonNull(matrix, "matrix");
+    Objects.requireNonNull(out, "out");
+    if (queryOffset < 0 || matrixOffset < 0 || outOffset < 0) {
+      throw new IllegalArgumentException("query, matrix, and output offsets must be >= 0");
+    }
+    if (rows < 0 || columns < 0) {
+      throw new IllegalArgumentException("rows and columns must be >= 0");
+    }
+    if (rowStride < columns) {
+      throw new IllegalArgumentException(
+          "rowStride must be >= columns: " + rowStride + " < " + columns);
+    }
+    if (queryOffset > query.length - columns) {
+      throw new IllegalArgumentException("query range exceeds query.length");
+    }
+    long matrixEnd =
+        rows == 0 ? matrixOffset : matrixOffset + (long) (rows - 1) * rowStride + columns;
+    if (matrixEnd > matrix.length) {
+      throw new IllegalArgumentException("strided matrix range exceeds matrix.length");
+    }
+    if (outOffset > out.length - rows) {
+      throw new IllegalArgumentException("output range exceeds out.length");
+    }
+    if (out == query || out == matrix) {
+      throw new IllegalArgumentException("out must not alias query or matrix");
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -190,6 +190,21 @@ public interface VectorUtilSupport {
     }
   }
 
+  /**
+   * Fills an output range from offset query and strided matrix rows while preserving this
+   * provider's independent {@link #dotProduct(float[], int, float[], int, int)} result bit for bit.
+   */
+  void matVecDotExact(
+      float[] query,
+      int queryOffset,
+      float[] matrix,
+      int matrixOffset,
+      int rowStride,
+      int rows,
+      int columns,
+      float[] out,
+      int outOffset);
+
   /** Batched row-major GEMV over little-endian GGUF F32 rows without copying mapped weights. */
   default void ggufF32MatVecDot(
       float[] query, MemorySegment weight, int rows, int cols, float[] out) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
@@ -213,6 +213,48 @@ class VectorUtilSupportTest {
     }
   }
 
+  @Nested
+  class ExactStridedBatchDotProductTest {
+
+    @ParameterizedTest(name = "dim={0}")
+    @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
+    void matchesIndependentProviderDotProductsBitForBit(int dim) {
+      int queryOffset = 3;
+      int matrixOffset = 5;
+      int rowStride = dim + 7;
+      int rows = 7;
+      int outOffset = 2;
+      Random rng = new Random(SEED + dim);
+      float[] query = randomFloats(queryOffset + dim + 4, rng);
+      float[] matrix = randomFloats(matrixOffset + (rows - 1) * rowStride + dim + 6, rng);
+      float[] scalarOut = new float[outOffset + rows + 3];
+      float[] panamaOut = new float[outOffset + rows + 3];
+      java.util.Arrays.fill(scalarOut, Float.NaN);
+      java.util.Arrays.fill(panamaOut, Float.NaN);
+
+      scalar.matVecDotExact(
+          query, queryOffset, matrix, matrixOffset, rowStride, rows, dim, scalarOut, outOffset);
+      panama.matVecDotExact(
+          query, queryOffset, matrix, matrixOffset, rowStride, rows, dim, panamaOut, outOffset);
+
+      for (int row = 0; row < rows; row++) {
+        int rowOffset = matrixOffset + row * rowStride;
+        assertThat(Float.floatToRawIntBits(scalarOut[outOffset + row]))
+            .isEqualTo(
+                Float.floatToRawIntBits(
+                    scalar.dotProduct(query, queryOffset, matrix, rowOffset, dim)));
+        assertThat(Float.floatToRawIntBits(panamaOut[outOffset + row]))
+            .isEqualTo(
+                Float.floatToRawIntBits(
+                    panama.dotProduct(query, queryOffset, matrix, rowOffset, dim)));
+      }
+      assertThat(scalarOut[0]).isNaN();
+      assertThat(scalarOut[outOffset + rows]).isNaN();
+      assertThat(panamaOut[0]).isNaN();
+      assertThat(panamaOut[outOffset + rows]).isNaN();
+    }
+  }
+
   // ===========================
   // Float square distance tests
   // ===========================

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilTest.java
@@ -169,6 +169,41 @@ class VectorUtilTest {
   }
 
   @Test
+  void exactBatchDotProductSupportsOffsetsAndStridedRows() {
+    float[] query = {99.0f, 1.0f, 2.0f, 3.0f, 98.0f};
+    float[] matrix = {97.0f, 1.0f, 0.0f, 1.0f, 96.0f, 95.0f, 0.0f, 1.0f, 1.0f, 94.0f};
+    float[] out = {93.0f, Float.NaN, Float.NaN, 92.0f};
+
+    VectorUtil.batchDotProductExact(query, 1, matrix, 1, 5, 2, 3, out, 1);
+
+    assertThat(out).containsExactly(93.0f, 4.0f, 5.0f, 92.0f);
+  }
+
+  @Test
+  void exactBatchDotProductRejectsInvalidRangesAndAliases() {
+    float[] query = {1.0f, 2.0f};
+    float[] matrix = {3.0f, 4.0f, 5.0f, 6.0f};
+    float[] out = new float[2];
+
+    assertThatThrownBy(() -> VectorUtil.batchDotProductExact(query, 0, matrix, 0, 1, 2, 2, out, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rowStride");
+    assertThatThrownBy(() -> VectorUtil.batchDotProductExact(query, 1, matrix, 0, 2, 2, 2, out, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("query range");
+    assertThatThrownBy(() -> VectorUtil.batchDotProductExact(query, 0, matrix, 1, 2, 2, 2, out, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("matrix range");
+    assertThatThrownBy(() -> VectorUtil.batchDotProductExact(query, 0, matrix, 0, 2, 2, 2, out, 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("output range");
+    assertThatThrownBy(
+            () -> VectorUtil.batchDotProductExact(query, 0, matrix, 0, 2, 2, 2, query, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not alias");
+  }
+
+  @Test
   void addScaledInPlace_rejectsInvalidArguments() {
     float[] out = {1.0f, 2.0f};
     float[] vector = {3.0f, 4.0f};


### PR DESCRIPTION
## Summary
- add a mandatory provider contract for exact offset/stride batch dot products
- share query vector loads across two Panama rows while preserving independent-dot bits
- cover scalar and Panama providers, facade validation, and all test dimensions
- add a projection-shaped JMH benchmark

## Verification
- ./gradlew :vectors-core:spotlessApply :vectors-core:check :vectors-bench:spotbugsJmh
- controlled AMD EPYC-Milan / Graal JDK 25, 3 forks x 5 measurements:
  - 64 rows: 0.686 vs 0.784 us/op (12.5% faster)
  - 192 rows: 2.021 vs 2.360 us/op (14.4% faster)
  - 512 rows: 6.531 vs 7.471 us/op (12.6% faster)

Every batched result is raw-bit-identical to the active provider offset dotProduct result.