### PR TITLE
bench(core): align row dispatch chunk topology

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufRowDispatchBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufRowDispatchBenchmark.java
@@ -58,6 +58,9 @@ public class GgufRowDispatchBenchmark {
   @Param("1024")
   int cols;
 
+  @Param("2")
+  int chunksPerThread;
+
   private GgufRowExecutor executor;
   private float[] query;
   private float[] weights;
@@ -76,7 +79,7 @@ public class GgufRowDispatchBenchmark {
         GgufParallelSupport.newExecutor(
             GgufParallelSupport.ExecutionMode.parse(executionMode),
             parallelism,
-            4,
+            chunksPerThread,
             "vectors-bench");
   }
 


### PR DESCRIPTION
## Summary
- expose persistent-executor chunks per thread as a JMH parameter
- default the dispatch benchmark to the production topology of two chunks per thread
- remove the prior hardcoded four-chunk measurement mismatch

## Verification
- ./gradlew :vectors-bench:spotlessApply :vectors-bench:jmhClasses :vectors-bench:spotbugsJmh

## Context
A seeded-chunk executor candidate appeared 1.36% faster under the old four-chunk harness but regressed all three whole-model process-pair medians under the production two-chunk topology. The candidate was removed; this PR fixes the benchmark control before another executor experiment.