### PR TITLE
perf(core): remove redundant Q4 nibble masks

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -121,6 +121,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return requested && vectorBits >= 256 && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
   }
 
+  static ByteVector q4HighNibbles(ByteVector packed) {
+    // Logical shift zero-fills each byte lane, so the result is already in [0, 15].
+    return packed.lanewise(VectorOperators.LSHR, 4);
+  }
+
   private static boolean useQ4ShortPairwise(GgufQ4Kernel kernel, int blocks) {
     return useQ4ShortPairwise(kernel, VECTOR_BITSIZE, blocks);
   }
@@ -773,7 +778,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ByteVector.fromMemorySegment(
               ByteVector.SPECIES_128, qWeight, blockOffset + Short.BYTES, ByteOrder.LITTLE_ENDIAN);
       ByteVector lowNibbles = packed.and((byte) 0x0F);
-      ByteVector highNibbles = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+      ByteVector highNibbles = q4HighNibbles(packed);
       if (useUnsignedPairwise) {
         for (int batch = 0; batch < batchSize; batch++) {
           int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
@@ -1057,7 +1062,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                     blockOffset + Short.BYTES,
                     ByteOrder.LITTLE_ENDIAN);
             ByteVector lowNibbles = packed.and((byte) 0x0F);
-            ByteVector highNibbles = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+            ByteVector highNibbles = q4HighNibbles(packed);
             if (useUnsignedPairwise) {
               for (int batch = 0; batch < batchSize; batch++) {
                 int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
@@ -1251,7 +1256,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ByteVector.fromMemorySegment(
               ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
       ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
-      ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+      ByteVector high = q4HighNibbles(packed).sub((byte) 8);
       ShortVector low16 =
           (ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
       ShortVector high16 =
@@ -1274,7 +1279,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ByteVector.fromMemorySegment(
               ByteVector.SPECIES_64, qWeight, nibbleOffset + half, ByteOrder.LITTLE_ENDIAN);
       ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
-      ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+      ByteVector high = q4HighNibbles(packed).sub((byte) 8);
       ShortVector low16 =
           (ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_128, 0);
       ShortVector high16 =
@@ -1299,7 +1304,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         ByteVector.fromMemorySegment(
             ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
     ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
-    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+    ByteVector high = q4HighNibbles(packed).sub((byte) 8);
     ShortVector lowProducts =
         ((ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0))
             .mul(
@@ -1322,7 +1327,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         ByteVector.fromMemorySegment(
             ByteVector.SPECIES_128, qWeight, nibbleOffset, ByteOrder.LITTLE_ENDIAN);
     ByteVector low = packed.and((byte) 0x0F).sub((byte) 8);
-    ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F).sub((byte) 8);
+    ByteVector high = q4HighNibbles(packed).sub((byte) 8);
     ShortVector low16 =
         (ShortVector) low.convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
     ShortVector high16 =
@@ -1355,7 +1360,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           ByteVector.fromMemorySegment(
               ByteVector.SPECIES_128, qWeight, blockOffset + Short.BYTES, ByteOrder.LITTLE_ENDIAN);
       ByteVector low = packed.and((byte) 0x0F);
-      ByteVector high = packed.lanewise(VectorOperators.LSHR, 4).and((byte) 0x0F);
+      ByteVector high = q4HighNibbles(packed);
       int quantOffset = block * GGUF_Q_BLOCK_SIZE;
       int correctionOffset = block * 8;
       IntVector lowGroups =

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -24,9 +24,11 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
+import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -99,6 +101,30 @@ class PanamaGgufQuantizedDotTest {
             GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
     assertThat(corrections).containsOnly(sentinel);
+  }
+
+  @Test
+  void q4HighNibblesDecodeEveryUnsignedByteWithoutCrossLaneBits() {
+    assertQ4HighNibbles(ByteVector.SPECIES_64);
+    assertQ4HighNibbles(ByteVector.SPECIES_128);
+  }
+
+  private static void assertQ4HighNibbles(VectorSpecies<Byte> species) {
+    byte[] packed = new byte[species.length()];
+    byte[] expected = new byte[packed.length];
+
+    for (int first = 0; first < 256; first += packed.length) {
+      for (int lane = 0; lane < packed.length; lane++) {
+        int unsigned = first + lane;
+        packed[lane] = (byte) unsigned;
+        expected[lane] = (byte) (unsigned >>> 4);
+      }
+
+      ByteVector actual =
+          PanamaVectorUtilSupport.q4HighNibbles(ByteVector.fromArray(species, packed, 0));
+
+      assertThat(actual.toArray()).containsExactly(expected);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- centralize unsigned Q4 high-nibble extraction on the Vector API lane-wise logical right shift
- remove the redundant post-shift mask from all Q4_0 row and batched dot-product paths
- exhaustively verify every byte value for 64-bit and 128-bit vector species

## Why

GraalVM JDK 25 retained a second `VPAND` after the high-nibble shift even though lane-wise `LSHR 4` already produces values in `[0, 15]`. The redundant mask was present in the production Q4_0 decode loops.

## Performance evidence

Controlled x86_64 VPS, GraalVM JDK 25.0.3:

- normalized 64-block Q4 row kernel: **159.492 -> 122.321 ns/op** (-23.3%)
- instructions: **2610.113 -> 2564.475/op** (-45.6/op)
- production 1024x2048 unsigned-Q4 GEMV: **0.044 -> 0.039 ms/op** (-11.4%)
- Qwen3 0.6B Q4_0 prefill gate, 30 trials/mode: median TTFT **1288.712 -> 1241.523 ms** (-3.66%); median CPU **8795 -> 8445 ms** (-3.98%)
- Qwen3 0.6B Q4_0 decode gate, 18 trials/mode: median TTFT **1284.471 -> 1229.038 ms** (-4.32%); median p95 TPOT **19.569 -> 18.901 ms** (-3.41%)

All corresponding generated-token hash arrays were exact. The explicit high-half `VPAND` disappears from final assembly while the required low-nibble mask remains.

## Validation

```
./gradlew :vectors-core:check :vectors-bench:jmhClasses
```

The full core test, SpotBugs, JaCoCo, formatting, and JMH compilation gates pass.