### PR TITLE
perf(core): combine batched Q4 integer halves

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufBatchedMatmulBenchmark.java
@@ -15,6 +15,7 @@
  */
 package com.integrallis.vectors.bench;
 
+import com.integrallis.vectors.core.GgufQ4Kernel;
 import com.integrallis.vectors.core.VectorUtil;
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
@@ -46,7 +47,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1)
 public class GgufBatchedMatmulBenchmark {
 
-  @Param({"1", "2", "4", "8", "32"})
+  @Param({"1", "2", "4", "8", "24", "32"})
   int batchSize;
 
   @Param("1024")
@@ -128,6 +129,40 @@ public class GgufBatchedMatmulBenchmark {
           independentQuants,
           independentScales,
           independentZeroPointCorrections);
+      blackhole.consume(independentOut);
+    }
+  }
+
+  @Benchmark
+  public void unsignedBatched(Blackhole blackhole) {
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQuants,
+        batchedScales,
+        batchedZeroPointCorrections,
+        batchedLanes,
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void unsignedIndependent(Blackhole blackhole) {
+    for (float[] query : independentQueries) {
+      VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+          query,
+          weights,
+          rows,
+          cols,
+          independentOut,
+          independentQuants,
+          independentScales,
+          independentZeroPointCorrections,
+          GgufQ4Kernel.UNSIGNED_PAIRWISE);
       blackhole.consume(independentOut);
     }
   }

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedDotBenchmark.java
@@ -98,31 +98,34 @@ public class GgufQ4UnsignedDotBenchmark {
   }
 
   private float scalarReference() {
-    float[] accumulator = new float[4];
+    float[] lowAccumulator = new float[4];
+    float[] highAccumulator = new float[4];
     for (int block = 0; block < blocks; block++) {
       long blockOffset = (long) block * BLOCK_BYTES;
       float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      for (int group = 0; group < 4; group++) {
+      for (int group = 0; group < 8; group++) {
         int sum = 0;
-        for (int half = 0; half < 2; half++) {
-          for (int lane = 0; lane < 4; lane++) {
-            int index = half * 16 + group * 4 + lane;
-            int packed =
-                Byte.toUnsignedInt(
-                    weights.get(ValueLayout.JAVA_BYTE, blockOffset + 2 + (index & 15)));
-            int nibble = half == 0 ? packed & 0x0F : packed >>> 4;
-            sum += (nibble - 8) * q8Quants[block * BLOCK_SIZE + index];
-          }
+        for (int lane = 0; lane < 4; lane++) {
+          int index = group * 4 + lane;
+          int packedIndex = index & 15;
+          int packed =
+              Byte.toUnsignedInt(weights.get(ValueLayout.JAVA_BYTE, blockOffset + 2 + packedIndex));
+          int nibble = index < 16 ? packed & 0x0F : packed >>> 4;
+          sum += (nibble - 8) * q8Quants[block * BLOCK_SIZE + index];
         }
-        accumulator[group] = Math.fma(scale, sum, accumulator[group]);
+        if (group < 4) {
+          lowAccumulator[group] = Math.fma(scale, sum, lowAccumulator[group]);
+        } else {
+          highAccumulator[group - 4] = Math.fma(scale, sum, highAccumulator[group - 4]);
+        }
       }
     }
-    return reduce(accumulator);
+    return reduce(lowAccumulator, highAccumulator);
   }
 
-  private static float reduce(float[] accumulator) {
-    float even = accumulator[0] + accumulator[2];
-    float odd = accumulator[1] + accumulator[3];
+  private static float reduce(float[] low, float[] high) {
+    float even = (high[0] + low[0]) + (high[2] + low[2]);
+    float odd = (high[1] + low[1]) + (high[3] + low[3]);
     return even + odd;
   }
 }

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedDotBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/core/GgufQ4UnsignedDotBenchmark.java
@@ -98,34 +98,31 @@ public class GgufQ4UnsignedDotBenchmark {
   }
 
   private float scalarReference() {
-    float[] lowAccumulator = new float[4];
-    float[] highAccumulator = new float[4];
+    float[] accumulator = new float[4];
     for (int block = 0; block < blocks; block++) {
       long blockOffset = (long) block * BLOCK_BYTES;
       float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-      for (int group = 0; group < 8; group++) {
+      for (int group = 0; group < 4; group++) {
         int sum = 0;
-        for (int lane = 0; lane < 4; lane++) {
-          int index = group * 4 + lane;
-          int packedIndex = index & 15;
-          int packed =
-              Byte.toUnsignedInt(weights.get(ValueLayout.JAVA_BYTE, blockOffset + 2 + packedIndex));
-          int nibble = index < 16 ? packed & 0x0F : packed >>> 4;
-          sum += (nibble - 8) * q8Quants[block * BLOCK_SIZE + index];
+        for (int half = 0; half < 2; half++) {
+          for (int lane = 0; lane < 4; lane++) {
+            int index = half * 16 + group * 4 + lane;
+            int packed =
+                Byte.toUnsignedInt(
+                    weights.get(ValueLayout.JAVA_BYTE, blockOffset + 2 + (index & 15)));
+            int nibble = half == 0 ? packed & 0x0F : packed >>> 4;
+            sum += (nibble - 8) * q8Quants[block * BLOCK_SIZE + index];
+          }
         }
-        if (group < 4) {
-          lowAccumulator[group] = Math.fma(scale, sum, lowAccumulator[group]);
-        } else {
-          highAccumulator[group - 4] = Math.fma(scale, sum, highAccumulator[group - 4]);
-        }
+        accumulator[group] = Math.fma(scale, sum, accumulator[group]);
       }
     }
-    return reduce(lowAccumulator, highAccumulator);
+    return reduce(accumulator);
   }
 
-  private static float reduce(float[] low, float[] high) {
-    float even = (high[0] + low[0]) + (high[2] + low[2]);
-    float odd = (high[1] + low[1]) + (high[3] + low[3]);
+  private static float reduce(float[] accumulator) {
+    float even = accumulator[0] + accumulator[2];
+    float odd = accumulator[1] + accumulator[3];
     return even + odd;
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -922,7 +922,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     for (int batch = 0; batch < batchSize; batch++) {
       int laneOffset = rowLaneOffset + batch * FloatVector.SPECIES_256.length();
       out[batch * rows + row] =
-          reduceAdd(FloatVector.fromArray(FloatVector.SPECIES_256, laneScratch, laneOffset));
+          reduceAdd(FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset));
     }
   }
 
@@ -1265,21 +1265,15 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16),
             IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
             pairFactors);
-    FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
-    FloatVector lowAccumulator =
+    IntVector combinedGroups = lowGroups.add(highGroups);
+    FloatVector accumulator =
         FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset);
-    FloatVector highAccumulator =
-        FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset + 4);
     fma(
-            (FloatVector) lowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-            scaleVector,
-            lowAccumulator)
+            (FloatVector)
+                combinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+            FloatVector.broadcast(FloatVector.SPECIES_128, scale),
+            accumulator)
         .intoArray(laneScratch, laneOffset);
-    fma(
-            (FloatVector) highGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-            scaleVector,
-            highAccumulator)
-        .intoArray(laneScratch, laneOffset + 4);
   }
 
   private static void accumulateQ4_0UnsignedBatchQueryBlockPair(
@@ -1296,10 +1290,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float firstScale,
       float secondScale,
       ShortVector pairFactors) {
-    FloatVector lowAccumulator =
+    FloatVector accumulator =
         FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset);
-    FloatVector highAccumulator =
-        FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset + 4);
 
     IntVector firstLowGroups =
         q4_0Q8_0UnsignedPairwiseGroups(
@@ -1313,19 +1305,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16),
             IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
             pairFactors);
-    FloatVector firstScaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, firstScale);
-    lowAccumulator =
+    IntVector firstCombinedGroups = firstLowGroups.add(firstHighGroups);
+    accumulator =
         fma(
             (FloatVector)
-                firstLowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-            firstScaleVector,
-            lowAccumulator);
-    highAccumulator =
-        fma(
-            (FloatVector)
-                firstHighGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-            firstScaleVector,
-            highAccumulator);
+                firstCombinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+            FloatVector.broadcast(FloatVector.SPECIES_128, firstScale),
+            accumulator);
 
     int secondQuantOffset = quantOffset + GGUF_Q_BLOCK_SIZE;
     int secondCorrectionOffset = correctionOffset + 8;
@@ -1343,19 +1329,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             IntVector.fromArray(
                 IntVector.SPECIES_128, zeroPointCorrections, secondCorrectionOffset + 4),
             pairFactors);
-    FloatVector secondScaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, secondScale);
+    IntVector secondCombinedGroups = secondLowGroups.add(secondHighGroups);
     fma(
             (FloatVector)
-                secondLowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-            secondScaleVector,
-            lowAccumulator)
+                secondCombinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+            FloatVector.broadcast(FloatVector.SPECIES_128, secondScale),
+            accumulator)
         .intoArray(laneScratch, laneOffset);
-    fma(
-            (FloatVector)
-                secondHighGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-            secondScaleVector,
-            highAccumulator)
-        .intoArray(laneScratch, laneOffset + 4);
   }
 
   /** Fixed split-half hsum tree; Vector.reduceLanes does not guarantee an evaluation order. */
@@ -1528,8 +1508,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] q8Scales,
       int[] zeroPointCorrections) {
     ShortVector pairFactors = ShortVector.fromArray(ShortVector.SPECIES_128, Q4_PAIR_FACTORS, 0);
-    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
-    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_128);
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
       float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
@@ -1553,25 +1532,16 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               IntVector.fromArray(
                   IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
               pairFactors);
-      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
-      lowAccumulator =
-          fma(
-              (FloatVector) lowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              lowAccumulator);
-      highAccumulator =
+      IntVector combinedGroups = lowGroups.add(highGroups);
+      accumulator =
           fma(
               (FloatVector)
-                  highGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              scaleVector,
-              highAccumulator);
+                  combinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              FloatVector.broadcast(FloatVector.SPECIES_128, scale),
+              accumulator);
     }
-    float even =
-        (highAccumulator.lane(0) + lowAccumulator.lane(0))
-            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
-    float odd =
-        (highAccumulator.lane(1) + lowAccumulator.lane(1))
-            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
+    float even = accumulator.lane(0) + accumulator.lane(2);
+    float odd = accumulator.lane(1) + accumulator.lane(3);
     return even + odd;
   }
 

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -1508,7 +1508,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] q8Scales,
       int[] zeroPointCorrections) {
     ShortVector pairFactors = ShortVector.fromArray(ShortVector.SPECIES_128, Q4_PAIR_FACTORS, 0);
-    FloatVector accumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector lowAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
+    FloatVector highAccumulator = FloatVector.zero(FloatVector.SPECIES_128);
     for (int block = 0; block < blocks; block++) {
       long blockOffset = rowOffset + (long) block * GGUF_Q4_0_BLOCK_BYTES;
       float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset)) * q8Scales[block];
@@ -1532,16 +1533,25 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
               IntVector.fromArray(
                   IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
               pairFactors);
-      IntVector combinedGroups = lowGroups.add(highGroups);
-      accumulator =
+      FloatVector scaleVector = FloatVector.broadcast(FloatVector.SPECIES_128, scale);
+      lowAccumulator =
+          fma(
+              (FloatVector) lowGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              lowAccumulator);
+      highAccumulator =
           fma(
               (FloatVector)
-                  combinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
-              FloatVector.broadcast(FloatVector.SPECIES_128, scale),
-              accumulator);
+                  highGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+              scaleVector,
+              highAccumulator);
     }
-    float even = accumulator.lane(0) + accumulator.lane(2);
-    float odd = accumulator.lane(1) + accumulator.lane(3);
+    float even =
+        (highAccumulator.lane(0) + lowAccumulator.lane(0))
+            + (highAccumulator.lane(2) + lowAccumulator.lane(2));
+    float odd =
+        (highAccumulator.lane(1) + lowAccumulator.lane(1))
+            + (highAccumulator.lane(3) + lowAccumulator.lane(3));
     return even + odd;
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -693,6 +693,7 @@ class GgufQuantizedDotTest {
         repeat(q4Block(0.125f, ones(cols), (lo, hi) -> (lo * 5 + hi * 3) & 0xFF), cols / 32);
     byte[] row1 = repeat(q4Block(-0.25f, ones(cols), (lo, hi) -> (lo * 7 + hi) & 0xFF), cols / 32);
     float[] expected = new float[batchSize * rows];
+    float[] unsignedExpected = new float[batchSize * rows];
     float[] actual = new float[batchSize * rows];
     float[] unsignedActual = new float[batchSize * rows];
     byte[] q8Quants = new byte[batchSize * cols];
@@ -714,6 +715,17 @@ class GgufQuantizedDotTest {
             new float[cols / 32],
             q4Corrections(cols));
         System.arraycopy(result, 0, expected, batch * rows, rows);
+        VectorUtil.ggufQ4_0Q8_0BatchDotProduct(
+            query,
+            segment,
+            rows,
+            cols,
+            result,
+            new byte[cols],
+            new float[cols / 32],
+            q4Corrections(cols),
+            GgufQ4Kernel.UNSIGNED_PAIRWISE);
+        System.arraycopy(result, 0, unsignedExpected, batch * rows, rows);
       }
 
       VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
@@ -740,7 +752,7 @@ class GgufQuantizedDotTest {
           GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
       assertThat(actual).containsExactly(expected);
-      assertThat(unsignedActual).containsExactly(expected);
+      assertThat(unsignedActual).containsExactly(unsignedExpected);
       assertThat(q8Quants[0]).isNotZero();
     }
   }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -679,7 +679,7 @@ class GgufQuantizedDotTest {
   }
 
   @Test
-  void q4_0Q8_0BatchedMatmulMatchesIndependentQueries() {
+  void q4_0Q8_0BatchedMatmulMatchesIndependentQueriesNumerically() {
     int batchSize = 3;
     int rows = 2;
     int cols = 1024;
@@ -752,7 +752,9 @@ class GgufQuantizedDotTest {
           GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
       assertThat(actual).containsExactly(expected);
-      assertThat(unsignedActual).containsExactly(unsignedExpected);
+      for (int index = 0; index < unsignedActual.length; index++) {
+        assertThat(unsignedActual[index]).isCloseTo(unsignedExpected[index], within(0.01f));
+      }
       assertThat(q8Quants[0]).isNotZero();
     }
   }

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -188,7 +188,7 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q4_0Q8_0UnsignedPairwiseRowMatchesShortPairwiseExactly() {
+  void q4_0Q8_0UnsignedPairwiseRowCombinesIntegerHalvesBeforeScaling() {
     int blocks = 64;
     byte[] weightBytes = new byte[blocks * 18];
     byte[] q8 = new byte[blocks * 32];
@@ -217,25 +217,33 @@ class PanamaGgufQuantizedDotTest {
       }
 
       MemorySegment weights = MemorySegment.ofArray(weightBytes);
-      FloatVector expectedLanes = FloatVector.zero(FloatVector.SPECIES_256);
+      FloatVector expectedLanes = FloatVector.zero(FloatVector.SPECIES_128);
       for (int block = 0; block < blocks; block++) {
         long blockOffset = (long) block * 18;
         float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
-        IntVector groups =
+        int[] groups =
             PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
-                weights, blockOffset + Short.BYTES, q8, block * 32);
+                    weights, blockOffset + Short.BYTES, q8, block * 32)
+                .toArray();
+        IntVector combinedGroups =
+            IntVector.fromArray(
+                IntVector.SPECIES_128,
+                new int[] {
+                  groups[0] + groups[4],
+                  groups[1] + groups[5],
+                  groups[2] + groups[6],
+                  groups[3] + groups[7]
+                },
+                0);
         expectedLanes =
             PanamaVectorUtilSupport.fma(
-                (FloatVector) groups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0),
-                FloatVector.broadcast(FloatVector.SPECIES_256, scale),
+                (FloatVector)
+                    combinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
+                FloatVector.broadcast(FloatVector.SPECIES_128, scale),
                 expectedLanes);
       }
-      float even =
-          (expectedLanes.lane(4) + expectedLanes.lane(0))
-              + (expectedLanes.lane(6) + expectedLanes.lane(2));
-      float odd =
-          (expectedLanes.lane(5) + expectedLanes.lane(1))
-              + (expectedLanes.lane(7) + expectedLanes.lane(3));
+      float even = expectedLanes.lane(0) + expectedLanes.lane(2);
+      float odd = expectedLanes.lane(1) + expectedLanes.lane(3);
       float expected = even + odd;
 
       float actual =

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -188,7 +188,7 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q4_0Q8_0UnsignedPairwiseRowCombinesIntegerHalvesBeforeScaling() {
+  void q4_0Q8_0UnsignedPairwiseRowPreservesSplitHalfAccumulation() {
     int blocks = 64;
     byte[] weightBytes = new byte[blocks * 18];
     byte[] q8 = new byte[blocks * 32];
@@ -217,13 +217,84 @@ class PanamaGgufQuantizedDotTest {
       }
 
       MemorySegment weights = MemorySegment.ofArray(weightBytes);
-      FloatVector expectedLanes = FloatVector.zero(FloatVector.SPECIES_128);
+      FloatVector expectedLanes = FloatVector.zero(FloatVector.SPECIES_256);
       for (int block = 0; block < blocks; block++) {
         long blockOffset = (long) block * 18;
         float scale = Float.float16ToFloat(weights.get(LE_SHORT, blockOffset)) * q8Scales[block];
+        IntVector groups =
+            PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
+                weights, blockOffset + Short.BYTES, q8, block * 32);
+        expectedLanes =
+            PanamaVectorUtilSupport.fma(
+                (FloatVector) groups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0),
+                FloatVector.broadcast(FloatVector.SPECIES_256, scale),
+                expectedLanes);
+      }
+      float even =
+          (expectedLanes.lane(4) + expectedLanes.lane(0))
+              + (expectedLanes.lane(6) + expectedLanes.lane(2));
+      float odd =
+          (expectedLanes.lane(5) + expectedLanes.lane(1))
+              + (expectedLanes.lane(7) + expectedLanes.lane(3));
+      float expected = even + odd;
+
+      float actual =
+          PanamaVectorUtilSupport.q4_0Q8_0UnsignedPairwiseRowDot(
+              weights, 0, blocks, q8, q8Scales, zeroPointCorrections);
+
+      assertThat(Float.floatToRawIntBits(actual)).isEqualTo(Float.floatToRawIntBits(expected));
+    }
+  }
+
+  @Test
+  void q4_0Q8_0UnsignedPairwiseBatchedMatmulCombinesIntegerHalvesBeforeScaling() {
+    int blocks = 65;
+    int cols = blocks * 32;
+    int batchSize = 2;
+    byte[] weightBytes = new byte[blocks * 18];
+    float[] queries = new float[batchSize * cols];
+    Random random = new Random(0x424154434845444cL);
+    for (int block = 0; block < blocks; block++) {
+      int weightOffset = block * 18;
+      short scale = Float.floatToFloat16(0.001f + random.nextFloat() * 0.05f);
+      weightBytes[weightOffset] = (byte) scale;
+      weightBytes[weightOffset + 1] = (byte) (scale >>> 8);
+      for (int index = 0; index < 16; index++) {
+        weightBytes[weightOffset + Short.BYTES + index] = (byte) random.nextInt();
+      }
+    }
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    MemorySegment weights = MemorySegment.ofArray(weightBytes);
+    float[] actual = new float[batchSize];
+    byte[] q8 = new byte[batchSize * cols];
+    float[] q8Scales = new float[batchSize * blocks];
+    int[] zeroPointCorrections = new int[batchSize * blocks * 8];
+    VectorUtil.ggufQ4_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        1,
+        cols,
+        actual,
+        q8,
+        q8Scales,
+        zeroPointCorrections,
+        new float[batchSize * 8],
+        GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      FloatVector expectedLanes = FloatVector.zero(FloatVector.SPECIES_128);
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = (long) block * 18;
+        float scale =
+            Float.float16ToFloat(weights.get(LE_SHORT, blockOffset))
+                * q8Scales[batch * blocks + block];
         int[] groups =
             PanamaVectorUtilSupport.q4_0Q8_0ShortPairwiseIntegerLanes(
-                    weights, blockOffset + Short.BYTES, q8, block * 32)
+                    weights, blockOffset + Short.BYTES, q8, batch * cols + block * 32)
                 .toArray();
         IntVector combinedGroups =
             IntVector.fromArray(
@@ -242,15 +313,11 @@ class PanamaGgufQuantizedDotTest {
                 FloatVector.broadcast(FloatVector.SPECIES_128, scale),
                 expectedLanes);
       }
-      float even = expectedLanes.lane(0) + expectedLanes.lane(2);
-      float odd = expectedLanes.lane(1) + expectedLanes.lane(3);
-      float expected = even + odd;
-
-      float actual =
-          PanamaVectorUtilSupport.q4_0Q8_0UnsignedPairwiseRowDot(
-              weights, 0, blocks, q8, q8Scales, zeroPointCorrections);
-
-      assertThat(Float.floatToRawIntBits(actual)).isEqualTo(Float.floatToRawIntBits(expected));
+      float expected =
+          (expectedLanes.lane(2) + expectedLanes.lane(0))
+              + (expectedLanes.lane(3) + expectedLanes.lane(1));
+      assertThat(Float.floatToRawIntBits(actual[batch]))
+          .isEqualTo(Float.floatToRawIntBits(expected));
     }
   }
 
@@ -535,7 +602,7 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
-  void q4_0UnsignedBlockPairsMatchGemvExactlyForOddAndEvenBlockCounts() {
+  void q4_0UnsignedBlockPairsStayNumericallyCloseToGemvForOddAndEvenBlockCounts() {
     int batchSize = 3;
     int rows = 5;
     Random random = new Random(0x5144_424c_4f43_4b53L);
@@ -588,7 +655,9 @@ class PanamaGgufQuantizedDotTest {
           new float[batchSize * rows * 8],
           GgufQ4Kernel.UNSIGNED_PAIRWISE);
 
-      assertThat(actual).containsExactly(expected);
+      for (int index = 0; index < actual.length; index++) {
+        assertThat(actual[index]).isCloseTo(expected[index], offset(1e-5f));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- combine the low- and high-nibble Q4_0 integer groups before one I2F conversion and scale FMA in the unsigned-pairwise batched matmul path
- preserve the existing split-half accumulation bits for independent GEMV/decode
- add exact tests for both arithmetic contracts, odd/even block tails, and JMH coverage for batched versus independent execution

This follows llama.cpp's Q4_0/Q8_0 integer reduction shape without changing the public API or applying the changed floating-point tree to decode.

## Test-first contract

The first broad implementation made the independent-row exactness test fail (`1091293162` expected raw float bits versus `1091293159` actual) and regressed the independent JMH path. The final implementation splits the contracts explicitly:

- `q4_0Q8_0UnsignedPairwiseRowPreservesSplitHalfAccumulation`
- `q4_0Q8_0UnsignedPairwiseBatchedMatmulCombinesIntegerHalvesBeforeScaling`
- randomized odd/even block-count comparison with a numerical tolerance between the intentionally different accumulation trees

## Performance evidence

Controlled GraalVM 25 JMH, two processes per mode, two forks/process, 5x1s warmup and 5x1s measurement:

| Path | Batch | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: | ---: |
| Batched matmul | 8 | 0.315284 ms | 0.297170 ms | -5.75% |
| Batched matmul | 24 | 0.848191 ms | 0.759179 ms | -10.49% |
| Batched matmul | 32 | 1.092134 ms | 0.995066 ms | -8.89% |

The restored independent path moved +1.7% to +2.8% across separate process populations, within the guardrail uncertainty; its production source and arithmetic are unchanged.

Qwen3 0.6B Q4_0 prefill, six counterbalanced process pairs and 30 trials/mode:

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| p50 TTFT | 1018.886 ms | 907.498 ms | -10.93% |
| p50 prefill | 153.377 tok/s | 172.311 tok/s | +12.34% |
| p50 process CPU | 7710 ms | 6810 ms | -11.67% |

The candidate won all six process medians and all 30 paired trials for those metrics. A separate 64-token, 30-trial guardrail measured decode at 58.606 versus 57.868 tok/s (-1.26% aggregate, -0.99% paired-trial median), so no decode gain is claimed.

The candidate is deterministic for a fixed prompt. Against pinned llama.cpp `b10012-c71854292`, complete 64-token sequence parity across five nonce-varied prompts improved from 1/5 to 3/5, consistent with adopting its integer-combination order.

## Verification

- `./gradlew :vectors-core:check :vectors-bench:jmhClasses :vectors-bench:spotlessCheck`
- Models composite gate: `./gradlew :models-backend-purejava:test :models-bench:test`
- full real-model prefill/decode A/B on the controlled eight-vCPU host with GraalVM 25, fixed 2 GiB heap, and exact launch profile
