### PR TITLE
feat(gguf): add staged quantized row execution

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufStagePlanBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufStagePlanBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Isolates publication and completion cost for two dependent GGUF work stages. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Threads(1)
+@Fork(
+    value = 3,
+    jvmArgsPrepend = {"--add-modules", "jdk.incubator.vector", "-XX:ActiveProcessorCount=8"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 2)
+public class GgufStagePlanBenchmark {
+
+  private static final int FIRST_WORK_ITEMS = 152;
+  private static final int SECOND_WORK_ITEMS = 1024;
+
+  private GgufPersistentRowExecutor executor;
+  private GgufStagePlan plan;
+  private int[] firstOutput;
+  private int[] secondOutput;
+  private IntConsumer firstOperation;
+  private IntConsumer secondOperation;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    firstOutput = new int[FIRST_WORK_ITEMS];
+    secondOutput = new int[SECOND_WORK_ITEMS];
+    firstOperation = item -> firstOutput[item]++;
+    secondOperation = item -> secondOutput[item] += firstOutput[item % FIRST_WORK_ITEMS];
+    executor = new GgufPersistentRowExecutor(8, 2, "vectors-stage-bench");
+    plan =
+        GgufStagePlan.of(
+            GgufStagePlan.stage(FIRST_WORK_ITEMS, this::runFirstRange),
+            GgufStagePlan.stage(SECOND_WORK_ITEMS, this::runSecondRange));
+  }
+
+  @Benchmark
+  public void separateDispatches(Blackhole blackhole) {
+    executor.forEach(FIRST_WORK_ITEMS, firstOperation);
+    executor.forEach(SECOND_WORK_ITEMS, secondOperation);
+    blackhole.consume(secondOutput);
+  }
+
+  @Benchmark
+  public void stagedDispatch(Blackhole blackhole) {
+    executor.execute(plan);
+    blackhole.consume(secondOutput);
+  }
+
+  private void runFirstRange(int fromInclusive, int toExclusive) {
+    for (int item = fromInclusive; item < toExclusive; item++) {
+      firstOperation.accept(item);
+    }
+  }
+
+  private void runSecondRange(int fromInclusive, int toExclusive) {
+    for (int item = fromInclusive; item < toExclusive; item++) {
+      secondOperation.accept(item);
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    executor.close();
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufParallelSupport.java
@@ -135,6 +135,14 @@ final class GgufParallelSupport {
     return CHUNKS_PER_THREAD;
   }
 
+  static void execute(GgufStagePlan plan) {
+    if (ENABLED && PARALLELISM > 1) {
+      ExecutorHolder.INSTANCE.execute(plan);
+      return;
+    }
+    plan.executeSerially();
+  }
+
   static GgufRowExecutor newExecutor(
       ExecutionMode mode, int parallelism, int chunksPerThread, String threadNamePrefix) {
     return switch (mode) {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufPersistentRowExecutor.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufPersistentRowExecutor.java
@@ -18,6 +18,7 @@ package com.integrallis.vectors.core;
 import java.util.Objects;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.IntConsumer;
@@ -33,7 +34,9 @@ final class GgufPersistentRowExecutor implements GgufRowExecutor {
   private final AtomicReference<Throwable> failure = new AtomicReference<>();
   private final Thread[] workers;
 
+  private AtomicIntegerArray stageNextChunks = new AtomicIntegerArray(0);
   private IntConsumer operation;
+  private GgufStagePlan stagePlan;
   private int rows;
   private int chunkSize;
   private boolean closed;
@@ -75,6 +78,7 @@ final class GgufPersistentRowExecutor implements GgufRowExecutor {
     try {
       ensureOpen();
       operation = rowOperation;
+      stagePlan = null;
       rows = rowCount;
       int targetChunks = (int) Math.min(rowCount, (long) parallelism * chunksPerWorker);
       chunkSize = (rowCount + targetChunks - 1) / targetChunks;
@@ -99,6 +103,31 @@ final class GgufPersistentRowExecutor implements GgufRowExecutor {
     return parallelism;
   }
 
+  @Override
+  public void execute(GgufStagePlan plan) {
+    Objects.requireNonNull(plan, "plan");
+
+    publicationLock.lock();
+    try {
+      ensureOpen();
+      operation = null;
+      stagePlan = plan;
+      prepareStageChunks(plan.stageCount());
+      failure.set(null);
+
+      phase.arriveAndAwaitAdvance();
+      executePublishedPlan(plan);
+
+      Throwable thrown = failure.get();
+      stagePlan = null;
+      if (thrown != null) {
+        rethrow(thrown);
+      }
+    } finally {
+      publicationLock.unlock();
+    }
+  }
+
   private void workerLoop() {
     while (true) {
       phase.arriveAndAwaitAdvance();
@@ -106,8 +135,54 @@ final class GgufPersistentRowExecutor implements GgufRowExecutor {
         phase.arriveAndAwaitAdvance();
         return;
       }
-      executePublishedOperation();
+      GgufStagePlan publishedPlan = stagePlan;
+      if (publishedPlan != null) {
+        executePublishedPlan(publishedPlan);
+      } else {
+        executePublishedOperation();
+        phase.arriveAndAwaitAdvance();
+      }
+    }
+  }
+
+  private void executePublishedPlan(GgufStagePlan plan) {
+    for (int stageIndex = 0; stageIndex < plan.stageCount(); stageIndex++) {
+      executeStage(plan.stage(stageIndex), stageIndex);
       phase.arriveAndAwaitAdvance();
+    }
+  }
+
+  private void executeStage(GgufStagePlan.Stage stage, int stageIndex) {
+    if (failure.get() != null) {
+      return;
+    }
+    try {
+      int workItems = stage.workItems();
+      int targetChunks = (int) Math.min(workItems, (long) parallelism * (long) chunksPerWorker);
+      int stageChunkSize = (workItems + targetChunks - 1) / targetChunks;
+      while (failure.get() == null) {
+        int chunk = stageNextChunks.getAndIncrement(stageIndex);
+        if (chunk >= targetChunks) {
+          return;
+        }
+        int start = chunk * stageChunkSize;
+        int end = Math.min(start + stageChunkSize, workItems);
+        if (start < end) {
+          stage.operation().execute(start, end);
+        }
+      }
+    } catch (Throwable thrown) {
+      failure.compareAndSet(null, thrown);
+    }
+  }
+
+  private void prepareStageChunks(int stageCount) {
+    if (stageNextChunks.length() < stageCount) {
+      stageNextChunks = new AtomicIntegerArray(stageCount);
+      return;
+    }
+    for (int stage = 0; stage < stageCount; stage++) {
+      stageNextChunks.set(stage, 0);
     }
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.Objects;
+
+/** Caller-owned reusable Q8_0 activation storage for staged GGUF matrix operations. */
+public final class GgufQ8_0Batch {
+
+  private static final int BLOCK_SIZE = VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
+  private static final int CORRECTIONS_PER_BLOCK = BLOCK_SIZE / 4;
+
+  private final int batchCapacity;
+  private final int dimensions;
+  private final int blocks;
+  private final byte[] quants;
+  private final float[] scales;
+  private final int[] zeroPointCorrections;
+
+  private GgufQ8_0Batch(int batchCapacity, int dimensions) {
+    this.batchCapacity = batchCapacity;
+    this.dimensions = dimensions;
+    this.blocks = dimensions / BLOCK_SIZE;
+    this.quants = new byte[checkedProduct(batchCapacity, dimensions, "Q8_0 quants")];
+    this.scales = new float[checkedProduct(batchCapacity, blocks, "Q8_0 scales")];
+    this.zeroPointCorrections =
+        new int
+            [checkedProduct(
+                checkedProduct(batchCapacity, blocks, "Q8_0 correction blocks"),
+                CORRECTIONS_PER_BLOCK,
+                "Q8_0 corrections")];
+  }
+
+  /** Allocates reusable storage for {@code batchCapacity} activation rows. */
+  public static GgufQ8_0Batch allocate(int batchCapacity, int dimensions) {
+    if (batchCapacity < 1) {
+      throw new IllegalArgumentException("batchCapacity must be positive: " + batchCapacity);
+    }
+    if (dimensions < BLOCK_SIZE || dimensions % BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "dimensions must be a positive multiple of " + BLOCK_SIZE + ": " + dimensions);
+    }
+    return new GgufQ8_0Batch(batchCapacity, dimensions);
+  }
+
+  /** Quantizes complete batch rows for a subsequent Q4_0 operation. */
+  public void quantizeForQ4(float[] values, int batchSize, GgufQ4Kernel kernel) {
+    quantizeBlockRangeForQ4(values, batchSize, 0, blocks, kernel);
+  }
+
+  /**
+   * Quantizes one non-empty contiguous block range across active batch rows.
+   *
+   * <p>Distinct block ranges may be written concurrently.
+   */
+  public void quantizeBlockRangeForQ4(
+      float[] values, int batchSize, int fromBlock, int toBlock, GgufQ4Kernel kernel) {
+    Objects.requireNonNull(values, "values");
+    Objects.requireNonNull(kernel, "kernel");
+    checkBatchSize(batchSize);
+    if (fromBlock < 0 || fromBlock >= toBlock || toBlock > blocks) {
+      throw new IndexOutOfBoundsException(
+          "block range must satisfy 0 <= fromBlock < toBlock <= blocks: "
+              + fromBlock
+              + ".."
+              + toBlock
+              + " for "
+              + blocks);
+    }
+    int length = (toBlock - fromBlock) * BLOCK_SIZE;
+    int requiredValues = checkedProduct(batchSize, dimensions, "batchSize * dimensions");
+    if (values.length < requiredValues) {
+      throw new IllegalArgumentException(
+          "values.length must be >= batchSize * dimensions: "
+              + values.length
+              + " < "
+              + requiredValues);
+    }
+    boolean corrections = kernel == GgufQ4Kernel.UNSIGNED_PAIRWISE;
+    for (int batch = 0; batch < batchSize; batch++) {
+      int valueOffset = batch * dimensions + fromBlock * BLOCK_SIZE;
+      int scaleOffset = batch * blocks + fromBlock;
+      if (corrections) {
+        GgufQuantizationSupport.quantizeQ8_0WithQ4Corrections(
+            values,
+            valueOffset,
+            length,
+            quants,
+            valueOffset,
+            scales,
+            scaleOffset,
+            zeroPointCorrections,
+            scaleOffset * CORRECTIONS_PER_BLOCK);
+      } else {
+        GgufQuantizationSupport.quantizeQ8_0(
+            values, valueOffset, length, quants, valueOffset, scales, scaleOffset);
+      }
+    }
+  }
+
+  /** Returns the maximum number of activation rows retained by this storage. */
+  public int batchCapacity() {
+    return batchCapacity;
+  }
+
+  /** Returns the number of values in each activation row. */
+  public int dimensions() {
+    return dimensions;
+  }
+
+  byte[] quants() {
+    return quants;
+  }
+
+  float[] scales() {
+    return scales;
+  }
+
+  int[] zeroPointCorrections() {
+    return zeroPointCorrections;
+  }
+
+  private void checkBatchSize(int batchSize) {
+    if (batchSize < 1 || batchSize > batchCapacity) {
+      throw new IllegalArgumentException(
+          "batchSize must be between 1 and " + batchCapacity + ": " + batchSize);
+    }
+  }
+
+  private static int checkedProduct(int first, int second, String label) {
+    try {
+      return Math.multiplyExact(first, second);
+    } catch (ArithmeticException exception) {
+      throw new IllegalArgumentException(label + " exceeds array capacity", exception);
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufRowExecutor.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufRowExecutor.java
@@ -15,12 +15,17 @@
  */
 package com.integrallis.vectors.core;
 
+import java.util.Objects;
 import java.util.function.IntConsumer;
 
 /** Internal execution contract for independent GGUF output rows. */
 interface GgufRowExecutor extends AutoCloseable {
 
   void forEach(int rows, IntConsumer rowOperation);
+
+  default void execute(GgufStagePlan plan) {
+    Objects.requireNonNull(plan, "plan").executeSerially();
+  }
 
   @Override
   default void close() {}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufStagePlan.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufStagePlan.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+import java.util.Objects;
+
+/** Reusable ordered stages that share one configured GGUF worker publication. */
+public final class GgufStagePlan {
+
+  private final Stage[] stages;
+
+  private GgufStagePlan(Stage[] stages) {
+    this.stages = stages;
+  }
+
+  /** Creates an immutable plan containing at least one stage. */
+  public static GgufStagePlan of(Stage... stages) {
+    Objects.requireNonNull(stages, "stages");
+    if (stages.length == 0) {
+      throw new IllegalArgumentException("a GGUF stage plan requires at least one stage");
+    }
+    Stage[] copy = stages.clone();
+    for (Stage stage : copy) {
+      Objects.requireNonNull(stage, "stage");
+    }
+    return new GgufStagePlan(copy);
+  }
+
+  /** Creates one range-partitioned stage. */
+  public static Stage stage(int workItems, RangeOperation operation) {
+    return new Stage(workItems, operation);
+  }
+
+  /** Executes this plan using the configured GGUF execution policy. */
+  public void execute() {
+    GgufParallelSupport.execute(this);
+  }
+
+  /** Returns the number of ordered stages. */
+  public int stageCount() {
+    return stages.length;
+  }
+
+  Stage stage(int index) {
+    return stages[index];
+  }
+
+  void executeSerially() {
+    for (Stage stage : stages) {
+      stage.operation().execute(0, stage.workItems());
+    }
+  }
+
+  /** One ordered stage partitioned into non-overlapping contiguous ranges. */
+  public record Stage(int workItems, RangeOperation operation) {
+
+    public Stage {
+      if (workItems < 1) {
+        throw new IllegalArgumentException("stage workItems must be positive");
+      }
+      operation = Objects.requireNonNull(operation, "operation");
+    }
+  }
+
+  /** Performs one non-empty half-open range of stage work items. */
+  @FunctionalInterface
+  public interface RangeOperation {
+
+    void execute(int fromInclusive, int toExclusive);
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -685,72 +685,141 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
-        row -> {
-          long rowOffset = row * rowBytes;
-          int rowLaneOffset = row * batchSize * FloatVector.SPECIES_256.length();
-          int rowLaneEnd = rowLaneOffset + batchSize * FloatVector.SPECIES_256.length();
-          for (int lane = rowLaneOffset; lane < rowLaneEnd; lane++) {
-            laneScratch[lane] = 0.0f;
-          }
+        row ->
+            ggufQ4_0Q8_0BatchedMatmulRow(
+                qWeight,
+                batchSize,
+                rows,
+                cols,
+                row,
+                out,
+                q8Quants,
+                q8Scales,
+                q8ZeroPointCorrections,
+                laneScratch,
+                blocks,
+                rowBytes,
+                useShortPairwise,
+                useUnsignedPairwise));
+  }
 
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
-            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
-            ByteVector packed =
-                ByteVector.fromMemorySegment(
-                    ByteVector.SPECIES_128,
-                    qWeight,
-                    blockOffset + Short.BYTES,
-                    ByteOrder.LITTLE_ENDIAN);
-            ByteVector lowNibbles = packed.and((byte) 0x0F);
-            ByteVector highNibbles = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
-            if (useUnsignedPairwise) {
-              for (int batch = 0; batch < batchSize; batch++) {
-                int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
-                accumulateQ4_0UnsignedBatchQuery(
-                    laneScratch,
-                    laneOffset,
-                    lowNibbles,
-                    highNibbles,
-                    q8Quants,
-                    (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
-                    q8ZeroPointCorrections,
-                    (batch * blocks + block) * 8,
-                    weightScale * q8Scales[batch * blocks + block]);
-              }
-              continue;
-            }
-            ShortVector low =
-                (ShortVector)
-                    lowNibbles
-                        .sub((byte) 8)
-                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
-            ShortVector high =
-                (ShortVector)
-                    highNibbles
-                        .sub((byte) 8)
-                        .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+  @Override
+  public void ggufQ4_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
+    if (VECTOR_BITSIZE < 256) {
+      VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmulRows(
+          qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, kernel);
+      return;
+    }
 
-            for (int batch = 0; batch < batchSize; batch++) {
-              int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
-              accumulateQ4_0BatchQuery(
-                  laneScratch,
-                  laneOffset,
-                  low,
-                  high,
-                  q8Quants,
-                  (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
-                  weightScale * q8Scales[batch * blocks + block],
-                  useShortPairwise);
-            }
-          }
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    long rowBytes = (long) blocks * GGUF_Q4_0_BLOCK_BYTES;
+    boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
+    boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
+    for (int row = fromRow; row < toRow; row++) {
+      ggufQ4_0Q8_0BatchedMatmulRow(
+          qWeight,
+          batchSize,
+          rows,
+          cols,
+          row,
+          out,
+          activation.quants(),
+          activation.scales(),
+          activation.zeroPointCorrections(),
+          laneScratch,
+          blocks,
+          rowBytes,
+          useShortPairwise,
+          useUnsignedPairwise);
+    }
+  }
 
-          for (int batch = 0; batch < batchSize; batch++) {
-            int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
-            out[batch * rows + row] =
-                reduceAdd(FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
-          }
-        });
+  private void ggufQ4_0Q8_0BatchedMatmulRow(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int row,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      int[] q8ZeroPointCorrections,
+      float[] laneScratch,
+      int blocks,
+      long rowBytes,
+      boolean useShortPairwise,
+      boolean useUnsignedPairwise) {
+    long rowOffset = row * rowBytes;
+    int rowLaneOffset = row * batchSize * FloatVector.SPECIES_256.length();
+    int rowLaneEnd = rowLaneOffset + batchSize * FloatVector.SPECIES_256.length();
+    for (int lane = rowLaneOffset; lane < rowLaneEnd; lane++) {
+      laneScratch[lane] = 0.0f;
+    }
+
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
+      float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      ByteVector packed =
+          ByteVector.fromMemorySegment(
+              ByteVector.SPECIES_128, qWeight, blockOffset + Short.BYTES, ByteOrder.LITTLE_ENDIAN);
+      ByteVector lowNibbles = packed.and((byte) 0x0F);
+      ByteVector highNibbles = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+      if (useUnsignedPairwise) {
+        for (int batch = 0; batch < batchSize; batch++) {
+          int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+          accumulateQ4_0UnsignedBatchQuery(
+              laneScratch,
+              laneOffset,
+              lowNibbles,
+              highNibbles,
+              q8Quants,
+              (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
+              q8ZeroPointCorrections,
+              (batch * blocks + block) * 8,
+              weightScale * q8Scales[batch * blocks + block]);
+        }
+        continue;
+      }
+      ShortVector low =
+          (ShortVector)
+              lowNibbles
+                  .sub((byte) 8)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+      ShortVector high =
+          (ShortVector)
+              highNibbles
+                  .sub((byte) 8)
+                  .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+
+      for (int batch = 0; batch < batchSize; batch++) {
+        int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+        accumulateQ4_0BatchQuery(
+            laneScratch,
+            laneOffset,
+            low,
+            high,
+            q8Quants,
+            (batch * cols) + block * GGUF_Q_BLOCK_SIZE,
+            weightScale * q8Scales[batch * blocks + block],
+            useShortPairwise);
+      }
+    }
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
+      out[batch * rows + row] =
+          reduceAdd(FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
+    }
   }
 
   @Override

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -830,6 +830,69 @@ public final class VectorUtil {
         Objects.requireNonNull(kernel, "kernel"));
   }
 
+  /**
+   * Computes a non-empty Q4_0 output-row range from a caller-prequantized activation batch.
+   *
+   * <p>This low-level operation performs no quantization and no worker publication, allowing a
+   * {@link GgufStagePlan} to compose dependent matrix stages without nested scheduling.
+   */
+  public static void ggufQ4_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    if (fromRow < 0 || fromRow >= toRow || toRow > rows) {
+      throw new IndexOutOfBoundsException(
+          "row range must satisfy 0 <= fromRow < toRow <= rows: "
+              + fromRow
+              + ".."
+              + toRow
+              + " for "
+              + rows);
+    }
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(activation, "activation");
+    Objects.requireNonNull(laneScratch, "laneScratch");
+    Objects.requireNonNull(kernel, "kernel");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q4_0_BLOCK_BYTES);
+    if (batchSize > activation.batchCapacity()) {
+      throw new IllegalArgumentException(
+          "batchSize exceeds activation capacity: "
+              + batchSize
+              + " > "
+              + activation.batchCapacity());
+    }
+    if (cols != activation.dimensions()) {
+      throw new IllegalArgumentException(
+          "cols must equal activation dimensions: " + cols + " != " + activation.dimensions());
+    }
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    checkGgufQ4LaneScratch(laneScratch, batchSize, rows, "Q4 row-range lane scratch");
+    IMPL.ggufQ4_0Q8_0BatchedMatmulRows(
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, kernel);
+  }
+
   /** Two Q4_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
   public static void ggufQ4_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -725,6 +725,37 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Q4_0 rows over a caller-prequantized Q8_0 activation batch without row scheduling. */
+  default void ggufQ4_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneScratch,
+      GgufQ4Kernel kernel) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    long rowBytes = ggufQ4_0RowBytes(cols);
+    for (int batch = 0; batch < batchSize; batch++) {
+      int quantBatchOffset = batch * cols;
+      int scaleBatchOffset = batch * blocks;
+      for (int row = fromRow; row < toRow; row++) {
+        out[batch * rows + row] =
+            ggufQ4_0Q8_0ScalarRowDot(
+                qWeight,
+                row * rowBytes,
+                blocks,
+                activation.quants(),
+                quantBatchOffset,
+                activation.scales(),
+                scaleBatchOffset);
+      }
+    }
+  }
+
   /** Two Q4_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
   default void ggufQ4_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufParallelSupportTest.java
@@ -155,6 +155,113 @@ class GgufParallelSupportTest {
   }
 
   @Test
+  void persistentExecutorRunsOrderedStagesWithExactRangeCoverage() {
+    AtomicInteger firstCompleted = new AtomicInteger();
+    AtomicIntegerArray firstVisits = new AtomicIntegerArray(257);
+    AtomicIntegerArray secondVisits = new AtomicIntegerArray(61);
+    GgufStagePlan plan =
+        GgufStagePlan.of(
+            GgufStagePlan.stage(
+                firstVisits.length(),
+                (fromInclusive, toExclusive) -> {
+                  for (int item = fromInclusive; item < toExclusive; item++) {
+                    firstVisits.incrementAndGet(item);
+                    firstCompleted.incrementAndGet();
+                  }
+                }),
+            GgufStagePlan.stage(
+                secondVisits.length(),
+                (fromInclusive, toExclusive) -> {
+                  if (firstCompleted.get() != firstVisits.length()) {
+                    throw new AssertionError("second stage observed incomplete first stage");
+                  }
+                  for (int item = fromInclusive; item < toExclusive; item++) {
+                    secondVisits.incrementAndGet(item);
+                  }
+                }));
+
+    try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test")) {
+      executor.execute(plan);
+    }
+
+    for (int item = 0; item < firstVisits.length(); item++) {
+      assertThat(firstVisits.get(item)).as("first stage item %s", item).isOne();
+    }
+    for (int item = 0; item < secondVisits.length(); item++) {
+      assertThat(secondVisits.get(item)).as("second stage item %s", item).isOne();
+    }
+  }
+
+  @Test
+  void persistentExecutorPropagatesStageFailureAndRemainsReusable() {
+    GgufStagePlan failing =
+        GgufStagePlan.of(
+            GgufStagePlan.stage(64, (fromInclusive, toExclusive) -> {}),
+            GgufStagePlan.stage(
+                64,
+                (fromInclusive, toExclusive) -> {
+                  if (fromInclusive <= 17 && 17 < toExclusive) {
+                    throw new IllegalStateException("stage boom");
+                  }
+                }));
+
+    try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test")) {
+      assertThatThrownBy(() -> executor.execute(failing))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("stage boom");
+
+      AtomicIntegerArray visits = new AtomicIntegerArray(64);
+      executor.execute(
+          GgufStagePlan.of(
+              GgufStagePlan.stage(
+                  visits.length(),
+                  (fromInclusive, toExclusive) -> {
+                    for (int item = fromInclusive; item < toExclusive; item++) {
+                      visits.incrementAndGet(item);
+                    }
+                  })));
+      for (int item = 0; item < visits.length(); item++) {
+        assertThat(visits.get(item)).as("reused item %s", item).isOne();
+      }
+    }
+  }
+
+  @Test
+  void persistentExecutorSerializesConcurrentStagePublishers() throws Exception {
+    try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test");
+        ExecutorService publishers = Executors.newFixedThreadPool(4)) {
+      List<Future<AtomicIntegerArray>> results = new ArrayList<>();
+      for (int publisher = 0; publisher < 4; publisher++) {
+        results.add(
+            publishers.submit(
+                () -> {
+                  AtomicIntegerArray visits = new AtomicIntegerArray(97);
+                  GgufStagePlan plan =
+                      GgufStagePlan.of(
+                          GgufStagePlan.stage(
+                              visits.length(),
+                              (fromInclusive, toExclusive) -> {
+                                for (int item = fromInclusive; item < toExclusive; item++) {
+                                  visits.incrementAndGet(item);
+                                }
+                              }));
+                  for (int round = 0; round < 20; round++) {
+                    executor.execute(plan);
+                  }
+                  return visits;
+                }));
+      }
+
+      for (Future<AtomicIntegerArray> result : results) {
+        AtomicIntegerArray visits = result.get();
+        for (int item = 0; item < visits.length(); item++) {
+          assertThat(visits.get(item)).as("stage item %s", item).isEqualTo(20);
+        }
+      }
+    }
+  }
+
+  @Test
   void persistentExecutorSerializesConcurrentPublishersWithoutLosingRows() throws Exception {
     try (GgufPersistentRowExecutor executor = new GgufPersistentRowExecutor(4, 4, "vectors-test");
         ExecutorService publishers = Executors.newFixedThreadPool(4)) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -746,6 +746,126 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0PrequantizedRowRangesComposeToTheExactBatchedResult() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 1024;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow =
+        repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), cols / 32);
+    byte[] secondRow =
+        repeat(q4Block(-0.25f, ones(32), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32);
+    MemorySegment weight =
+        MemorySegment.ofArray(
+            concat(concat(firstRow, secondRow), concat(concat(firstRow, secondRow), firstRow)));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    GgufQ8_0Batch activation = GgufQ8_0Batch.allocate(batchSize, cols);
+
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        weight,
+        batchSize,
+        rows,
+        cols,
+        expected,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)],
+        q4Corrections(batchSize * cols),
+        new float[batchSize * rows * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    activation.quantizeForQ4(queries, batchSize, GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+        weight,
+        batchSize,
+        rows,
+        cols,
+        0,
+        2,
+        actual,
+        activation,
+        new float[batchSize * rows * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+        weight,
+        batchSize,
+        rows,
+        cols,
+        2,
+        rows,
+        actual,
+        activation,
+        new float[batchSize * rows * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q4_0BlockRangeActivationQuantizationMatchesWholeBatchExactly() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 1024;
+    int blocks = cols / 32;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] row = repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 11 + hi * 3) & 0xFF), blocks);
+    MemorySegment weight = MemorySegment.ofArray(repeat(row, rows));
+    GgufQ8_0Batch whole = GgufQ8_0Batch.allocate(batchSize, cols);
+    GgufQ8_0Batch rangeWise = GgufQ8_0Batch.allocate(batchSize, cols);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+
+    whole.quantizeForQ4(queries, batchSize, GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    int split = blocks / 3;
+    rangeWise.quantizeBlockRangeForQ4(queries, batchSize, 0, split, GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    rangeWise.quantizeBlockRangeForQ4(
+        queries, batchSize, split, blocks, GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+        weight,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        expected,
+        whole,
+        new float[batchSize * rows * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+        weight,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        actual,
+        rangeWise,
+        new float[batchSize * rows * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q8_0BatchRejectsInvalidShapeAndBlockRanges() {
+    assertThatThrownBy(() -> GgufQ8_0Batch.allocate(0, 32))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchCapacity");
+    assertThatThrownBy(() -> GgufQ8_0Batch.allocate(1, 33))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("dimensions");
+
+    GgufQ8_0Batch activation = GgufQ8_0Batch.allocate(1, 32);
+    assertThatThrownBy(
+            () ->
+                activation.quantizeBlockRangeForQ4(
+                    new float[32], 1, 1, 2, GgufQ4Kernel.UNSIGNED_PAIRWISE))
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessageContaining("block range");
+  }
+
+  @Test
   void q4_0Q8_0DualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
     int batchSize = 3;
     int cols = 1024;


### PR DESCRIPTION
## What changed

- add a reusable ordered GGUF range-stage plan on the persistent row executor
- add caller-owned Q8_0 batch storage with concurrent block-range quantization
- add an unscheduled prequantized Q4_0 batched row-range kernel
- retain scalar and Panama implementations with exact composition tests
- add executor concurrency/failure coverage and a two-stage publication JMH benchmark

## Why

Pure-Java prefill was spending 22.84% of sampled CPU in row-worker publication and completion. Dependent transformer operations could not share one worker publication without a generic staged primitive, and Models should not place transformer policy in Vectors.

The final Qwen3 0.6B Q4_0 gate uses this API from Models and measured a raw median prefill improvement from 115.847 to 124.822 tok/s (+7.75%). Six counterbalanced pairs with ten warmups and five trials per process produced five staged wins, a +7.02% paired median prefill gain, and effectively flat raw median CPU time.

## Validation

- `./gradlew :vectors-core:spotlessApply :vectors-core:check :vectors-bench:jmhClasses --no-daemon`
- three-fork local JMH: staged dispatch 4.882 us/op vs separate dispatches 5.741 us/op
- exact split-range Q4 and Q8 composition tests
- persistent executor ordering, failure propagation, reuse, close, and concurrent publisher tests
