### PR TITLE
feat(gguf): support disjoint Q4 scratch windows

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -702,6 +702,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                 q8Scales,
                 q8ZeroPointCorrections,
                 laneScratch,
+                0,
                 blocks,
                 rowBytes,
                 useShortPairwise,
@@ -720,9 +721,36 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       GgufQ8_0Batch activation,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
+    ggufQ4_0Q8_0BatchedMatmulRows(
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, 0, kernel);
+  }
+
+  @Override
+  public void ggufQ4_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneScratch,
+      int laneScratchRowOffset,
+      GgufQ4Kernel kernel) {
     if (VECTOR_BITSIZE < 256) {
       VectorUtilSupport.super.ggufQ4_0Q8_0BatchedMatmulRows(
-          qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, kernel);
+          qWeight,
+          batchSize,
+          rows,
+          cols,
+          fromRow,
+          toRow,
+          out,
+          activation,
+          laneScratch,
+          laneScratchRowOffset,
+          kernel);
       return;
     }
 
@@ -742,6 +770,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           activation.scales(),
           activation.zeroPointCorrections(),
           laneScratch,
+          laneScratchRowOffset,
           blocks,
           rowBytes,
           useShortPairwise,
@@ -760,12 +789,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] q8Scales,
       int[] q8ZeroPointCorrections,
       float[] laneScratch,
+      int laneScratchRowOffset,
       int blocks,
       long rowBytes,
       boolean useShortPairwise,
       boolean useUnsignedPairwise) {
     long rowOffset = row * rowBytes;
-    int rowLaneOffset = row * batchSize * FloatVector.SPECIES_256.length();
+    int rowLaneOffset = (laneScratchRowOffset + row) * batchSize * FloatVector.SPECIES_256.length();
     int rowLaneEnd = rowLaneOffset + batchSize * FloatVector.SPECIES_256.length();
     for (int lane = rowLaneOffset; lane < rowLaneEnd; lane++) {
       laneScratch[lane] = 0.0f;

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -847,6 +847,28 @@ public final class VectorUtil {
       GgufQ8_0Batch activation,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
+    ggufQ4_0Q8_0BatchedMatmulRows(
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, 0, kernel);
+  }
+
+  /**
+   * Computes a Q4_0 output-row range using an interior row window of shared lane scratch.
+   *
+   * <p>Distinct matrix ranges may execute concurrently when their scratch-row windows do not
+   * overlap.
+   */
+  public static void ggufQ4_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneScratch,
+      int laneScratchRowOffset,
+      GgufQ4Kernel kernel) {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
     }
@@ -866,6 +888,10 @@ public final class VectorUtil {
     Objects.requireNonNull(activation, "activation");
     Objects.requireNonNull(laneScratch, "laneScratch");
     Objects.requireNonNull(kernel, "kernel");
+    if (laneScratchRowOffset < 0) {
+      throw new IllegalArgumentException(
+          "laneScratchRowOffset must be non-negative: " + laneScratchRowOffset);
+    }
     checkGgufQuantizedMatrixArguments(
         qWeight,
         rows,
@@ -888,9 +914,23 @@ public final class VectorUtil {
       throw new IllegalArgumentException(
           "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
     }
-    checkGgufQ4LaneScratch(laneScratch, batchSize, rows, "Q4 row-range lane scratch");
+    checkGgufQ4LaneScratch(
+        laneScratch,
+        batchSize,
+        Math.addExact(laneScratchRowOffset, rows),
+        "Q4 row-range lane scratch");
     IMPL.ggufQ4_0Q8_0BatchedMatmulRows(
-        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, kernel);
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        fromRow,
+        toRow,
+        out,
+        activation,
+        laneScratch,
+        laneScratchRowOffset,
+        kernel);
   }
 
   /** Two Q4_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -737,6 +737,23 @@ public interface VectorUtilSupport {
       GgufQ8_0Batch activation,
       float[] laneScratch,
       GgufQ4Kernel kernel) {
+    ggufQ4_0Q8_0BatchedMatmulRows(
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, laneScratch, 0, kernel);
+  }
+
+  /** Q4_0 rows using a non-overlapping row window in caller-owned lane scratch. */
+  default void ggufQ4_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneScratch,
+      int laneScratchRowOffset,
+      GgufQ4Kernel kernel) {
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     long rowBytes = ggufQ4_0RowBytes(cols);
     for (int batch = 0; batch < batchSize; batch++) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -803,6 +803,93 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q4_0PrequantizedRowRangeUsesAnInteriorLaneScratchWindow() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 1024;
+    int scratchRowOffset = 2;
+    int scratchRows = scratchRowOffset + rows + 1;
+    int lanesPerScratchRow = batchSize * 8;
+    float marker = -777.25f;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] row =
+        repeat(q4Block(0.125f, ones(32), (lo, hi) -> (lo * 13 + hi * 7) & 0xFF), cols / 32);
+    MemorySegment weight = MemorySegment.ofArray(repeat(row, rows));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    float[] laneScratch = new float[scratchRows * lanesPerScratchRow];
+    java.util.Arrays.fill(laneScratch, marker);
+    GgufQ8_0Batch activation = GgufQ8_0Batch.allocate(batchSize, cols);
+
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        weight,
+        batchSize,
+        rows,
+        cols,
+        expected,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)],
+        q4Corrections(batchSize * cols),
+        new float[batchSize * rows * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    activation.quantizeForQ4(queries, batchSize, GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+        weight,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        actual,
+        activation,
+        laneScratch,
+        scratchRowOffset,
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    assertThat(actual).containsExactly(expected);
+    assertThat(java.util.Arrays.copyOfRange(laneScratch, 0, scratchRowOffset * lanesPerScratchRow))
+        .containsOnly(marker);
+    assertThat(
+            java.util.Arrays.copyOfRange(
+                laneScratch, (scratchRowOffset + rows) * lanesPerScratchRow, laneScratch.length))
+        .containsOnly(marker);
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+                    weight,
+                    batchSize,
+                    rows,
+                    cols,
+                    0,
+                    rows,
+                    actual,
+                    activation,
+                    laneScratch,
+                    -1,
+                    GgufQ4Kernel.UNSIGNED_PAIRWISE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("laneScratchRowOffset");
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ4_0Q8_0BatchedMatmulRows(
+                    weight,
+                    batchSize,
+                    rows,
+                    cols,
+                    0,
+                    rows,
+                    actual,
+                    activation,
+                    new float[batchSize * rows * 8],
+                    1,
+                    GgufQ4Kernel.UNSIGNED_PAIRWISE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("lane scratch length");
+  }
+
+  @Test
   void q4_0BlockRangeActivationQuantizationMatchesWholeBatchExactly() {
     int batchSize = 3;
     int rows = 5;


### PR DESCRIPTION
## Summary
- add an offset-aware overload for caller-prequantized Q4_0 row ranges
- isolate each matrix in a caller-owned lane-scratch row window for concurrent staged execution
- preserve the existing zero-offset API and scalar-provider behavior
- validate negative offsets and total scratch capacity

## Verification
- ./gradlew :vectors-core:check
- exact Q4_0 output parity with untouched prefix and suffix scratch windows