### PR TITLE
perf(core): quantize Q8 activation batch ranges

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8_0Batch.java
@@ -80,6 +80,15 @@ public final class GgufQ8_0Batch {
   }
 
   /**
+   * Quantizes one non-empty contiguous range of active batch rows for Q8_0 consumers.
+   *
+   * <p>Distinct batch ranges may be written concurrently.
+   */
+  public void quantizeBatchRange(float[] values, int batchSize, int fromBatch, int toBatch) {
+    quantizeRange(values, batchSize, fromBatch, toBatch, 0, blocks, false);
+  }
+
+  /**
    * Quantizes one non-empty contiguous block range across active batch rows.
    *
    * <p>Distinct block ranges may be written concurrently.
@@ -102,8 +111,28 @@ public final class GgufQ8_0Batch {
 
   private void quantizeBlockRange(
       float[] values, int batchSize, int fromBlock, int toBlock, boolean corrections) {
+    quantizeRange(values, batchSize, 0, batchSize, fromBlock, toBlock, corrections);
+  }
+
+  private void quantizeRange(
+      float[] values,
+      int batchSize,
+      int fromBatch,
+      int toBatch,
+      int fromBlock,
+      int toBlock,
+      boolean corrections) {
     Objects.requireNonNull(values, "values");
     checkBatchSize(batchSize);
+    if (fromBatch < 0 || fromBatch >= toBatch || toBatch > batchSize) {
+      throw new IndexOutOfBoundsException(
+          "batch range must satisfy 0 <= fromBatch < toBatch <= batchSize: "
+              + fromBatch
+              + ".."
+              + toBatch
+              + " for "
+              + batchSize);
+    }
     if (fromBlock < 0 || fromBlock >= toBlock || toBlock > blocks) {
       throw new IndexOutOfBoundsException(
           "block range must satisfy 0 <= fromBlock < toBlock <= blocks: "
@@ -122,7 +151,7 @@ public final class GgufQ8_0Batch {
               + " < "
               + requiredValues);
     }
-    for (int batch = 0; batch < batchSize; batch++) {
+    for (int batch = fromBatch; batch < toBatch; batch++) {
       int valueOffset = batch * dimensions + fromBlock * BLOCK_SIZE;
       int scaleOffset = batch * blocks + fromBlock;
       if (corrections) {

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.IntUnaryOperator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -877,6 +878,9 @@ class GgufQuantizedDotTest {
                     new float[32], 1, 1, 2, GgufQ4Kernel.UNSIGNED_PAIRWISE))
         .isInstanceOf(IndexOutOfBoundsException.class)
         .hasMessageContaining("block range");
+    assertThatThrownBy(() -> activation.quantizeBatchRange(new float[32], 1, 1, 1))
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessageContaining("batch range");
   }
 
   @Test
@@ -1500,6 +1504,42 @@ class GgufQuantizedDotTest {
         weights, batchSize, rows, cols, 0, 2, actual, rangeWise);
     VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
         weights, batchSize, rows, cols, 2, rows, actual, rangeWise);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void blockMajorQ8_0BatchRangeQuantizationMatchesWholeBatchExactlyWhenConcurrent() {
+    int batchSize = 5;
+    int rows = 7;
+    int cols = 96;
+    int blocks = cols / 32;
+    float[] queries = patternedQueries(batchSize, cols);
+    GgufQ8_0Batch whole =
+        GgufQ8_0Batch.allocate(batchSize + 2, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    GgufQ8_0Batch rangeWise =
+        GgufQ8_0Batch.allocate(batchSize + 2, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+
+    whole.quantize(queries, batchSize);
+    CompletableFuture.allOf(
+            CompletableFuture.runAsync(
+                () -> rangeWise.quantizeBatchRange(queries, batchSize, 0, 2)),
+            CompletableFuture.runAsync(
+                () -> rangeWise.quantizeBatchRange(queries, batchSize, 2, batchSize)))
+        .join();
+
+    assertThat(rangeWise.quants()).containsExactly(whole.quants());
+    assertThat(rangeWise.scales()).containsExactly(whole.scales());
+    assertThat(rangeWise.blockMajorQuants()).containsExactly(whole.blockMajorQuants());
+
+    byte[] row = repeat(q8Block(0.125f, index -> index * 13 - 117), blocks);
+    MemorySegment weights = MemorySegment.ofArray(repeat(row, rows));
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, expected, whole);
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, actual, rangeWise);
 
     assertThat(actual).containsExactly(expected);
   }


### PR DESCRIPTION
## Summary

- add explicit disjoint batch-range quantization to `GgufQ8_0Batch`
- preserve canonical scales, packed bytes, block-major bytes, and downstream Q8 output
- cover concurrent non-overlapping row ranges with active batches smaller than capacity

## Why

The staged Q8 transformer path leaves seven GGUF participants waiting while one participant prepares every FFN input row. This architecture-neutral primitive lets Models partition Q8 activation preparation by row while retaining transformer topology and scheduling policy in Models.

## Validation

- `./gradlew :vectors-core:check`
- exact concurrent whole-batch versus disjoint-range quantization test
- downstream SmolLM2 360M Q8_0 gate on GraalVM Java 25: p50 TTFT `913.102 -> 899.064 ms` (-1.54%), p95 TTFT -1.77%, p50 prefill +1.77%, six of six process-pair medians improved, and all 30 corresponding outputs matched exactly
