### PR TITLE
perf(core): add staged Q8 row primitives

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
@@ -61,6 +61,20 @@ public final class GgufQ8_0Batch {
     quantizeBlockRangeForQ4(values, batchSize, 0, blocks, kernel);
   }
 
+  /** Quantizes complete batch rows for a subsequent Q8_0 operation. */
+  public void quantize(float[] values, int batchSize) {
+    quantizeBlockRange(values, batchSize, 0, blocks);
+  }
+
+  /**
+   * Quantizes one non-empty contiguous block range across active batch rows.
+   *
+   * <p>Distinct block ranges may be written concurrently.
+   */
+  public void quantizeBlockRange(float[] values, int batchSize, int fromBlock, int toBlock) {
+    quantizeBlockRange(values, batchSize, fromBlock, toBlock, false);
+  }
+
   /**
    * Quantizes one non-empty contiguous block range across active batch rows.
    *
@@ -68,8 +82,14 @@ public final class GgufQ8_0Batch {
    */
   public void quantizeBlockRangeForQ4(
       float[] values, int batchSize, int fromBlock, int toBlock, GgufQ4Kernel kernel) {
-    Objects.requireNonNull(values, "values");
     Objects.requireNonNull(kernel, "kernel");
+    quantizeBlockRange(
+        values, batchSize, fromBlock, toBlock, kernel == GgufQ4Kernel.UNSIGNED_PAIRWISE);
+  }
+
+  private void quantizeBlockRange(
+      float[] values, int batchSize, int fromBlock, int toBlock, boolean corrections) {
+    Objects.requireNonNull(values, "values");
     checkBatchSize(batchSize);
     if (fromBlock < 0 || fromBlock >= toBlock || toBlock > blocks) {
       throw new IndexOutOfBoundsException(
@@ -89,7 +109,6 @@ public final class GgufQ8_0Batch {
               + " < "
               + requiredValues);
     }
-    boolean corrections = kernel == GgufQ4Kernel.UNSIGNED_PAIRWISE;
     for (int batch = 0; batch < batchSize; batch++) {
       int valueOffset = batch * dimensions + fromBlock * BLOCK_SIZE;
       int scaleOffset = batch * blocks + fromBlock;

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -3776,6 +3776,44 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         });
   }
 
+  /** SIMD Q8_0 row-range multiplication over caller-prequantized activation rows. */
+  @Override
+  public void ggufQ8_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    byte[] q8Quants = activation.quants();
+    float[] q8Scales = activation.scales();
+    long rowBytes = (long) blocks * GGUF_Q8_0_BLOCK_BYTES;
+    for (int row = fromRow; row < toRow; row++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        out[batch * rows + row] = 0.0f;
+      }
+
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+        float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+        long weightOffset = blockOffset + Short.BYTES;
+        int blockActivationOffset = block * GGUF_Q_BLOCK_SIZE;
+        for (int batch = 0; batch < batchSize; batch++) {
+          float scale = weightScale * q8Scales[batch * blocks + block];
+          int integerSum =
+              q8_0Q8_0IntegerDot(
+                  qWeight, weightOffset, q8Quants, batch * cols + blockActivationOffset);
+          int outputIndex = batch * rows + row;
+          out[outputIndex] = MathUtil.fma(scale, integerSum, out[outputIndex]);
+        }
+      }
+    }
+  }
+
   @Override
   public void ggufQ8_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1903,6 +1903,64 @@ public final class VectorUtil {
         queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
   }
 
+  /**
+   * Computes a non-empty Q8_0 output-row range from a caller-prequantized activation batch.
+   *
+   * <p>This low-level operation performs no quantization and no worker publication, allowing a
+   * {@link GgufStagePlan} to compose dependent matrix stages without nested scheduling.
+   */
+  public static void ggufQ8_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    if (fromRow < 0 || fromRow >= toRow || toRow > rows) {
+      throw new IndexOutOfBoundsException(
+          "row range must satisfy 0 <= fromRow < toRow <= rows: "
+              + fromRow
+              + ".."
+              + toRow
+              + " for "
+              + rows);
+    }
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(activation, "activation");
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    if (batchSize > activation.batchCapacity()) {
+      throw new IllegalArgumentException(
+          "batchSize exceeds activation capacity: "
+              + batchSize
+              + " > "
+              + activation.batchCapacity());
+    }
+    if (cols != activation.dimensions()) {
+      throw new IllegalArgumentException(
+          "cols must equal activation dimensions: " + cols + " != " + activation.dimensions());
+    }
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    IMPL.ggufQ8_0Q8_0BatchedMatmulRows(
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+  }
+
   /** Two Q8_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
   public static void ggufQ8_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1814,6 +1814,37 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Q8_0 row-range multiplication over caller-prequantized activation rows. */
+  default void ggufQ8_0Q8_0BatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    long rowBytes = ggufQ8_0RowBytes(cols);
+    byte[] q8Quants = activation.quants();
+    float[] q8Scales = activation.scales();
+    for (int batch = 0; batch < batchSize; batch++) {
+      int quantBatchOffset = batch * cols;
+      int scaleBatchOffset = batch * blocks;
+      for (int row = fromRow; row < toRow; row++) {
+        out[batch * rows + row] =
+            ggufQ8_0Q8_0ScalarRowDot(
+                qWeight,
+                row * rowBytes,
+                blocks,
+                q8Quants,
+                quantBatchOffset,
+                q8Scales,
+                scaleBatchOffset);
+      }
+    }
+  }
+
   /** Two Q8_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
   default void ggufQ8_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1397,6 +1397,65 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0PrequantizedRowRangesComposeToTheExactBatchedResult() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 64;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] firstRow = repeat(q8Block(0.125f, index -> index * 7 - 53), 2);
+    byte[] secondRow = repeat(q8Block(-0.25f, index -> 61 - index * 5), 2);
+    MemorySegment weights =
+        MemorySegment.ofArray(
+            concat(concat(firstRow, secondRow), concat(concat(firstRow, secondRow), firstRow)));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    GgufQ8_0Batch activation = GgufQ8_0Batch.allocate(batchSize, cols);
+
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        expected,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 32)]);
+    activation.quantize(queries, batchSize);
+
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, 2, actual, activation);
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
+        weights, batchSize, rows, cols, 2, rows, actual, activation);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q8_0BlockRangeActivationQuantizationMatchesWholeBatchExactly() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 64;
+    int blocks = cols / 32;
+    float[] queries = patternedQueries(batchSize, cols);
+    byte[] row = repeat(q8Block(0.125f, index -> index * 11 - 47), blocks);
+    MemorySegment weights = MemorySegment.ofArray(repeat(row, rows));
+    GgufQ8_0Batch whole = GgufQ8_0Batch.allocate(batchSize, cols);
+    GgufQ8_0Batch rangeWise = GgufQ8_0Batch.allocate(batchSize, cols);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+
+    whole.quantize(queries, batchSize);
+    rangeWise.quantizeBlockRange(queries, batchSize, 0, 1);
+    rangeWise.quantizeBlockRange(queries, batchSize, 1, blocks);
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, expected, whole);
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, actual, rangeWise);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
   void q8_0Q8_0DualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
     int batchSize = 3;
     int cols = 64;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -733,6 +733,42 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0Q8_0PrequantizedRowRangesMatchScalarReferenceExactly() {
+    int batchSize = 3;
+    int rows = 17;
+    int cols = 96;
+    Random random = new Random(0x5188_524f_5753L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 34];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 34) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    GgufQ8_0Batch activation = GgufQ8_0Batch.allocate(batchSize, cols);
+    activation.quantize(queries, batchSize);
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+
+    new ScalarVectorUtilSupport()
+        .ggufQ8_0Q8_0BatchedMatmulRows(
+            weightSegment, batchSize, rows, cols, 0, rows, expected, activation);
+    PanamaVectorUtilSupport support = new PanamaVectorUtilSupport();
+    support.ggufQ8_0Q8_0BatchedMatmulRows(
+        weightSegment, batchSize, rows, cols, 0, 7, actual, activation);
+    support.ggufQ8_0Q8_0BatchedMatmulRows(
+        weightSegment, batchSize, rows, cols, 7, rows, actual, activation);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
   void q4_KQ8_KKernelMatchesScalarReferenceAcrossRowsAndBlocks() {
     int rows = 512;
     int cols = 2048;


### PR DESCRIPTION
## What changed

- Add reusable generic Q8_0 activation and block-range quantization.
- Add prequantized Q8_0 matrix row-range primitives for scalar and Panama providers.
- Cover whole-versus-range composition and scalar-versus-SIMD exactness.

## Why

Models can retain dependent Q8 transformer stages without repeated activation quantization or nested worker publication.

## Validation

- `./gradlew :vectors-core:spotlessApply :vectors-core:check`
- Models composite `:models-backend-purejava:unitTest`
- SmolLM2 Q8 controlled gate: +19.20% median prefill, -15.94% median TTFT, exact outputs.