### PR TITLE
perf(core): combine batched Q4 corrections

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 public final class GgufQ8_0Batch {
 
   private static final int BLOCK_SIZE = VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
-  private static final int CORRECTIONS_PER_BLOCK = BLOCK_SIZE / 4;
+  private static final int CORRECTIONS_PER_BLOCK = BLOCK_SIZE / 8;
 
   private final int batchCapacity;
   private final int dimensions;
@@ -94,7 +94,7 @@ public final class GgufQ8_0Batch {
       int valueOffset = batch * dimensions + fromBlock * BLOCK_SIZE;
       int scaleOffset = batch * blocks + fromBlock;
       if (corrections) {
-        GgufQuantizationSupport.quantizeQ8_0WithQ4Corrections(
+        GgufQuantizationSupport.quantizeQ8_0WithCombinedQ4Corrections(
             values,
             valueOffset,
             length,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQuantizationSupport.java
@@ -38,7 +38,8 @@ final class GgufQuantizationSupport {
       int quantOffset,
       float[] scales,
       int scaleOffset) {
-    quantizeQ8_0(query, queryOffset, dimensions, quants, quantOffset, scales, scaleOffset, null, 0);
+    quantizeQ8_0(
+        query, queryOffset, dimensions, quants, quantOffset, scales, scaleOffset, null, 0, false);
   }
 
   private static void quantizeQ8_0(
@@ -50,8 +51,10 @@ final class GgufQuantizationSupport {
       float[] scales,
       int scaleOffset,
       int[] zeroPointCorrections,
-      int correctionOffset) {
+      int correctionOffset,
+      boolean combineCorrectionHalves) {
     int blocks = dimensions / VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
+    int correctionsPerBlock = combineCorrectionHalves ? 4 : 8;
     for (int block = 0; block < blocks; block++) {
       int offset = block * VectorUtilSupport.GGUF_Q_BLOCK_SIZE;
       float absoluteMax = 0.0f;
@@ -69,8 +72,15 @@ final class GgufQuantizationSupport {
         if (zeroPointCorrections != null) {
           groupSum += quant;
           if ((index & 3) == 3) {
-            int group = block * 8 + (index >>> 2);
-            zeroPointCorrections[correctionOffset + group] = 8 * groupSum;
+            int group = index >>> 2;
+            int correctionGroup = combineCorrectionHalves ? group & 3 : group;
+            int correctionIndex = correctionOffset + block * correctionsPerBlock + correctionGroup;
+            int correction = 8 * groupSum;
+            if (combineCorrectionHalves && index >= 16) {
+              zeroPointCorrections[correctionIndex] += correction;
+            } else {
+              zeroPointCorrections[correctionIndex] = correction;
+            }
             groupSum = 0;
           }
         }
@@ -103,7 +113,31 @@ final class GgufQuantizationSupport {
         scales,
         scaleOffset,
         zeroPointCorrections,
-        correctionOffset);
+        correctionOffset,
+        false);
+  }
+
+  static void quantizeQ8_0WithCombinedQ4Corrections(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] quants,
+      int quantOffset,
+      float[] scales,
+      int scaleOffset,
+      int[] zeroPointCorrections,
+      int correctionOffset) {
+    quantizeQ8_0(
+        query,
+        queryOffset,
+        dimensions,
+        quants,
+        quantOffset,
+        scales,
+        scaleOffset,
+        zeroPointCorrections,
+        correctionOffset,
+        true);
   }
 
   static void quantizeQ8_K(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -168,6 +168,34 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         query, queryOffset, dimensions, q8Quants, quantOffset, q8Scales, scaleOffset);
   }
 
+  private static void quantizeQ8_0ForBatchedQ4(
+      float[] query,
+      int queryOffset,
+      int dimensions,
+      byte[] q8Quants,
+      int quantOffset,
+      float[] q8Scales,
+      int scaleOffset,
+      int[] q8ZeroPointCorrections,
+      int correctionOffset,
+      boolean computeZeroPointCorrections) {
+    if (computeZeroPointCorrections) {
+      GgufQuantizationSupport.quantizeQ8_0WithCombinedQ4Corrections(
+          query,
+          queryOffset,
+          dimensions,
+          q8Quants,
+          quantOffset,
+          q8Scales,
+          scaleOffset,
+          q8ZeroPointCorrections,
+          correctionOffset);
+      return;
+    }
+    GgufQuantizationSupport.quantizeQ8_0(
+        query, queryOffset, dimensions, q8Quants, quantOffset, q8Scales, scaleOffset);
+  }
+
   // --- Float dot product: 4x unrolled FMA (Lucene pattern) ---
 
   @Override
@@ -672,7 +700,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
     for (int batch = 0; batch < batchSize; batch++) {
-      quantizeQ8_0ForQ4(
+      quantizeQ8_0ForBatchedQ4(
           queries,
           batch * cols,
           cols,
@@ -681,7 +709,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           q8Scales,
           batch * blocks,
           q8ZeroPointCorrections,
-          batch * blocks * 8,
+          batch * blocks * 4,
           useUnsignedPairwise);
     }
 
@@ -888,7 +916,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             q8Quants,
             batch * cols + block * GGUF_Q_BLOCK_SIZE,
             q8ZeroPointCorrections,
-            blockIndex * 8,
+            blockIndex * 4,
             firstWeightScale * q8Scales[blockIndex],
             secondWeightScale * q8Scales[blockIndex + 1],
             pairFactors);
@@ -914,7 +942,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             q8Quants,
             batch * cols + block * GGUF_Q_BLOCK_SIZE,
             q8ZeroPointCorrections,
-            blockIndex * 8,
+            blockIndex * 4,
             weightScale * q8Scales[blockIndex]);
       }
     }
@@ -1098,7 +1126,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     boolean useShortPairwise = useQ4ShortPairwise(kernel, blocks);
     boolean useUnsignedPairwise = useQ4UnsignedPairwise(kernel, blocks);
     for (int batch = 0; batch < batchSize; batch++) {
-      quantizeQ8_0ForQ4(
+      quantizeQ8_0ForBatchedQ4(
           queries,
           batch * cols,
           cols,
@@ -1107,7 +1135,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           q8Scales,
           batch * blocks,
           q8ZeroPointCorrections,
-          batch * blocks * 8,
+          batch * blocks * 4,
           useUnsignedPairwise);
     }
 
@@ -1253,19 +1281,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int correctionOffset,
       float scale) {
     ShortVector pairFactors = ShortVector.fromArray(ShortVector.SPECIES_128, Q4_PAIR_FACTORS, 0);
-    IntVector lowGroups =
-        q4_0Q8_0UnsignedPairwiseGroups(
+    IntVector lowProducts =
+        q4_0Q8_0UnsignedPairwiseProducts(
             lowNibbles,
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset),
-            IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset),
             pairFactors);
-    IntVector highGroups =
-        q4_0Q8_0UnsignedPairwiseGroups(
+    IntVector highProducts =
+        q4_0Q8_0UnsignedPairwiseProducts(
             highNibbles,
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16),
-            IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
             pairFactors);
-    IntVector combinedGroups = lowGroups.add(highGroups);
+    IntVector combinedGroups =
+        lowProducts
+            .add(highProducts)
+            .sub(
+                IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset));
     FloatVector accumulator =
         FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset);
     fma(
@@ -1293,19 +1323,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     FloatVector accumulator =
         FloatVector.fromArray(FloatVector.SPECIES_128, laneScratch, laneOffset);
 
-    IntVector firstLowGroups =
-        q4_0Q8_0UnsignedPairwiseGroups(
+    IntVector firstLowProducts =
+        q4_0Q8_0UnsignedPairwiseProducts(
             firstLowNibbles,
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset),
-            IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset),
             pairFactors);
-    IntVector firstHighGroups =
-        q4_0Q8_0UnsignedPairwiseGroups(
+    IntVector firstHighProducts =
+        q4_0Q8_0UnsignedPairwiseProducts(
             firstHighNibbles,
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, quantOffset + 16),
-            IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset + 4),
             pairFactors);
-    IntVector firstCombinedGroups = firstLowGroups.add(firstHighGroups);
+    IntVector firstCombinedGroups =
+        firstLowProducts
+            .add(firstHighProducts)
+            .sub(
+                IntVector.fromArray(IntVector.SPECIES_128, zeroPointCorrections, correctionOffset));
     accumulator =
         fma(
             (FloatVector)
@@ -1314,22 +1346,23 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             accumulator);
 
     int secondQuantOffset = quantOffset + GGUF_Q_BLOCK_SIZE;
-    int secondCorrectionOffset = correctionOffset + 8;
-    IntVector secondLowGroups =
-        q4_0Q8_0UnsignedPairwiseGroups(
+    int secondCorrectionOffset = correctionOffset + 4;
+    IntVector secondLowProducts =
+        q4_0Q8_0UnsignedPairwiseProducts(
             secondLowNibbles,
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, secondQuantOffset),
-            IntVector.fromArray(
-                IntVector.SPECIES_128, zeroPointCorrections, secondCorrectionOffset),
             pairFactors);
-    IntVector secondHighGroups =
-        q4_0Q8_0UnsignedPairwiseGroups(
+    IntVector secondHighProducts =
+        q4_0Q8_0UnsignedPairwiseProducts(
             secondHighNibbles,
             ByteVector.fromArray(ByteVector.SPECIES_128, q8Quants, secondQuantOffset + 16),
-            IntVector.fromArray(
-                IntVector.SPECIES_128, zeroPointCorrections, secondCorrectionOffset + 4),
             pairFactors);
-    IntVector secondCombinedGroups = secondLowGroups.add(secondHighGroups);
+    IntVector secondCombinedGroups =
+        secondLowProducts
+            .add(secondHighProducts)
+            .sub(
+                IntVector.fromArray(
+                    IntVector.SPECIES_128, zeroPointCorrections, secondCorrectionOffset));
     fma(
             (FloatVector)
                 secondCombinedGroups.convertShape(VectorOperators.I2F, FloatVector.SPECIES_128, 0),
@@ -1560,8 +1593,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       ByteVector signedQ8,
       IntVector zeroPointCorrection,
       ShortVector pairFactors) {
+    return q4_0Q8_0UnsignedPairwiseProducts(unsignedNibbles, signedQ8, pairFactors)
+        .sub(zeroPointCorrection);
+  }
+
+  private static IntVector q4_0Q8_0UnsignedPairwiseProducts(
+      ByteVector unsignedNibbles, ByteVector signedQ8, ShortVector pairFactors) {
     ShortVector pairProducts = multiplyAddUnsignedSignedBytes128(unsignedNibbles, signedQ8);
-    return multiplyAddSignedShorts128(pairProducts, pairFactors).sub(zeroPointCorrection);
+    return multiplyAddSignedShorts128(pairProducts, pairFactors);
   }
 
   private static IntVector fourProductLanesFromShortPairs(

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -350,6 +350,39 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0BatchQuantizationCombinesQ4HalfCorrections() {
+    int batchSize = 2;
+    int dimensions = 64;
+    int blocks = dimensions / 32;
+    float[] values = new float[batchSize * dimensions];
+    Random random = new Random(0x434f4d42494e4544L);
+    for (int index = 0; index < values.length; index++) {
+      values[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    GgufQ8_0Batch activation = GgufQ8_0Batch.allocate(batchSize, dimensions);
+    activation.quantizeForQ4(values, batchSize, GgufQ4Kernel.UNSIGNED_PAIRWISE);
+
+    byte[] quants = activation.quants();
+    int[] corrections = activation.zeroPointCorrections();
+    assertThat(corrections).hasSize(batchSize * blocks * 4);
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int block = 0; block < blocks; block++) {
+        int quantOffset = batch * dimensions + block * 32;
+        int correctionOffset = (batch * blocks + block) * 4;
+        for (int group = 0; group < 4; group++) {
+          int groupSum = 0;
+          for (int lane = 0; lane < 4; lane++) {
+            groupSum += quants[quantOffset + group * 4 + lane];
+            groupSum += quants[quantOffset + 16 + group * 4 + lane];
+          }
+          assertThat(corrections[correctionOffset + group]).isEqualTo(8 * groupSum);
+        }
+      }
+    }
+  }
+
+  @Test
   void q4_KQ8_KIntegerDotDecodesBothNibbleHalves() {
     byte[] packed = new byte[32];
     byte[] q8 = new byte[32];


### PR DESCRIPTION
## Summary

- store four combined Q4 zero-point correction lanes per batched Q8_0 block
- preserve the eight-lane split correction contract for independent GEMV and decode
- reduce the batched packed-dot graph to two correction loads and one subtraction per block

## Why

The retained combined-half Q4 prefill kernel exhausted all 16 AVX2 vector registers. Graal spilled
the floating accumulator because each block pair loaded four independent correction vectors even
though the arithmetic immediately combined corresponding low/high halves.

The compact layout removes those redundant live vectors without changing packed multiply/add,
conversion, FMA, or independent decode order.

## Measured Impact

Controlled GraalVM 25 JMH, averaging two counterbalanced processes with two forks each:

| Batch | Baseline | Candidate | Change |
| ---: | ---: | ---: | ---: |
| 8 | 0.304479 ms | 0.263128 ms | -13.58% |
| 24 | 0.767363 ms | 0.668690 ms | -12.86% |
| 32 | 0.997913 ms | 0.853539 ms | -14.47% |

The independent GEMV controls changed by -0.15%, -1.13%, and +0.39%. No process collected.

The six-pair Qwen3 0.6B Q4_0 gate produced 30 trials per mode:

- median TTFT: 899.476 ms to 752.379 ms (-16.35%)
- median prefill: 173.926 to 208.985 tok/s (+20.16%)
- mean trial CPU: 6,750.333 ms to 5,605.333 ms (-16.96%)
- all corresponding input counts, output counts, and output hashes matched

The 30-trial, 64-token guardrail measured decode at 59.247 versus 59.486 tok/s (+0.40%), with exact
corresponding output hashes.

Generated JVMCI code shrank from 5,485 to 5,108 bytes. `VMOVDQU` fell from 13 to 9, `VMOVUPS`
from 11 to 9, and both vector stack spill/reload pairs disappeared.

## Validation

- `./gradlew :vectors-core:spotlessApply :vectors-core:check :vectors-bench:jmhClasses :vectors-bench:spotlessCheck`
- Models composite build: `./gradlew :models-backend-purejava:test :models-bench:test`
- controlled JMH with GC profiling on AMD EPYC Milan / AVX2 / GraalVM 25.0.3
- six counterbalanced full-model prefill pairs and six counterbalanced decode-guardrail pairs
