### PR TITLE
perf(core): add unsigned Q4 pairwise kernel

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
@@ -62,9 +62,11 @@ public class GgufBatchedMatmulBenchmark {
   private float[] independentOut;
   private byte[] batchedQuants;
   private float[] batchedScales;
+  private int[] batchedZeroPointCorrections;
   private float[] batchedLanes;
   private byte[] independentQuants;
   private float[] independentScales;
+  private int[] independentZeroPointCorrections;
 
   @Setup(Level.Trial)
   public void setUp() {
@@ -91,9 +93,11 @@ public class GgufBatchedMatmulBenchmark {
     independentOut = new float[rows];
     batchedQuants = new byte[batchSize * cols];
     batchedScales = new float[batchSize * (cols / 32)];
+    batchedZeroPointCorrections = new int[batchSize * cols / 4];
     batchedLanes = new float[batchSize * rows * 8];
     independentQuants = new byte[cols];
     independentScales = new float[cols / 32];
+    independentZeroPointCorrections = new int[cols / 4];
   }
 
   @Benchmark
@@ -107,6 +111,7 @@ public class GgufBatchedMatmulBenchmark {
         batchedOut,
         batchedQuants,
         batchedScales,
+        batchedZeroPointCorrections,
         batchedLanes);
     blackhole.consume(batchedOut);
   }
@@ -115,7 +120,14 @@ public class GgufBatchedMatmulBenchmark {
   public void independent(Blackhole blackhole) {
     for (float[] query : independentQueries) {
       VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-          query, weights, rows, cols, independentOut, independentQuants, independentScales);
+          query,
+          weights,
+          rows,
+          cols,
+          independentOut,
+          independentQuants,
+          independentScales,
+          independentZeroPointCorrections);
       blackhole.consume(independentOut);
     }
   }

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQuantizedMatVecBenchmark.java
@@ -72,6 +72,7 @@ public class GgufQuantizedMatVecBenchmark {
   private float[] thirdOut;
   private byte[] q8Quants;
   private float[] q8Scales;
+  private int[] q8ZeroPointCorrections;
   private short[] q8Sums;
 
   @Setup(Level.Trial)
@@ -112,6 +113,7 @@ public class GgufQuantizedMatVecBenchmark {
     thirdOut = new float[auxiliaryRows];
     q8Quants = new byte[cols];
     q8Scales = new float[cols / 32];
+    q8ZeroPointCorrections = new int[cols / 4];
     q8Sums = new short[cols / 16];
   }
 
@@ -123,15 +125,17 @@ public class GgufQuantizedMatVecBenchmark {
 
   @Benchmark
   public void q4_0WithQ8_0Activation(Blackhole blackhole) {
-    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, q4Weights, rows, cols, out, q8Quants, q8Scales, q8ZeroPointCorrections);
     blackhole.consume(out);
   }
 
   @Benchmark
   public void q4_0SeparateDualProjection(Blackhole blackhole) {
-    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-        query, secondQ4Weights, rows, cols, secondOut, q8Quants, q8Scales);
+        query, q4Weights, rows, cols, out, q8Quants, q8Scales, q8ZeroPointCorrections);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query, secondQ4Weights, rows, cols, secondOut, q8Quants, q8Scales, q8ZeroPointCorrections);
     blackhole.consume(out);
     blackhole.consume(secondOut);
   }
@@ -139,7 +143,17 @@ public class GgufQuantizedMatVecBenchmark {
   @Benchmark
   public void q4_0GroupedDualProjection(Blackhole blackhole) {
     VectorUtil.ggufQ4_0Q8_0DualBatchDotProduct(
-        query, q4Weights, rows, out, secondQ4Weights, rows, secondOut, cols, q8Quants, q8Scales);
+        query,
+        q4Weights,
+        rows,
+        out,
+        secondQ4Weights,
+        rows,
+        secondOut,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8ZeroPointCorrections);
     blackhole.consume(out);
     blackhole.consume(secondOut);
   }
@@ -147,11 +161,26 @@ public class GgufQuantizedMatVecBenchmark {
   @Benchmark
   public void q4_0SeparateQkvProjection(Blackhole blackhole) {
     int auxiliaryRows = Math.max(1, rows / 8);
-    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(query, q4Weights, rows, cols, out, q8Quants, q8Scales);
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-        query, secondQ4Weights, auxiliaryRows, cols, secondOut, q8Quants, q8Scales);
+        query, q4Weights, rows, cols, out, q8Quants, q8Scales, q8ZeroPointCorrections);
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-        query, thirdQ4Weights, auxiliaryRows, cols, thirdOut, q8Quants, q8Scales);
+        query,
+        secondQ4Weights,
+        auxiliaryRows,
+        cols,
+        secondOut,
+        q8Quants,
+        q8Scales,
+        q8ZeroPointCorrections);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        thirdQ4Weights,
+        auxiliaryRows,
+        cols,
+        thirdOut,
+        q8Quants,
+        q8Scales,
+        q8ZeroPointCorrections);
     blackhole.consume(out);
     blackhole.consume(secondOut);
     blackhole.consume(thirdOut);
@@ -173,7 +202,8 @@ public class GgufQuantizedMatVecBenchmark {
         thirdOut,
         cols,
         q8Quants,
-        q8Scales);
+        q8Scales,
+        q8ZeroPointCorrections);
     blackhole.consume(out);
     blackhole.consume(secondOut);
     blackhole.consume(thirdOut);

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedDotBenchmark.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures unsigned-nibble Q4 arithmetic with precomputed Q8 zero-point corrections. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class GgufQ4UnsignedDotBenchmark {
+
+  private static final int BLOCK_BYTES = 18;
+  private static final int BLOCK_SIZE = 32;
+  private static final ValueLayout.OfShort LE_SHORT =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  @Param({"1", "32", "64"})
+  int blocks;
+
+  private MemorySegment weights;
+  private byte[] q8Quants;
+  private float[] q8Scales;
+  private int[] zeroPointCorrections;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(0x514750414952L);
+    byte[] weightBytes = new byte[blocks * BLOCK_BYTES];
+    q8Quants = new byte[blocks * BLOCK_SIZE];
+    q8Scales = new float[blocks];
+    zeroPointCorrections = new int[blocks * 8];
+    for (int block = 0; block < blocks; block++) {
+      int weightOffset = block * BLOCK_BYTES;
+      short scale = Float.floatToFloat16(0.001f + random.nextFloat() * 0.05f);
+      weightBytes[weightOffset] = (byte) scale;
+      weightBytes[weightOffset + 1] = (byte) (scale >>> 8);
+      for (int index = 0; index < 16; index++) {
+        weightBytes[weightOffset + Short.BYTES + index] = (byte) random.nextInt();
+      }
+      for (int index = 0; index < BLOCK_SIZE; index++) {
+        q8Quants[block * BLOCK_SIZE + index] = (byte) random.nextInt(-127, 128);
+      }
+      for (int group = 0; group < 8; group++) {
+        int start = block * BLOCK_SIZE + group * 4;
+        zeroPointCorrections[block * 8 + group] =
+            8 * (q8Quants[start] + q8Quants[start + 1] + q8Quants[start + 2] + q8Quants[start + 3]);
+      }
+      q8Scales[block] = 0.001f + random.nextFloat() * 0.05f;
+    }
+    weights = MemorySegment.ofArray(weightBytes);
+
+    float expected = scalarReference();
+    float actual = unsignedBytePairwise();
+    if (Float.floatToRawIntBits(expected) != Float.floatToRawIntBits(actual)) {
+      throw new IllegalStateException("Q4 unsigned-byte benchmark kernel disagrees");
+    }
+  }
+
+  @Benchmark
+  public float unsignedBytePairwise() {
+    return PanamaVectorUtilSupport.q4_0Q8_0UnsignedPairwiseRowDot(
+        weights, 0, blocks, q8Quants, q8Scales, zeroPointCorrections);
+  }
+
+  private float scalarReference() {
+    float[] lowAccumulator = new float[4];
+    float[] highAccumulator = new float[4];
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = (long) block * BLOCK_BYTES;
+      float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+      for (int group = 0; group < 8; group++) {
+        int sum = 0;
+        for (int lane = 0; lane < 4; lane++) {
+          int index = group * 4 + lane;
+          int packedIndex = index & 15;
+          int packed =
+              Byte.toUnsignedInt(weights.get(ValueLayout.JAVA_BYTE, blockOffset + 2 + packedIndex));
+          int nibble = index < 16 ? packed & 0x0F : packed >>> 4;
+          sum += (nibble - 8) * q8Quants[block * BLOCK_SIZE + index];
+        }
+        if (group < 4) {
+          lowAccumulator[group] = Math.fma(scale, sum, lowAccumulator[group]);
+        } else {
+          highAccumulator[group - 4] = Math.fma(scale, sum, highAccumulator[group - 4]);
+        }
+      }
+    }
+    return reduce(lowAccumulator, highAccumulator);
+  }
+
+  private static float reduce(float[] low, float[] high) {
+    float even = (high[0] + low[0]) + (high[2] + low[2]);
+    float odd = (high[1] + low[1]) + (high[3] + low[3]);
+    return even + odd;
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedMatVecBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedMatVecBenchmark.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Production-shaped Q4_0 GEMV gate for the unsigned-nibble zero-point formulation. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(
+    value = 1,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 7, time = 1)
+public class GgufQ4UnsignedMatVecBenchmark {
+
+  private static final int BLOCK_BYTES = 18;
+  private static final int BLOCK_SIZE = 32;
+
+  @Param("1024")
+  int rows;
+
+  @Param("2048")
+  int cols;
+
+  private float[] query;
+  private MemorySegment weights;
+  private float[] baselineOut;
+  private float[] candidateOut;
+  private byte[] baselineQ8Quants;
+  private float[] baselineQ8Scales;
+  private int[] baselineZeroPointCorrections;
+  private byte[] candidateQ8Quants;
+  private float[] candidateQ8Scales;
+  private int[] candidateZeroPointCorrections;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(0x51475a504f494e54L);
+    query = new float[cols];
+    for (int index = 0; index < cols; index++) {
+      query[index] = random.nextFloat() * 2.0f - 1.0f;
+    }
+
+    int blocks = cols / BLOCK_SIZE;
+    byte[] weightBytes = new byte[rows * blocks * BLOCK_BYTES];
+    for (int block = 0; block < rows * blocks; block++) {
+      int offset = block * BLOCK_BYTES;
+      short scale = Float.floatToFloat16(0.001f + random.nextFloat() * 0.05f);
+      weightBytes[offset] = (byte) scale;
+      weightBytes[offset + 1] = (byte) (scale >>> 8);
+      for (int index = Short.BYTES; index < BLOCK_BYTES; index++) {
+        weightBytes[offset + index] = (byte) random.nextInt();
+      }
+    }
+    weights = MemorySegment.ofArray(weightBytes);
+
+    baselineOut = new float[rows];
+    candidateOut = new float[rows];
+    baselineQ8Quants = new byte[cols];
+    baselineQ8Scales = new float[blocks];
+    baselineZeroPointCorrections = new int[blocks * 8];
+    candidateQ8Quants = new byte[cols];
+    candidateQ8Scales = new float[blocks];
+    candidateZeroPointCorrections = new int[blocks * 8];
+
+    runBaseline();
+    runCandidate();
+    for (int row = 0; row < rows; row++) {
+      if (Float.floatToRawIntBits(baselineOut[row]) != Float.floatToRawIntBits(candidateOut[row])) {
+        throw new IllegalStateException("Q4 unsigned GEMV disagrees at row " + row);
+      }
+    }
+  }
+
+  @Benchmark
+  public void shortPairwiseControl(Blackhole blackhole) {
+    runBaseline();
+    blackhole.consume(checksum(baselineOut));
+  }
+
+  @Benchmark
+  public void unsignedZeroPointCandidate(Blackhole blackhole) {
+    runCandidate();
+    blackhole.consume(checksum(candidateOut));
+  }
+
+  private void runBaseline() {
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        weights,
+        rows,
+        cols,
+        baselineOut,
+        baselineQ8Quants,
+        baselineQ8Scales,
+        baselineZeroPointCorrections,
+        GgufQ4Kernel.SHORT_PAIRWISE);
+  }
+
+  private void runCandidate() {
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        weights,
+        rows,
+        cols,
+        candidateOut,
+        candidateQ8Quants,
+        candidateQ8Scales,
+        candidateZeroPointCorrections,
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+  }
+
+  private static int checksum(float[] values) {
+    int hash = 1;
+    for (float value : values) {
+      hash = 31 * hash + Float.floatToRawIntBits(value);
+    }
+    return hash;
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ4Kernel.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ4Kernel.java
@@ -21,5 +21,11 @@ public enum GgufQ4Kernel {
   WIDENED,
 
   /** Uses signed-short pairwise multiply-add when the active vector shape supports it. */
-  SHORT_PAIRWISE
+  SHORT_PAIRWISE,
+
+  /**
+   * Uses unsigned-Q4/signed-Q8 byte pairwise multiply-add with Q8 zero-point corrections computed
+   * once during activation quantization.
+   */
+  UNSIGNED_PAIRWISE
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
@@ -38,6 +38,19 @@ final class GgufQuantizationSupport {
       int quantOffset,
       float[] scales,
       int scaleOffset) {
+    quantizeQ8_0(query, queryOffset, dimensions, quants, quantOffset, scales, scaleOffset, null, 0);
+  }
+
+  private static void quantizeQ8_0(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] quants,
+      int quantOffset,
+      float[] scales,
+      int scaleOffset,
+      int[] zeroPointCorrections,
+      int correctionOffset) {
     int blocks = dimensions / VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
     for (int block = 0; block < blocks; block++) {
       int offset = block * VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
@@ -49,11 +62,48 @@ final class GgufQuantizationSupport {
       float scale = absoluteMax / 127.0f;
       float inverseScale = absoluteMax == 0.0f ? 0.0f : 127.0f / absoluteMax;
       scales[scaleOffset + block] = Float.float16ToFloat(Float.floatToFloat16(scale));
+      int groupSum = 0;
       for (int index = 0; index < VectorUtilSupport.GGUF_Q_BLOCK_SIZE; index++) {
-        quants[quantOffset + offset + index] =
-            (byte) ggmlNearestInt(query[queryOffset + offset + index] * inverseScale);
+        byte quant = (byte) ggmlNearestInt(query[queryOffset + offset + index] * inverseScale);
+        quants[quantOffset + offset + index] = quant;
+        if (zeroPointCorrections != null) {
+          groupSum += quant;
+          if ((index & 3) == 3) {
+            int group = block * 8 + (index >>> 2);
+            zeroPointCorrections[correctionOffset + group] = 8 * groupSum;
+            groupSum = 0;
+          }
+        }
       }
     }
+  }
+
+  static void quantizeQ8_0WithQ4Corrections(
+      float[] query, int dimensions, byte[] quants, float[] scales, int[] zeroPointCorrections) {
+    quantizeQ8_0WithQ4Corrections(
+        query, 0, dimensions, quants, 0, scales, 0, zeroPointCorrections, 0);
+  }
+
+  static void quantizeQ8_0WithQ4Corrections(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] quants,
+      int quantOffset,
+      float[] scales,
+      int scaleOffset,
+      int[] zeroPointCorrections,
+      int correctionOffset) {
+    quantizeQ8_0(
+        query,
+        queryOffset,
+        dimensions,
+        quants,
+        quantOffset,
+        scales,
+        scaleOffset,
+        zeroPointCorrections,
+        correctionOffset);
   }
 
   static void quantizeQ8_K(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -89,6 +89,15 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 0);
   private static final VectorShuffle<Short> SHORT_256_ODD_LANES =
       VectorShuffle.makeUnzip(ShortVector.SPECIES_256, 1);
+  private static final VectorShuffle<Byte> BYTE_128_EVEN_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 0);
+  private static final VectorShuffle<Byte> BYTE_128_ODD_LANES =
+      VectorShuffle.makeUnzip(ByteVector.SPECIES_128, 1);
+  private static final VectorShuffle<Short> SHORT_128_EVEN_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 0);
+  private static final VectorShuffle<Short> SHORT_128_ODD_LANES =
+      VectorShuffle.makeUnzip(ShortVector.SPECIES_128, 1);
+  private static final short[] Q4_PAIR_FACTORS = {1, 1, 1, 1, 1, 1, 1, 1};
   private static final ByteVector Q5_HIGH_BIT_MASKS =
       ByteVector.fromArray(
           ByteVector.SPECIES_64, new byte[] {1, 2, 4, 8, 16, 32, 64, (byte) 0x80}, 0);
@@ -106,7 +115,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   static boolean useQ4ShortPairwise(GgufQ4Kernel kernel, int vectorBits, int blocks) {
     boolean requested =
         switch (Objects.requireNonNull(kernel, "kernel")) {
-          case WIDENED -> false;
+          case WIDENED, UNSIGNED_PAIRWISE -> false;
           case SHORT_PAIRWISE -> true;
         };
     return requested && vectorBits >= 256 && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
@@ -114,6 +123,44 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   private static boolean useQ4ShortPairwise(GgufQ4Kernel kernel, int blocks) {
     return useQ4ShortPairwise(kernel, VECTOR_BITSIZE, blocks);
+  }
+
+  static boolean useQ4UnsignedPairwise(GgufQ4Kernel kernel, int vectorBits, int blocks) {
+    return Objects.requireNonNull(kernel, "kernel") == GgufQ4Kernel.UNSIGNED_PAIRWISE
+        && vectorBits >= 256
+        && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
+  }
+
+  private static boolean useQ4UnsignedPairwise(GgufQ4Kernel kernel, int blocks) {
+    return useQ4UnsignedPairwise(kernel, VECTOR_BITSIZE, blocks);
+  }
+
+  private static void quantizeQ8_0ForQ4(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] q8Quants,
+      int quantOffset,
+      float[] q8Scales,
+      int scaleOffset,
+      int[] q8ZeroPointCorrections,
+      int correctionOffset,
+      boolean computeZeroPointCorrections) {
+    if (computeZeroPointCorrections) {
+      GgufQuantizationSupport.quantizeQ8_0WithQ4Corrections(
+          query,
+          queryOffset,
+          dimensions,
+          q8Quants,
+          quantOffset,
+          q8Scales,
+          scaleOffset,
+          q8ZeroPointCorrections,
+          correctionOffset);
+      return;
+    }
+    GgufQuantizationSupport.quantizeQ8_0(
+        query, queryOffset, dimensions, q8Quants, quantOffset, q8Scales, scaleOffset);
   }
 
   // --- Float dot product: 4x unrolled FMA (Lucene pattern) ---
@@ -383,20 +430,25 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
-    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
-
     long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
+    boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
+    quantizeQ8_0ForQ4(
+        query, 0, cols, q8Quants, 0, q8Scales, 0, q8ZeroPointCorrections, 0, useUnsignedPairwise);
     GgufParallelSupport.forEachRow(
         qWeight,
         rows,
         cols,
         row ->
             out[row] =
-                q4_0Q8_0RowDot(
-                    qWeight, row * rowBytes, blocks, q8Quants, q8Scales, useShortPairwise));
+                useUnsignedPairwise
+                    ? q4_0Q8_0UnsignedPairwiseRowDot(
+                        qWeight, row * rowBytes, blocks, q8Quants, q8Scales, q8ZeroPointCorrections)
+                    : q4_0Q8_0RowDot(
+                        qWeight, row * rowBytes, blocks, q8Quants, q8Scales, useShortPairwise));
   }
 
   @Override
@@ -411,12 +463,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
-    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
-
     long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
+    boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
+    quantizeQ8_0ForQ4(
+        query, 0, cols, q8Quants, 0, q8Scales, 0, q8ZeroPointCorrections, 0, useUnsignedPairwise);
     int totalRows = Math.addExact(firstRows, secondRows);
     GgufParallelSupport.forEachRow(
         firstWeight,
@@ -439,6 +493,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           }
 
           long rowOffset = matrixRow * rowBytes;
+          if (useUnsignedPairwise) {
+            out[matrixRow] =
+                q4_0Q8_0UnsignedPairwiseRowDot(
+                    qWeight, rowOffset, blocks, q8Quants, q8Scales, q8ZeroPointCorrections);
+            return;
+          }
           if (VECTOR_BITSIZE >= 256) {
             FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
             for (int block = 0; block < blocks; block++) {
@@ -490,12 +550,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
-    GgufQuantizationSupport.quantizeQ8_0(query, cols, q8Quants, q8Scales);
-
     long rowBytes = (long) (cols / GGUF_Q_BLOCK_SIZE) * GGUF_Q4_0_BLOCK_BYTES;
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
+    boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
+    quantizeQ8_0ForQ4(
+        query, 0, cols, q8Quants, 0, q8Scales, 0, q8ZeroPointCorrections, 0, useUnsignedPairwise);
     int secondStart = firstRows;
     int thirdStart = Math.addExact(firstRows, secondRows);
     int totalRows = Math.addExact(thirdStart, thirdRows);
@@ -525,6 +587,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           }
 
           long rowOffset = matrixRow * rowBytes;
+          if (useUnsignedPairwise) {
+            out[matrixRow] =
+                q4_0Q8_0UnsignedPairwiseRowDot(
+                    qWeight, rowOffset, blocks, q8Quants, q8Scales, q8ZeroPointCorrections);
+            return;
+          }
           if (VECTOR_BITSIZE >= 256) {
             FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_256);
             for (int block = 0; block < blocks; block++) {
@@ -571,23 +639,45 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     if (batchSize == 1) {
-      ggufQ4_0Q8_0MatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales, kernel);
+      ggufQ4_0Q8_0MatVecDot(
+          queries, qWeight, rows, cols, out, q8Quants, q8Scales, q8ZeroPointCorrections, kernel);
       return;
     }
     if (VECTOR_BITSIZE < 256) {
       VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmul(
-          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, laneScratch, kernel);
+          queries,
+          qWeight,
+          batchSize,
+          rows,
+          cols,
+          out,
+          q8Quants,
+          q8Scales,
+          q8ZeroPointCorrections,
+          laneScratch,
+          kernel);
       return;
     }
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
+    boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
     for (int batch = 0; batch < batchSize; batch++) {
-      GgufQuantizationSupport.quantizeQ8_0(
-          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+      quantizeQ8_0ForQ4(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8ZeroPointCorrections,
+          batch * blocks * 8,
+          useUnsignedPairwise);
     }
 
     long rowBytes = (long) blocks * GGUF_Q4_0_BLOCK_BYTES;
@@ -612,17 +702,32 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     qWeight,
                     blockOffset + Short.BYTES,
                     ByteOrder.LITTLE_ENDIAN);
+            ByteVector lowNibbles = packed.and((byte) 0x0F);
+            ByteVector highNibbles = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+            if (useUnsignedPairwise) {
+              for (int batch = 0; batch < batchSize; batch++) {
+                int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+                accumulateQ4_0UnsignedBatchQuery(
+                    laneScratch,
+                    laneOffset,
+                    lowNibbles,
+                    highNibbles,
+                    q8Quants,
+                    (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
+                    q8ZeroPointCorrections,
+                    (batch * blocks + block) * 8,
+                    weightScale * q8Scales[batch * blocks + block]);
+              }
+              continue;
+            }
             ShortVector low =
                 (ShortVector)
-                    packed
-                        .and((byte) 0x0F)
+                    lowNibbles
                         .sub((byte) 8)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
             ShortVector high =
                 (ShortVector)
-                    packed
-                        .lanewise(VectorOperators.LSHR, 4)
-                        .and((byte) 0x0F)
+                    highNibbles
                         .sub((byte) 8)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
 
@@ -661,6 +766,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     if (batchSize == 1) {
@@ -675,6 +781,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           cols,
           q8Quants,
           q8Scales,
+          q8ZeroPointCorrections,
           kernel);
       return;
     }
@@ -693,6 +800,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         kernel);
   }
@@ -713,6 +821,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     if (batchSize == 1) {
@@ -730,6 +839,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           cols,
           q8Quants,
           q8Scales,
+          q8ZeroPointCorrections,
           kernel);
       return;
     }
@@ -748,6 +858,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         kernel);
   }
@@ -767,6 +878,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     if (VECTOR_BITSIZE < 256) {
@@ -783,6 +895,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             cols,
             q8Quants,
             q8Scales,
+            q8ZeroPointCorrections,
             laneScratch,
             kernel);
       } else {
@@ -801,6 +914,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             cols,
             q8Quants,
             q8Scales,
+            q8ZeroPointCorrections,
             laneScratch,
             kernel);
       }
@@ -809,9 +923,19 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
+    boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
     for (int batch = 0; batch < batchSize; batch++) {
-      GgufQuantizationSupport.quantizeQ8_0(
-          queries, batch * cols, cols, q8Quants, batch * cols, q8Scales, batch * blocks);
+      quantizeQ8_0ForQ4(
+          queries,
+          batch * cols,
+          cols,
+          q8Quants,
+          batch * cols,
+          q8Scales,
+          batch * blocks,
+          q8ZeroPointCorrections,
+          batch * blocks * 8,
+          useUnsignedPairwise);
     }
 
     long rowBytes = (long) blocks * GGUF_Q4_0_BLOCK_BYTES;
@@ -863,17 +987,32 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     qWeight,
                     blockOffset + Short.BYTES,
                     ByteOrder.LITTLE_ENDIAN);
+            ByteVector lowNibbles = packed.and((byte) 0x0F);
+            ByteVector highNibbles = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+            if (useUnsignedPairwise) {
+              for (int batch = 0; batch < batchSize; batch++) {
+                int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+                accumulateQ4_0UnsignedBatchQuery(
+                    laneScratch,
+                    laneOffset,
+                    lowNibbles,
+                    highNibbles,
+                    q8Quants,
+                    (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
+                    q8ZeroPointCorrections,
+                    (batch * blocks + block) * 8,
+                    weightScale * q8Scales[batch * blocks + block]);
+              }
+              continue;
+            }
             ShortVector low =
                 (ShortVector)
-                    packed
-                        .and((byte) 0x0F)
+                    lowNibbles
                         .sub((byte) 8)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
             ShortVector high =
                 (ShortVector)
-                    packed
-                        .lanewise(VectorOperators.LSHR, 4)
-                        .and((byte) 0x0F)
+                    highNibbles
                         .sub((byte) 8)
                         .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
 
@@ -926,6 +1065,46 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset);
     fma(products, FloatVector.broadcast(FloatVector.SPECIES_256, scale), accumulator)
         .intoArray(laneScratch, laneOffset);
+  }
+
+  private static void accumulateQ4_0UnsignedBatchQuery(
+      float[] laneScratch,
+      int laneOffset,
+      ByteVector lowNibbles,
+      ByteVector highNibbles,
+      byte[] q8Quants,
+      int quantOffset,
+      int[] zeroPointCorrections,
+      int correctionOffset,
+      float scale) {
+    ShortVector pairFactors = ShortVector.fromArray(ShortVector.SPECIES_128, Q4_PAIR_FACTORS, 0);
+    IntVector lowGroups =
+        q4_0Q8_0UnsignedPairwiseGroups(
+            lowNibbles,
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset),
+            IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset),
+            pairFactors);
+    IntVector highGroups =
+        q4_0Q8_0UnsignedPairwiseGroups(
+            highNibbles,
+            ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16),
+            IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
+            pairFactors);
+    FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
+    FloatVector lowAccumulator =
+        FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset);
+    FloatVector highAccumulator =
+        FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset + 4);
+    fma(
+            (FloatVector) lowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+            scaleVector,
+            lowAccumulator)
+        .intoArray(laneScratch, laneOffset);
+    fma(
+            (FloatVector) highGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+            scaleVector,
+            highAccumulator)
+        .intoArray(laneScratch, laneOffset + 4);
   }
 
   /** Fixed split-half hsum tree; Vector.reduceLanes does not guarantee an evaluation order. */
@@ -1090,6 +1269,70 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return fourProductLanesFromShortPairs(low16, high16, qLow16, qHigh16);
   }
 
+  static float q4_0Q8_0UnsignedPairwiseRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      int blocks,
+      byte[] q8Quants,
+      float[] q8Scales,
+      int[] zeroPointCorrections) {
+    ShortVector pairFactors = ShortVector.fromArray(ShortVector.SPECIES_128, Q4_PAIR_FACTORS, 0);
+    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
+      ByteVector packed =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_128, qWeight, blockOffset + Short.BYTES, ByteOrder.LITTLE_ENDIAN);
+      ByteVector low = packed.and((byte) 0x0F);
+      ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+      int quantOffset = block * GGUF_Q_BLOCK_SIZE;
+      int correctionOffset = block * 8;
+      IntVector lowGroups =
+          q4_0Q8_0UnsignedPairwiseGroups(
+              low,
+              ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset),
+              IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset),
+              pairFactors);
+      IntVector highGroups =
+          q4_0Q8_0UnsignedPairwiseGroups(
+              high,
+              ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16),
+              IntVector.fromArray(
+                  IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
+              pairFactors);
+      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
+      lowAccumulator =
+          fma(
+              (FloatVector) lowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              lowAccumulator);
+      highAccumulator =
+          fma(
+              (FloatVector)
+                  highGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              highAccumulator);
+    }
+    float even =
+        (highAccumulator.lane(0) + lowAccumulator.lane(0))
+            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
+    float odd =
+        (highAccumulator.lane(1) + lowAccumulator.lane(1))
+            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
+    return even + odd;
+  }
+
+  private static IntVector q4_0Q8_0UnsignedPairwiseGroups(
+      ByteVector unsignedNibbles,
+      ByteVector signedQ8,
+      IntVector zeroPointCorrection,
+      ShortVector pairFactors) {
+    ShortVector pairProducts = multiplyAddUnsignedSignedBytes128(unsignedNibbles, signedQ8);
+    return multiplyAddSignedShorts128(pairProducts, pairFactors).sub(zeroPointCorrection);
+  }
+
   private static IntVector fourProductLanesFromShortPairs(
       ShortVector low, ShortVector high, ShortVector qLow, ShortVector qHigh) {
     IntVector lowPairs = multiplyAddSignedShorts256(low, qLow);
@@ -1114,6 +1357,43 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
     IntVector rightOddInts =
         (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_256, 0);
+    return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
+  }
+
+  private static ShortVector multiplyAddUnsignedSignedBytes128(
+      ByteVector unsigned, ByteVector signed) {
+    ByteVector unsignedEven = unsigned.rearrange(BYTE_128_EVEN_LANES);
+    ByteVector unsignedOdd = unsigned.rearrange(BYTE_128_ODD_LANES);
+    ByteVector signedEven = signed.rearrange(BYTE_128_EVEN_LANES);
+    ByteVector signedOdd = signed.rearrange(BYTE_128_ODD_LANES);
+    ShortVector unsignedEvenShorts =
+        (ShortVector)
+            unsignedEven.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
+    ShortVector unsignedOddShorts =
+        (ShortVector)
+            unsignedOdd.convertShape(VectorOperators.ZERO_EXTEND_B2S, ShortVector.SPECIES_128, 0);
+    ShortVector signedEvenShorts =
+        (ShortVector) signedEven.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+    ShortVector signedOddShorts =
+        (ShortVector) signedOdd.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
+    return unsignedEvenShorts
+        .mul(signedEvenShorts)
+        .lanewise(VectorOperators.SADD, unsignedOddShorts.mul(signedOddShorts));
+  }
+
+  private static IntVector multiplyAddSignedShorts128(ShortVector left, ShortVector right) {
+    ShortVector leftEven = left.rearrange(SHORT_128_EVEN_LANES);
+    ShortVector leftOdd = left.rearrange(SHORT_128_ODD_LANES);
+    ShortVector rightEven = right.rearrange(SHORT_128_EVEN_LANES);
+    ShortVector rightOdd = right.rearrange(SHORT_128_ODD_LANES);
+    IntVector leftEvenInts =
+        (IntVector) leftEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector leftOddInts =
+        (IntVector) leftOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector rightEvenInts =
+        (IntVector) rightEven.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
+    IntVector rightOddInts =
+        (IntVector) rightOdd.convertShape(VectorOperators.S2I, IntVector.SPECIES_128, 0);
     return leftEvenInts.mul(rightEvenInts).add(leftOddInts.mul(rightOddInts));
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorRuntimeCapabilities.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorRuntimeCapabilities.java
@@ -26,6 +26,7 @@ public record VectorRuntimeCapabilities(
     boolean fastScalarFma,
     boolean sve,
     boolean q4ShortPairwiseSupported,
+    boolean q4UnsignedPairwiseSupported,
     boolean ggufParallel,
     String ggufExecutor,
     int ggufThreads,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -458,6 +458,8 @@ public final class VectorUtil {
    *
    * @param q8Quants scratch space with at least {@code cols} entries
    * @param q8Scales scratch space with at least {@code cols / 32} entries
+   * @param q8ZeroPointCorrections scratch space with at least {@code cols / 4} entries; kernels
+   *     using unsigned Q4 arithmetic populate it during activation quantization
    */
   public static void ggufQ4_0Q8_0BatchDotProduct(
       float[] query,
@@ -466,9 +468,18 @@ public final class VectorUtil {
       int cols,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      int[] q8ZeroPointCorrections) {
     ggufQ4_0Q8_0BatchDotProduct(
-        query, qWeight, rows, cols, out, q8Quants, q8Scales, GgufQ4Kernel.WIDENED);
+        query,
+        qWeight,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        q8ZeroPointCorrections,
+        GgufQ4Kernel.WIDENED);
   }
 
   /** Q4_0 by Q8_0 GEMV with an explicit arithmetic-kernel policy. */
@@ -480,10 +491,12 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchArguments(
         query, qWeight, rows, cols, out, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    checkGgufQ4CorrectionScratch(q8ZeroPointCorrections, cols);
     IMPL.ggufQ4_0Q8_0MatVecDot(
         query,
         qWeight,
@@ -492,6 +505,7 @@ public final class VectorUtil {
         out,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         Objects.requireNonNull(kernel, "kernel"));
   }
 
@@ -512,7 +526,8 @@ public final class VectorUtil {
       float[] secondOut,
       int cols,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      int[] q8ZeroPointCorrections) {
     ggufQ4_0Q8_0DualBatchDotProduct(
         query,
         firstWeight,
@@ -524,6 +539,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         GgufQ4Kernel.WIDENED);
   }
 
@@ -539,12 +555,14 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchArguments(
         query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufQuantizedBatchArguments(
         query, secondWeight, secondRows, cols, secondOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    checkGgufQ4CorrectionScratch(q8ZeroPointCorrections, cols);
     IMPL.ggufQ4_0Q8_0DualMatVecDot(
         query,
         firstWeight,
@@ -556,6 +574,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         Objects.requireNonNull(kernel, "kernel"));
   }
 
@@ -578,7 +597,8 @@ public final class VectorUtil {
       float[] thirdOut,
       int cols,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      int[] q8ZeroPointCorrections) {
     ggufQ4_0Q8_0TripleBatchDotProduct(
         query,
         firstWeight,
@@ -593,6 +613,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         GgufQ4Kernel.WIDENED);
   }
 
@@ -611,6 +632,7 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchArguments(
         query, firstWeight, firstRows, cols, firstOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
@@ -619,6 +641,7 @@ public final class VectorUtil {
     checkGgufQuantizedBatchArguments(
         query, thirdWeight, thirdRows, cols, thirdOut, VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
     checkGgufActivationScratch(q8Quants, q8Scales, cols, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    checkGgufQ4CorrectionScratch(q8ZeroPointCorrections, cols);
     IMPL.ggufQ4_0Q8_0TripleMatVecDot(
         query,
         firstWeight,
@@ -633,6 +656,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         Objects.requireNonNull(kernel, "kernel"));
   }
 
@@ -645,6 +669,8 @@ public final class VectorUtil {
    *
    * @param q8Quants scratch space with at least {@code batchSize * cols} entries
    * @param q8Scales scratch space with at least {@code batchSize * (cols / 32)} entries
+   * @param q8ZeroPointCorrections scratch space with at least {@code batchSize * cols / 4} entries;
+   *     kernels using unsigned Q4 arithmetic populate it during activation quantization
    */
   public static void ggufQ4_0Q8_0BatchedMatmul(
       float[] queries,
@@ -654,9 +680,19 @@ public final class VectorUtil {
       int cols,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
+      float[] q8Scales,
+      int[] q8ZeroPointCorrections) {
     ggufQ4_0Q8_0BatchedMatmul(
-        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, GgufQ4Kernel.WIDENED);
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        q8ZeroPointCorrections,
+        GgufQ4Kernel.WIDENED);
   }
 
   /** Q4_0 batched matrix multiplication with an explicit arithmetic-kernel policy. */
@@ -669,6 +705,7 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
@@ -686,6 +723,7 @@ public final class VectorUtil {
         out,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         new float[checkedProduct(outputEntries, 8, "Q4 lane scratch")],
         kernel);
   }
@@ -693,6 +731,7 @@ public final class VectorUtil {
   /**
    * Allocation-free Q4_0 batched matrix multiplication with caller-owned reduction lanes.
    *
+   * @param q8ZeroPointCorrections scratch space with at least {@code batchSize * cols / 4} entries
    * @param laneScratch scratch space with at least {@code batchSize * rows * 8} entries
    */
   public static void ggufQ4_0Q8_0BatchedMatmul(
@@ -704,6 +743,7 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch) {
     ggufQ4_0Q8_0BatchedMatmul(
         queries,
@@ -714,6 +754,7 @@ public final class VectorUtil {
         out,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         GgufQ4Kernel.WIDENED);
   }
@@ -728,6 +769,7 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     if (batchSize < 1) {
@@ -737,6 +779,7 @@ public final class VectorUtil {
     Objects.requireNonNull(out, "out");
     Objects.requireNonNull(q8Quants, "q8Quants");
     Objects.requireNonNull(q8Scales, "q8Scales");
+    Objects.requireNonNull(q8ZeroPointCorrections, "q8ZeroPointCorrections");
     Objects.requireNonNull(laneScratch, "laneScratch");
     checkGgufQuantizedMatrixArguments(
         qWeight,
@@ -765,6 +808,7 @@ public final class VectorUtil {
       throw new IllegalArgumentException(
           "q8Scales.length must be >= batch scales: " + q8Scales.length + " < " + scaleEntries);
     }
+    checkGgufQ4CorrectionScratch(q8ZeroPointCorrections, queryEntries);
     if (laneScratch.length < laneEntries) {
       throw new IllegalArgumentException(
           "lane scratch length must be >= batchSize * rows * 8: "
@@ -781,6 +825,7 @@ public final class VectorUtil {
         out,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         Objects.requireNonNull(kernel, "kernel"));
   }
@@ -798,6 +843,7 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch) {
     ggufQ4_0Q8_0DualBatchedMatmul(
         queries,
@@ -811,6 +857,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         GgufQ4Kernel.WIDENED);
   }
@@ -828,6 +875,7 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchedArguments(
@@ -851,6 +899,7 @@ public final class VectorUtil {
     int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
     checkGgufActivationScratch(
         q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    checkGgufQ4CorrectionScratch(q8ZeroPointCorrections, activationEntries);
     checkGgufQ4LaneScratch(
         laneScratch, batchSize, Math.addExact(firstRows, secondRows), "dual Q4 lane scratch");
     IMPL.ggufQ4_0Q8_0DualBatchedMatmul(
@@ -865,6 +914,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         Objects.requireNonNull(kernel, "kernel"));
   }
@@ -885,6 +935,7 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch) {
     ggufQ4_0Q8_0TripleBatchedMatmul(
         queries,
@@ -901,6 +952,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         GgufQ4Kernel.WIDENED);
   }
@@ -921,6 +973,7 @@ public final class VectorUtil {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     checkGgufQuantizedBatchedArguments(
@@ -953,6 +1006,7 @@ public final class VectorUtil {
     int activationEntries = checkedProduct(batchSize, cols, "batchSize * cols");
     checkGgufActivationScratch(
         q8Quants, q8Scales, activationEntries, VectorUtilSupport.GGUF_Q_BLOCK_SIZE);
+    checkGgufQ4CorrectionScratch(q8ZeroPointCorrections, activationEntries);
     int totalRows = Math.addExact(Math.addExact(firstRows, secondRows), thirdRows);
     checkGgufQ4LaneScratch(laneScratch, batchSize, totalRows, "triple Q4 lane scratch");
     IMPL.ggufQ4_0Q8_0TripleBatchedMatmul(
@@ -970,6 +1024,7 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
+        q8ZeroPointCorrections,
         laneScratch,
         Objects.requireNonNull(kernel, "kernel"));
   }
@@ -2558,6 +2613,19 @@ public final class VectorUtil {
               + q8Sums.length
               + " < "
               + requiredSums);
+    }
+  }
+
+  private static void checkGgufQ4CorrectionScratch(
+      int[] q8ZeroPointCorrections, int activationEntries) {
+    Objects.requireNonNull(q8ZeroPointCorrections, "q8ZeroPointCorrections");
+    int required = activationEntries / 4;
+    if (q8ZeroPointCorrections.length < required) {
+      throw new IllegalArgumentException(
+          "q8ZeroPointCorrections.length must be >= activation entries / 4: "
+              + q8ZeroPointCorrections.length
+              + " < "
+              + required);
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -569,6 +569,7 @@ public interface VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
@@ -591,6 +592,7 @@ public interface VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
@@ -621,6 +623,7 @@ public interface VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       GgufQ4Kernel kernel) {
     quantizeQ8_0(query, cols, q8Quants, q8Scales);
 
@@ -684,6 +687,7 @@ public interface VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
@@ -734,6 +738,7 @@ public interface VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
@@ -785,6 +790,7 @@ public interface VectorUtilSupport {
       int cols,
       byte[] q8Quants,
       float[] q8Scales,
+      int[] q8ZeroPointCorrections,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorizationProvider.java
@@ -73,6 +73,7 @@ public final class VectorizationProvider {
         PanamaConstants.HAS_FAST_SCALAR_FMA,
         PanamaConstants.HAS_SVE,
         vectorApi && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256,
+        vectorApi && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256,
         GgufParallelSupport.enabled(),
         GgufParallelSupport.executionMode().name().toLowerCase(Locale.ROOT),
         GgufParallelSupport.parallelism(),
@@ -151,6 +152,10 @@ public final class VectorizationProvider {
         .append(mappedKQuantPolicy.q6())
         .append(')');
     sb.append(" q4ShortPairwiseSupported=")
+        .append(
+            impl instanceof PanamaVectorUtilSupport
+                && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256);
+    sb.append(" q4UnsignedPairwiseSupported=")
         .append(
             impl instanceof PanamaVectorUtilSupport
                 && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -482,7 +482,7 @@ class GgufQuantizedDotTest {
       MemorySegment segment = copy(arena, concat(row0, row1));
 
       VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-          query, segment, 2, query.length, out, q8Quants, q8Scales);
+          query, segment, 2, query.length, out, q8Quants, q8Scales, q4Corrections(query.length));
 
       float q8Scale = Float.float16ToFloat(Float.floatToFloat16(1.0f / 127.0f));
       assertThat(out[0]).isCloseTo(189.0f * q8Scale, within(1e-6f));
@@ -500,6 +500,7 @@ class GgufQuantizedDotTest {
     byte[] weights = repeat(block, rows * (cols / 32));
     float[] widened = new float[rows];
     float[] pairwise = new float[rows];
+    float[] unsignedPairwise = new float[rows];
 
     MemorySegment segment = MemorySegment.ofArray(weights);
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
@@ -510,6 +511,7 @@ class GgufQuantizedDotTest {
         widened,
         new byte[cols],
         new float[cols / 32],
+        q4Corrections(cols),
         GgufQ4Kernel.WIDENED);
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
         query,
@@ -519,9 +521,21 @@ class GgufQuantizedDotTest {
         pairwise,
         new byte[cols],
         new float[cols / 32],
+        q4Corrections(cols),
         GgufQ4Kernel.SHORT_PAIRWISE);
+    VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+        query,
+        segment,
+        rows,
+        cols,
+        unsignedPairwise,
+        new byte[cols],
+        new float[cols / 32],
+        q4Corrections(cols),
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
     assertThat(pairwise).containsExactly(widened);
+    assertThat(unsignedPairwise).containsExactly(widened);
   }
 
   @Test
@@ -549,7 +563,14 @@ class GgufQuantizedDotTest {
     MemorySegment firstSegment = MemorySegment.ofArray(firstWeights);
     MemorySegment secondSegment = MemorySegment.ofArray(secondWeights);
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-        query, firstSegment, firstRows, cols, expectedFirst, new byte[cols], new float[cols / 32]);
+        query,
+        firstSegment,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 32],
+        q4Corrections(cols));
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
         query,
         secondSegment,
@@ -557,7 +578,8 @@ class GgufQuantizedDotTest {
         cols,
         expectedSecond,
         new byte[cols],
-        new float[cols / 32]);
+        new float[cols / 32],
+        q4Corrections(cols));
 
     VectorUtil.ggufQ4_0Q8_0DualBatchDotProduct(
         query,
@@ -570,6 +592,7 @@ class GgufQuantizedDotTest {
         cols,
         new byte[cols],
         new float[cols / 32],
+        q4Corrections(cols),
         GgufQ4Kernel.SHORT_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
@@ -606,7 +629,14 @@ class GgufQuantizedDotTest {
     float[] actualThird = new float[thirdRows];
 
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-        query, firstWeight, firstRows, cols, expectedFirst, new byte[cols], new float[cols / 32]);
+        query,
+        firstWeight,
+        firstRows,
+        cols,
+        expectedFirst,
+        new byte[cols],
+        new float[cols / 32],
+        q4Corrections(cols));
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
         query,
         secondWeight,
@@ -614,9 +644,17 @@ class GgufQuantizedDotTest {
         cols,
         expectedSecond,
         new byte[cols],
-        new float[cols / 32]);
+        new float[cols / 32],
+        q4Corrections(cols));
     VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-        query, thirdWeight, thirdRows, cols, expectedThird, new byte[cols], new float[cols / 32]);
+        query,
+        thirdWeight,
+        thirdRows,
+        cols,
+        expectedThird,
+        new byte[cols],
+        new float[cols / 32],
+        q4Corrections(cols));
 
     VectorUtil.ggufQ4_0Q8_0TripleBatchDotProduct(
         query,
@@ -632,6 +670,7 @@ class GgufQuantizedDotTest {
         cols,
         new byte[cols],
         new float[cols / 32],
+        q4Corrections(cols),
         GgufQ4Kernel.SHORT_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
@@ -655,6 +694,7 @@ class GgufQuantizedDotTest {
     byte[] row1 = repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32);
     float[] expected = new float[batchSize * rows];
     float[] actual = new float[batchSize * rows];
+    float[] unsignedActual = new float[batchSize * rows];
     byte[] q8Quants = new byte[batchSize * cols];
     float[] q8Scales = new float[batchSize * (cols / 32)];
 
@@ -665,7 +705,14 @@ class GgufQuantizedDotTest {
         System.arraycopy(queries, batch * cols, query, 0, cols);
         float[] result = new float[rows];
         VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-            query, segment, rows, cols, result, new byte[cols], new float[cols / 32]);
+            query,
+            segment,
+            rows,
+            cols,
+            result,
+            new byte[cols],
+            new float[cols / 32],
+            q4Corrections(cols));
         System.arraycopy(result, 0, expected, batch * rows, rows);
       }
 
@@ -678,9 +725,22 @@ class GgufQuantizedDotTest {
           actual,
           q8Quants,
           q8Scales,
+          q4Corrections(batchSize * cols),
           GgufQ4Kernel.SHORT_PAIRWISE);
+      VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+          queries,
+          segment,
+          batchSize,
+          rows,
+          cols,
+          unsignedActual,
+          new byte[batchSize * cols],
+          new float[batchSize * (cols / 32)],
+          q4Corrections(batchSize * cols),
+          GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
       assertThat(actual).containsExactly(expected);
+      assertThat(unsignedActual).containsExactly(expected);
       assertThat(q8Quants[0]).isNotZero();
     }
   }
@@ -714,6 +774,7 @@ class GgufQuantizedDotTest {
         expectedFirst,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * firstRows * 8]);
     VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
         queries,
@@ -724,6 +785,7 @@ class GgufQuantizedDotTest {
         expectedSecond,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * secondRows * 8]);
 
     VectorUtil.ggufQ4_0Q8_0DualBatchedMatmul(
@@ -738,6 +800,7 @@ class GgufQuantizedDotTest {
         cols,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * (firstRows + secondRows) * 8],
         GgufQ4Kernel.SHORT_PAIRWISE);
 
@@ -768,6 +831,9 @@ class GgufQuantizedDotTest {
     float[] actualFirst = new float[batchSize * firstRows];
     float[] actualSecond = new float[batchSize * secondRows];
     float[] actualThird = new float[batchSize * thirdRows];
+    float[] unsignedFirst = new float[batchSize * firstRows];
+    float[] unsignedSecond = new float[batchSize * secondRows];
+    float[] unsignedThird = new float[batchSize * thirdRows];
     byte[] quants = new byte[batchSize * cols];
     float[] scales = new float[batchSize * (cols / 32)];
 
@@ -780,6 +846,7 @@ class GgufQuantizedDotTest {
         expectedFirst,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * firstRows * 8]);
     VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
         queries,
@@ -790,6 +857,7 @@ class GgufQuantizedDotTest {
         expectedSecond,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * secondRows * 8]);
     VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
         queries,
@@ -800,6 +868,7 @@ class GgufQuantizedDotTest {
         expectedThird,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * thirdRows * 8]);
 
     VectorUtil.ggufQ4_0Q8_0TripleBatchedMatmul(
@@ -817,12 +886,34 @@ class GgufQuantizedDotTest {
         cols,
         quants,
         scales,
+        q4Corrections(batchSize * cols),
         new float[batchSize * (firstRows + secondRows + thirdRows) * 8],
         GgufQ4Kernel.SHORT_PAIRWISE);
+    VectorUtil.ggufQ4_0Q8_0TripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        unsignedFirst,
+        secondWeight,
+        secondRows,
+        unsignedSecond,
+        thirdWeight,
+        thirdRows,
+        unsignedThird,
+        batchSize,
+        cols,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)],
+        q4Corrections(batchSize * cols),
+        new float[batchSize * (firstRows + secondRows + thirdRows) * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);
     assertThat(actualThird).containsExactly(expectedThird);
+    assertThat(unsignedFirst).containsExactly(expectedFirst);
+    assertThat(unsignedSecond).containsExactly(expectedSecond);
+    assertThat(unsignedThird).containsExactly(expectedThird);
   }
 
   @Test
@@ -838,10 +929,25 @@ class GgufQuantizedDotTest {
     try (Arena arena = Arena.ofConfined()) {
       MemorySegment segment = copy(arena, concat(row0, row1));
       VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-          query, segment, rows, cols, expected, new byte[cols], new float[cols / 32]);
+          query,
+          segment,
+          rows,
+          cols,
+          expected,
+          new byte[cols],
+          new float[cols / 32],
+          q4Corrections(cols));
 
       VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
-          query, segment, 1, rows, cols, actual, new byte[cols], new float[cols / 32]);
+          query,
+          segment,
+          1,
+          rows,
+          cols,
+          actual,
+          new byte[cols],
+          new float[cols / 32],
+          q4Corrections(cols));
 
       assertThat(actual).containsExactly(expected);
     }
@@ -871,7 +977,14 @@ class GgufQuantizedDotTest {
         float[] result = new float[rows];
         System.arraycopy(queries, batch * cols, query, 0, cols);
         VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-            query, segment, rows, cols, result, new byte[cols], new float[cols / 32]);
+            query,
+            segment,
+            rows,
+            cols,
+            result,
+            new byte[cols],
+            new float[cols / 32],
+            q4Corrections(cols));
         System.arraycopy(result, 0, expected, batch * rows, rows);
       }
 
@@ -884,6 +997,7 @@ class GgufQuantizedDotTest {
           actual,
           new byte[batchSize * cols],
           new float[batchSize * (cols / 32)],
+          q4Corrections(batchSize * cols),
           new float[batchSize * rows * 8]);
 
       assertThat(actual).containsExactly(expected);
@@ -915,20 +1029,31 @@ class GgufQuantizedDotTest {
     float[] gemvOut = new float[rows];
     byte[] gemvQuants = new byte[cols];
     float[] gemvScales = new float[blocks];
+    int[] gemvCorrections = q4Corrections(cols);
     byte[] batchQuants = new byte[batchSize * cols];
     float[] batchScales = new float[batchSize * blocks];
+    int[] batchCorrections = q4Corrections(batchSize * cols);
     float[] batchLanes = new float[batchSize * rows * 8];
 
     for (int iteration = 0; iteration < 12; iteration++) {
       for (int batch = 0; batch < batchSize; batch++) {
         System.arraycopy(queries, batch * cols, query, 0, cols);
         VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales);
+            query, weights, rows, cols, gemvOut, gemvQuants, gemvScales, gemvCorrections);
         System.arraycopy(gemvOut, 0, expected, batch * rows, rows);
       }
 
       VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
-          queries, weights, batchSize, rows, cols, actual, batchQuants, batchScales, batchLanes);
+          queries,
+          weights,
+          batchSize,
+          rows,
+          cols,
+          actual,
+          batchQuants,
+          batchScales,
+          batchCorrections,
+          batchLanes);
       assertThat(actual).containsExactly(expected);
     }
   }
@@ -949,6 +1074,7 @@ class GgufQuantizedDotTest {
                       new float[2],
                       new byte[64],
                       new float[2],
+                      q4Corrections(64),
                       new float[15]))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("lane scratch");
@@ -1309,9 +1435,22 @@ class GgufQuantizedDotTest {
       assertThatThrownBy(
               () ->
                   VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
-                      ones(32), q4, 1, 32, new float[1], new byte[31], new float[1]))
+                      ones(32),
+                      q4,
+                      1,
+                      32,
+                      new float[1],
+                      new byte[31],
+                      new float[1],
+                      q4Corrections(32)))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("q8Quants.length");
+      assertThatThrownBy(
+              () ->
+                  VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+                      ones(32), q4, 1, 32, new float[1], new byte[32], new float[1], new int[7]))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("q8ZeroPointCorrections.length");
       assertThatThrownBy(
               () ->
                   VectorUtil.ggufQ8_0Q8_0BatchDotProduct(
@@ -2655,6 +2794,10 @@ class GgufQuantizedDotTest {
       }
     }
     return out;
+  }
+
+  private static int[] q4Corrections(int activationEntries) {
+    return new int[activationEntries / 4];
   }
 
   @FunctionalInterface

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -19,16 +19,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
+import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorOperators;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("unit")
 class PanamaGgufQuantizedDotTest {
+
+  private static final ValueLayout.OfShort LE_SHORT =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
 
   @Test
   void q4ShortPairwiseRequiresExplicitSelectionAvx2WidthAndModelSizedRows() {
@@ -50,6 +56,49 @@ class PanamaGgufQuantizedDotTest {
         .isFalse();
     assertThat(PanamaVectorUtilSupport.useQ4ShortPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 256, 31))
         .isFalse();
+    assertThat(
+            PanamaVectorUtilSupport.useQ4UnsignedPairwise(GgufQ4Kernel.UNSIGNED_PAIRWISE, 128, 64))
+        .isFalse();
+    assertThat(
+            PanamaVectorUtilSupport.useQ4UnsignedPairwise(GgufQ4Kernel.UNSIGNED_PAIRWISE, 256, 31))
+        .isFalse();
+    assertThat(
+            PanamaVectorUtilSupport.useQ4UnsignedPairwise(GgufQ4Kernel.UNSIGNED_PAIRWISE, 256, 32))
+        .isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ4UnsignedPairwise(GgufQ4Kernel.SHORT_PAIRWISE, 256, 64))
+        .isFalse();
+  }
+
+  @Test
+  void unsignedPairwiseFallbackDoesNotComputeUnusedCorrections() {
+    int blocks = 31;
+    int cols = blocks * 32;
+    float[] query = new float[cols];
+    byte[] weights = new byte[blocks * 18];
+    ByteBuffer weightBuffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int block = 0; block < blocks; block++) {
+      weightBuffer.putShort(block * 18, Float.floatToFloat16(0.125f));
+      for (int index = 0; index < 32; index++) {
+        query[block * 32 + index] = (index - 15) / 17.0f;
+      }
+    }
+    int sentinel = 0x5148;
+    int[] corrections = new int[cols / 4];
+    java.util.Arrays.fill(corrections, sentinel);
+
+    new PanamaVectorUtilSupport()
+        .ggufQ4_0Q8_0MatVecDot(
+            query,
+            MemorySegment.ofArray(weights),
+            1,
+            cols,
+            new float[1],
+            new byte[cols],
+            new float[blocks],
+            corrections,
+            GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    assertThat(corrections).containsOnly(sentinel);
   }
 
   @Test
@@ -109,6 +158,93 @@ class PanamaGgufQuantizedDotTest {
       IntVector shortPairwise =
           PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(weights, 0, q8, 0);
       assertThat(shortPairwise.toArray()).containsExactly(expected.toArray());
+    }
+  }
+
+  @Test
+  void q4_0Q8_0UnsignedPairwiseRowMatchesShortPairwiseExactly() {
+    int blocks = 64;
+    byte[] weightBytes = new byte[blocks * 18];
+    byte[] q8 = new byte[blocks * 32];
+    float[] q8Scales = new float[blocks];
+    int[] zeroPointCorrections = new int[blocks * 8];
+    Random random = new Random(0x554e5349474e4544L);
+
+    for (int trial = 0; trial < 1_000; trial++) {
+      for (int block = 0; block < blocks; block++) {
+        int weightOffset = block * 18;
+        short scale = Float.floatToFloat16(0.001f + random.nextFloat() * 0.05f);
+        weightBytes[weightOffset] = (byte) scale;
+        weightBytes[weightOffset + 1] = (byte) (scale >>> 8);
+        for (int index = 0; index < 16; index++) {
+          weightBytes[weightOffset + Short.BYTES + index] = (byte) random.nextInt();
+        }
+        for (int index = 0; index < 32; index++) {
+          q8[block * 32 + index] = (byte) random.nextInt(-127, 128);
+        }
+        for (int group = 0; group < 8; group++) {
+          int offset = block * 32 + group * 4;
+          zeroPointCorrections[block * 8 + group] =
+              8 * (q8[offset] + q8[offset + 1] + q8[offset + 2] + q8[offset + 3]);
+        }
+        q8Scales[block] = 0.001f + random.nextFloat() * 0.05f;
+      }
+
+      MemorySegment weights = MemorySegment.ofArray(weightBytes);
+      FloatVector expectedLanes = FloatVector.zero(FloatVector.SPECIES_256);
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = (long) block * 18;
+        float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+        IntVector groups =
+            PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
+                weights, blockOffset + Short.BYTES, q8, block * 32);
+        expectedLanes =
+            PanamaVectorUtilSupport.fma(
+                (FloatVector) groups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0),
+                FloatVector.broadcast(FloatVector.SPECIES_256, scale),
+                expectedLanes);
+      }
+      float even =
+          (expectedLanes.lane(4) + expectedLanes.lane(0))
+              + (expectedLanes.lane(6) + expectedLanes.lane(2));
+      float odd =
+          (expectedLanes.lane(5) + expectedLanes.lane(1))
+              + (expectedLanes.lane(7) + expectedLanes.lane(3));
+      float expected = even + odd;
+
+      float actual =
+          PanamaVectorUtilSupport.q4_0Q8_0UnsignedPairwiseRowDot(
+              weights, 0, blocks, q8, q8Scales, zeroPointCorrections);
+
+      assertThat(Float.floatToRawIntBits(actual)).isEqualTo(Float.floatToRawIntBits(expected));
+    }
+  }
+
+  @Test
+  void q8_0QuantizationProducesExactQ4ZeroPointCorrections() {
+    float[] query = new float[96];
+    Random random = new Random(0x51385a504f494e54L);
+    for (int index = 0; index < query.length; index++) {
+      query[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+    byte[] quants = new byte[query.length];
+    float[] scales = new float[query.length / 32];
+    int[] zeroPointCorrections = new int[query.length / 4];
+    byte[] referenceQuants = new byte[query.length];
+    float[] referenceScales = new float[query.length / 32];
+
+    GgufQuantizationSupport.quantizeQ8_0(query, query.length, referenceQuants, referenceScales);
+
+    GgufQuantizationSupport.quantizeQ8_0WithQ4Corrections(
+        query, query.length, quants, scales, zeroPointCorrections);
+
+    assertThat(quants).containsExactly(referenceQuants);
+    assertThat(scales).containsExactly(referenceScales);
+    for (int group = 0; group < zeroPointCorrections.length; group++) {
+      int offset = group * 4;
+      assertThat(zeroPointCorrections[group])
+          .isEqualTo(
+              8 * (quants[offset] + quants[offset + 1] + quants[offset + 2] + quants[offset + 3]));
     }
   }
 
@@ -342,6 +478,7 @@ class PanamaGgufQuantizedDotTest {
             expected,
             expectedQuants,
             expectedScales,
+            new int[cols / 4],
             GgufQ4Kernel.WIDENED);
     new PanamaVectorUtilSupport()
         .ggufQ4_0Q8_0MatVecDot(
@@ -352,6 +489,7 @@ class PanamaGgufQuantizedDotTest {
             actual,
             actualQuants,
             actualScales,
+            new int[cols / 4],
             GgufQ4Kernel.WIDENED);
 
     assertThat(actualQuants).containsExactly(expectedQuants);

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorizationProviderTest.java
@@ -51,6 +51,7 @@ class VectorizationProviderTest {
     assertThat(summary).contains("mappedKQuantLongOffsets=auto(");
     assertThat(summary).contains("q4=").contains("q5=").contains("q6=");
     assertThat(summary).contains("q4ShortPairwiseSupported=");
+    assertThat(summary).contains("q4UnsignedPairwiseSupported=");
     assertThat(summary).contains("toggles=[");
     assertThat(summary).endsWith("]");
   }
@@ -130,6 +131,10 @@ class VectorizationProviderTest {
             VectorizationProvider.isPanamaEnabled() ? PanamaVectorUtilSupport.VECTOR_BITSIZE : 0);
     assertThat(capabilities.ggufExecutor()).isEqualTo("persistent");
     assertThat(capabilities.q4ShortPairwiseSupported())
+        .isEqualTo(
+            VectorizationProvider.isPanamaEnabled()
+                && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256);
+    assertThat(capabilities.q4UnsignedPairwiseSupported())
         .isEqualTo(
             VectorizationProvider.isPanamaEnabled()
                 && PanamaVectorUtilSupport.VECTOR_BITSIZE >= 256);


### PR DESCRIPTION
## Summary

- add an explicit unsigned-nibble Q4_0/Q8_0 pairwise kernel policy
- compute exact Q8 zero-point corrections once during activation quantization
- route single, grouped, and batched Q4 operations through the packed byte multiply-add graph
- expose runtime capability metadata and add production-shaped JMH gates
- remove the old Q4 method signatures instead of carrying compatibility overloads

## Why

The existing Java 25 Q4 path widens nibbles and activations before multiplying. Current llama.cpp AVX2 code instead uses packed unsigned-byte by signed-byte pairwise multiplication followed by signed-short pairwise reduction. Rewriting `(q4 - 8) * q8` as `q4 * q8 - 8 * sum(q8)` lets Graal emit the same `VPMADDUBSW`/`VPMADDWD` instruction family through the public Vector API while preserving the established floating-point accumulation order.

## Evidence

On the controlled eight-vCPU AMD EPYC Milan host with GraalVM CE JDK 25.0.3 and Qwen3 0.6B Q4_0:

| Metric | Short pairwise | Unsigned pairwise |
| --- | ---: | ---: |
| p50 TTFT | 1733.321 ms | 1349.070 ms |
| p50 prefill | 90.179 tok/s | 115.616 tok/s |
| p50 decode | 37.947 tok/s | 58.036 tok/s |
| p50 TPOT | 25.527 ms | 17.218 ms |
| mean trial CPU | 23073 ms | 15115 ms |

Six counterbalanced process pairs produced 18 trials per mode. The unsigned path won all 18 paired decode, TTFT, prefill, TPOT, and CPU comparisons. All 18 corresponding input counts, output counts, and output SHA-256 values matched exactly. No RSS claim is made because process residency varied with compilation lifetime.

The isolated 64-block row benchmark improved from 258.466 ns/op to 121.490 ns/op, and a 1024x2048 production-shaped GEMV improved by about 47% in the controlled JMH gate.

## Validation

- `./gradlew spotlessApply check` (395 tasks)
- `./gradlew :vectors-core:spotlessApply :vectors-core:check :vectors-bench:check`
- randomized bit-exact widened/short/unsigned row coverage
- exact single, grouped, and batched Q4 coverage
- fallback test proving below-threshold calls do not compute unused corrections
- controlled whole-model Qwen gate described above
