### PR TITLE
perf(core): add block-major Q8 activation batches

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
@@ -15,6 +15,7 @@
  */
 package com.integrallis.vectors.bench;
 
+import com.integrallis.vectors.core.GgufQ8ActivationLayout;
 import com.integrallis.vectors.core.GgufQ8_0Batch;
 import com.integrallis.vectors.core.VectorUtil;
 import java.lang.foreign.MemorySegment;
@@ -66,6 +67,7 @@ public class GgufQ8BatchedMatmulBenchmark {
   private byte[] independentQuants;
   private float[] independentScales;
   private GgufQ8_0Batch prequantized;
+  private GgufQ8_0Batch blockMajorPrequantized;
 
   @Setup(Level.Trial)
   public void setUp() {
@@ -90,6 +92,9 @@ public class GgufQ8BatchedMatmulBenchmark {
     independentScales = new float[cols / 32];
     prequantized = GgufQ8_0Batch.allocate(batchSize, cols);
     prequantized.quantize(queries, batchSize);
+    blockMajorPrequantized =
+        GgufQ8_0Batch.allocate(batchSize, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    blockMajorPrequantized.quantize(queries, batchSize);
   }
 
   private static byte[] randomQ8Blocks(Random random, int byteCount) {
@@ -123,6 +128,13 @@ public class GgufQ8BatchedMatmulBenchmark {
   public void prequantizedRows(Blackhole blackhole) {
     VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
         weights, batchSize, rows, cols, 0, rows, batchedOut, prequantized);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void blockMajorPrequantizedRows(Blackhole blackhole) {
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, batchedOut, blockMajorPrequantized);
     blackhole.consume(batchedOut);
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8ActivationLayout.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8ActivationLayout.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+/** Retained in-memory representation of a prepared Q8_0 activation batch. */
+public enum GgufQ8ActivationLayout {
+  /** Retains only the canonical signed-byte quantized values. */
+  PACKED_BYTES,
+
+  /** Also retains quantized bytes in block-major order for sequential matrix-row reuse. */
+  BLOCK_MAJOR_BYTES
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
@@ -26,15 +26,22 @@ public final class GgufQ8_0Batch {
   private final int batchCapacity;
   private final int dimensions;
   private final int blocks;
+  private final GgufQ8ActivationLayout layout;
   private final byte[] quants;
+  private final byte[] blockMajorQuants;
   private final float[] scales;
   private final int[] zeroPointCorrections;
 
-  private GgufQ8_0Batch(int batchCapacity, int dimensions) {
+  private GgufQ8_0Batch(int batchCapacity, int dimensions, GgufQ8ActivationLayout layout) {
     this.batchCapacity = batchCapacity;
     this.dimensions = dimensions;
     this.blocks = dimensions / BLOCK_SIZE;
+    this.layout = layout;
     this.quants = new byte[checkedProduct(batchCapacity, dimensions, "Q8_0 quants")];
+    this.blockMajorQuants =
+        layout == GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES
+            ? new byte[checkedProduct(batchCapacity, dimensions, "block-major Q8_0 quants")]
+            : null;
     this.scales = new float[checkedProduct(batchCapacity, blocks, "Q8_0 scales")];
     this.zeroPointCorrections =
         new int
@@ -46,6 +53,12 @@ public final class GgufQ8_0Batch {
 
   /** Allocates reusable storage for {@code batchCapacity} activation rows. */
   public static GgufQ8_0Batch allocate(int batchCapacity, int dimensions) {
+    return allocate(batchCapacity, dimensions, GgufQ8ActivationLayout.PACKED_BYTES);
+  }
+
+  /** Allocates reusable storage with an explicit retained activation layout. */
+  public static GgufQ8_0Batch allocate(
+      int batchCapacity, int dimensions, GgufQ8ActivationLayout layout) {
     if (batchCapacity < 1) {
       throw new IllegalArgumentException("batchCapacity must be positive: " + batchCapacity);
     }
@@ -53,7 +66,7 @@ public final class GgufQ8_0Batch {
       throw new IllegalArgumentException(
           "dimensions must be a positive multiple of " + BLOCK_SIZE + ": " + dimensions);
     }
-    return new GgufQ8_0Batch(batchCapacity, dimensions);
+    return new GgufQ8_0Batch(batchCapacity, dimensions, Objects.requireNonNull(layout, "layout"));
   }
 
   /** Quantizes complete batch rows for a subsequent Q4_0 operation. */
@@ -127,6 +140,13 @@ public final class GgufQ8_0Batch {
         GgufQuantizationSupport.quantizeQ8_0(
             values, valueOffset, length, quants, valueOffset, scales, scaleOffset);
       }
+      if (blockMajorQuants != null) {
+        for (int block = fromBlock; block < toBlock; block++) {
+          int sourceOffset = batch * dimensions + block * BLOCK_SIZE;
+          int blockMajorOffset = (block * batchCapacity + batch) * BLOCK_SIZE;
+          System.arraycopy(quants, sourceOffset, blockMajorQuants, blockMajorOffset, BLOCK_SIZE);
+        }
+      }
     }
   }
 
@@ -140,8 +160,17 @@ public final class GgufQ8_0Batch {
     return dimensions;
   }
 
+  /** Returns the retained activation layout. */
+  public GgufQ8ActivationLayout layout() {
+    return layout;
+  }
+
   byte[] quants() {
     return quants;
+  }
+
+  byte[] blockMajorQuants() {
+    return blockMajorQuants;
   }
 
   float[] scales() {

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -3826,6 +3826,56 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     }
   }
 
+  /** SIMD Q8_0 row-range multiplication over block-major caller-prequantized activation rows. */
+  @Override
+  public void ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    if (batchSize == 1 || VECTOR_BITSIZE < 256) {
+      ggufQ8_0Q8_0BatchedMatmulRows(
+          qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+      return;
+    }
+
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    byte[] blockMajorQuants = activation.blockMajorQuants();
+    float[] q8Scales = activation.scales();
+    long rowBytes = (long) blocks * GGUF_Q8_0_BLOCK_BYTES;
+    for (int row = fromRow; row < toRow; row++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        out[batch * rows + row] = 0.0f;
+      }
+
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+        float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+        long weightOffset = blockOffset + Short.BYTES;
+        int blockActivationOffset = block * activation.batchCapacity() * GGUF_Q_BLOCK_SIZE;
+        q8_0Q8_0AccumulateBatchedBlock(
+            qWeight,
+            weightOffset,
+            blockMajorQuants,
+            blockActivationOffset,
+            GGUF_Q_BLOCK_SIZE,
+            batchSize,
+            weightScale,
+            q8Scales,
+            block,
+            blocks,
+            out,
+            row,
+            rows);
+      }
+    }
+  }
+
   @Override
   public void ggufQ8_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1961,6 +1961,68 @@ public final class VectorUtil {
         qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
   }
 
+  /**
+   * Computes a non-empty Q8_0 output-row range from block-major caller-prequantized activations.
+   *
+   * <p>This opt-in operation reads each block's activation rows sequentially while traversing the
+   * matrix. The activation must use {@link GgufQ8ActivationLayout#BLOCK_MAJOR_BYTES}.
+   */
+  public static void ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+    }
+    if (rows < 1) {
+      throw new IllegalArgumentException("rows must be >= 1: " + rows);
+    }
+    if (fromRow < 0 || fromRow >= toRow || toRow > rows) {
+      throw new IndexOutOfBoundsException(
+          "row range must satisfy 0 <= fromRow < toRow <= rows: "
+              + fromRow
+              + ".."
+              + toRow
+              + " for "
+              + rows);
+    }
+    Objects.requireNonNull(out, "out");
+    Objects.requireNonNull(activation, "activation");
+    if (activation.layout() != GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES) {
+      throw new IllegalArgumentException(
+          "activation layout must be BLOCK_MAJOR_BYTES: " + activation.layout());
+    }
+    checkGgufQuantizedMatrixArguments(
+        qWeight,
+        rows,
+        cols,
+        VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+        VectorUtilSupport.GGUF_Q8_0_BLOCK_BYTES);
+    if (batchSize > activation.batchCapacity()) {
+      throw new IllegalArgumentException(
+          "batchSize exceeds activation capacity: "
+              + batchSize
+              + " > "
+              + activation.batchCapacity());
+    }
+    if (cols != activation.dimensions()) {
+      throw new IllegalArgumentException(
+          "cols must equal activation dimensions: " + cols + " != " + activation.dimensions());
+    }
+    int outputEntries = checkedProduct(batchSize, rows, "batchSize * rows");
+    if (out.length < outputEntries) {
+      throw new IllegalArgumentException(
+          "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
+    }
+    IMPL.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+  }
+
   /** Two Q8_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */
   public static void ggufQ8_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1845,6 +1845,19 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Q8_0 row-range multiplication over block-major caller-prequantized activation rows. */
+  default void ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    ggufQ8_0Q8_0BatchedMatmulRows(qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+  }
+
   /** Two Q8_0 projections over an activation batch sharing Q8_0 quantization and row dispatch. */
   default void ggufQ8_0Q8_0DualBatchedMatmul(
       float[] queries,

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1456,6 +1456,74 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void blockMajorQ8_0ActivationLayoutMatchesPackedWholeAndSplitQuantizationExactly() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 96;
+    int blocks = cols / 32;
+    float[] queries = patternedQueries(batchSize, cols);
+    GgufQ8_0Batch packed = GgufQ8_0Batch.allocate(batchSize, cols);
+    GgufQ8_0Batch whole =
+        GgufQ8_0Batch.allocate(batchSize, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    GgufQ8_0Batch rangeWise =
+        GgufQ8_0Batch.allocate(batchSize, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+
+    packed.quantize(queries, batchSize);
+    whole.quantize(queries, batchSize);
+    rangeWise.quantizeBlockRange(queries, batchSize, 0, 1);
+    rangeWise.quantizeBlockRange(queries, batchSize, 1, blocks);
+
+    assertThat(packed.layout()).isEqualTo(GgufQ8ActivationLayout.PACKED_BYTES);
+    assertThat(packed.blockMajorQuants()).isNull();
+    assertThat(whole.layout()).isEqualTo(GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    assertThat(whole.quants()).containsExactly(packed.quants());
+    assertThat(whole.scales()).containsExactly(packed.scales());
+    assertThat(rangeWise.blockMajorQuants()).containsExactly(whole.blockMajorQuants());
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int block = 0; block < blocks; block++) {
+        for (int lane = 0; lane < 32; lane++) {
+          int packedIndex = batch * cols + block * 32 + lane;
+          int blockMajorIndex = (block * whole.batchCapacity() + batch) * 32 + lane;
+          assertThat(whole.blockMajorQuants()[blockMajorIndex])
+              .isEqualTo(whole.quants()[packedIndex]);
+        }
+      }
+    }
+
+    byte[] row = repeat(q8Block(0.125f, index -> index * 9 - 128), blocks);
+    MemorySegment weights = MemorySegment.ofArray(repeat(row, rows));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, expected, packed);
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, 2, actual, rangeWise);
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights, batchSize, rows, cols, 2, rows, actual, rangeWise);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void blockMajorQ8_0RowsRequireExplicitBlockMajorActivationStorage() {
+    GgufQ8_0Batch packed = GgufQ8_0Batch.allocate(2, 32);
+
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+                    MemorySegment.ofArray(q8Block(0.125f, index -> index - 16)),
+                    2,
+                    1,
+                    32,
+                    0,
+                    1,
+                    new float[2],
+                    packed))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("BLOCK_MAJOR_BYTES");
+  }
+
+  @Test
   void q8_0Q8_0DualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
     int batchSize = 3;
     int cols = 64;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -525,7 +525,7 @@ class PanamaGgufQuantizedDotTest {
   void panamaProviderOwnsQ8_0Q8_0BatchedKernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
-        .contains("ggufQ8_0Q8_0BatchedMatmul");
+        .contains("ggufQ8_0Q8_0BatchedMatmul", "ggufQ8_0Q8_0BlockMajorBatchedMatmulRows");
   }
 
   @Test
@@ -763,6 +763,43 @@ class PanamaGgufQuantizedDotTest {
     support.ggufQ8_0Q8_0BatchedMatmulRows(
         weightSegment, batchSize, rows, cols, 0, 7, actual, activation);
     support.ggufQ8_0Q8_0BatchedMatmulRows(
+        weightSegment, batchSize, rows, cols, 7, rows, actual, activation);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q8_0Q8_0BlockMajorPrequantizedRowRangesMatchScalarReferenceExactly() {
+    int batchSize = 3;
+    int rows = 17;
+    int cols = 96;
+    Random random = new Random(0x5749_4445_4e45_44L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 34];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 34) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    GgufQ8_0Batch activation =
+        GgufQ8_0Batch.allocate(batchSize, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    activation.quantize(queries, batchSize);
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+
+    new ScalarVectorUtilSupport()
+        .ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+            weightSegment, batchSize, rows, cols, 0, rows, expected, activation);
+    PanamaVectorUtilSupport support = new PanamaVectorUtilSupport();
+    support.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weightSegment, batchSize, rows, cols, 0, 7, actual, activation);
+    support.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
         weightSegment, batchSize, rows, cols, 7, rows, actual, activation);
 
     assertThat(actual).containsExactly(expected);


### PR DESCRIPTION
## What changed
- add an explicit block-major byte layout for prepared Q8_0 activation batches while retaining canonical packed bytes
- add an opt-in prequantized Q8_0 row-range primitive that reuses the existing exact batched accumulator
- cover whole/split quantization, layout validation, provider ownership, scalar/Panama equivalence, and JMH batch sweeps

## Why
The staged Q8_0 kernel repeatedly crosses a cache-locality boundary above roughly 16 prompt rows. Keeping bytes compact while traversing one activation block across all rows improves batch-32 locality without changing packed defaults or batch-one behavior.

## Evidence
- local AVX2 batch-32 JMH: 20.365 ms -> 18.030 ms (-11.5%)
- controlled EPYC/GraalVM batch-32 JMH: 21.318 ms -> 20.347 ms (-4.6%)
- downstream SmolLM2 full-model p50 TTFT: 939.347 ms -> 925.622 ms (-1.46%); all corresponding outputs matched

## Validation
- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`