### PR TITLE
perf(core): add row-accumulated Q8 kernel

### DIFF
--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -33,6 +33,25 @@ outputs. A direct dual-only versus dual-plus-triple Q/K/V gate produced only a 0
 three faster and three slower pairs, and 6.68 MB higher median RSS. Models therefore keeps Q8_0
 Q/K/V independent. The exact generic triple API remains available for other model-specific gates.
 
+## Q8_0 block-major row accumulation gate
+
+The original block-major Q8_0 row kernel updated `out[batch * rows + row]` after every weight
+block. At batch 32 those outputs are widely spaced, so a 1024x2048 projection performed 64
+scattered read/modify/write cycles per output. The explicit `ROW_ACCUMULATED` kernel instead reuses
+one contiguous batch-sized scratch array for the row range and scatters each completed output once.
+Arithmetic order and output bits are unchanged.
+
+On GraalVM Java 25 and the controlled eight-vCPU AMD EPYC-Milan host, three warmups and five
+measurements reduced the batch-32 block-major JMH path from 20.571 to 4.335 ms/op (-78.9%). The
+same local Java 25 HotSpot/C2 comparison was neutral at 17.713 versus 17.480 ms/op, so Vectors keeps
+`SCATTERED` as the compatibility default and exposes the optimized strategy explicitly for measured
+model/runtime plans. A six-pair SmolLM2 360M Q8_0 gate in Models reduced p50 TTFT by 2.22%, p95
+TTFT by 3.67%, and median process CPU by 2.34%; all 30 corresponding outputs were exact.
+
+A separate llama.cpp-style signed-byte pairwise probe lowered one 32-byte dot from 2.566 to 2.291
+ns/op on Graal and helped batches 1 through 8, but the repeated batch-32 gate regressed from 20.648
+to 20.758 ms/op. That candidate remains unselected pending a decode-specific gate.
+
 ## Q5_0 batched prefill gate
 
 The Q5_0/Q8_0 batch-major kernel closes the last missing batched prefill format used by the tested

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
@@ -16,6 +16,7 @@
 package com.integrallis.vectors.bench;
 
 import com.integrallis.vectors.core.GgufQ8ActivationLayout;
+import com.integrallis.vectors.core.GgufQ8BlockMajorKernel;
 import com.integrallis.vectors.core.GgufQ8_0Batch;
 import com.integrallis.vectors.core.VectorUtil;
 import java.lang.foreign.MemorySegment;
@@ -135,6 +136,21 @@ public class GgufQ8BatchedMatmulBenchmark {
   public void blockMajorPrequantizedRows(Blackhole blackhole) {
     VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
         weights, batchSize, rows, cols, 0, rows, batchedOut, blockMajorPrequantized);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void blockMajorRowAccumulatedPrequantizedRows(Blackhole blackhole) {
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        batchedOut,
+        blockMajorPrequantized,
+        GgufQ8BlockMajorKernel.ROW_ACCUMULATED);
     blackhole.consume(batchedOut);
   }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8BlockMajorKernel.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8BlockMajorKernel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+/** Output accumulation strategy for block-major GGUF Q8_0 batch kernels. */
+public enum GgufQ8BlockMajorKernel {
+  /** Updates the caller's batch-major output after every weight block. */
+  SCATTERED,
+
+  /** Accumulates one output row contiguously and scatters it once after all weight blocks. */
+  ROW_ACCUMULATED
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -3836,9 +3836,16 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int fromRow,
       int toRow,
       float[] out,
-      GgufQ8_0Batch activation) {
+      GgufQ8_0Batch activation,
+      GgufQ8BlockMajorKernel kernel) {
+    Objects.requireNonNull(kernel, "kernel");
     if (batchSize == 1 || VECTOR_BITSIZE < 256) {
       ggufQ8_0Q8_0BatchedMatmulRows(
+          qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+      return;
+    }
+    if (kernel == GgufQ8BlockMajorKernel.ROW_ACCUMULATED) {
+      ggufQ8_0Q8_0BlockMajorBatchedMatmulRowsWithRowAccumulator(
           qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
       return;
     }
@@ -3872,6 +3879,53 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             out,
             row,
             rows);
+      }
+    }
+  }
+
+  private static void ggufQ8_0Q8_0BlockMajorBatchedMatmulRowsWithRowAccumulator(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    byte[] blockMajorQuants = activation.blockMajorQuants();
+    float[] q8Scales = activation.scales();
+    long rowBytes = (long) blocks * GGUF_Q8_0_BLOCK_BYTES;
+    float[] rowAccumulator = new float[batchSize];
+    for (int row = fromRow; row < toRow; row++) {
+      for (int batch = 0; batch < batchSize; batch++) {
+        rowAccumulator[batch] = 0.0f;
+      }
+
+      long rowOffset = row * rowBytes;
+      for (int block = 0; block < blocks; block++) {
+        long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+        float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+        long weightOffset = blockOffset + Short.BYTES;
+        int blockActivationOffset = block * activation.batchCapacity() * GGUF_Q_BLOCK_SIZE;
+        q8_0Q8_0AccumulateBatchedBlock(
+            qWeight,
+            weightOffset,
+            blockMajorQuants,
+            blockActivationOffset,
+            GGUF_Q_BLOCK_SIZE,
+            batchSize,
+            weightScale,
+            q8Scales,
+            block,
+            blocks,
+            rowAccumulator,
+            0,
+            1);
+      }
+
+      for (int batch = 0; batch < batchSize; batch++) {
+        out[batch * rows + row] = rowAccumulator[batch];
       }
     }
   }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1976,6 +1976,31 @@ public final class VectorUtil {
       int toRow,
       float[] out,
       GgufQ8_0Batch activation) {
+    ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        fromRow,
+        toRow,
+        out,
+        activation,
+        GgufQ8BlockMajorKernel.SCATTERED);
+  }
+
+  /**
+   * Computes a non-empty Q8_0 output-row range with an explicit block-major accumulation kernel.
+   */
+  public static void ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      GgufQ8BlockMajorKernel kernel) {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
     }
@@ -1993,6 +2018,7 @@ public final class VectorUtil {
     }
     Objects.requireNonNull(out, "out");
     Objects.requireNonNull(activation, "activation");
+    Objects.requireNonNull(kernel, "kernel");
     if (activation.layout() != GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES) {
       throw new IllegalArgumentException(
           "activation layout must be BLOCK_MAJOR_BYTES: " + activation.layout());
@@ -2020,7 +2046,7 @@ public final class VectorUtil {
           "out.length must be >= batchSize * rows: " + out.length + " < " + outputEntries);
     }
     IMPL.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
-        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+        qWeight, batchSize, rows, cols, fromRow, toRow, out, activation, kernel);
   }
 
   /** Two Q8_0 matrices over an activation batch with one Q8_0 quantization and row dispatch. */

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -18,6 +18,7 @@ package com.integrallis.vectors.core;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 /**
  * Interface for all SIMD-accelerable vector operations. Implementations are selected at runtime by
@@ -1855,6 +1856,30 @@ public interface VectorUtilSupport {
       int toRow,
       float[] out,
       GgufQ8_0Batch activation) {
+    ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        fromRow,
+        toRow,
+        out,
+        activation,
+        GgufQ8BlockMajorKernel.SCATTERED);
+  }
+
+  /** Q8_0 row-range multiplication with an explicit block-major output accumulation strategy. */
+  default void ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation,
+      GgufQ8BlockMajorKernel kernel) {
+    Objects.requireNonNull(kernel, "kernel");
     ggufQ8_0Q8_0BatchedMatmulRows(qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -1509,6 +1509,51 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void explicitBlockMajorQ8KernelsMatchPackedRowsExactly() {
+    int batchSize = 3;
+    int rows = 5;
+    int cols = 96;
+    int blocks = cols / 32;
+    float[] queries = patternedQueries(batchSize, cols);
+    GgufQ8_0Batch packed = GgufQ8_0Batch.allocate(batchSize, cols);
+    GgufQ8_0Batch blockMajor =
+        GgufQ8_0Batch.allocate(batchSize, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    packed.quantize(queries, batchSize);
+    blockMajor.quantize(queries, batchSize);
+    byte[] row = repeat(q8Block(0.125f, index -> index * 7 - 109), blocks);
+    MemorySegment weights = MemorySegment.ofArray(repeat(row, rows));
+    float[] expected = new float[batchSize * rows];
+    float[] scattered = new float[batchSize * rows];
+    float[] rowAccumulated = new float[batchSize * rows];
+
+    VectorUtil.ggufQ8_0Q8_0BatchedMatmulRows(
+        weights, batchSize, rows, cols, 0, rows, expected, packed);
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        scattered,
+        blockMajor,
+        GgufQ8BlockMajorKernel.SCATTERED);
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        rowAccumulated,
+        blockMajor,
+        GgufQ8BlockMajorKernel.ROW_ACCUMULATED);
+
+    assertThat(scattered).containsExactly(expected);
+    assertThat(rowAccumulated).containsExactly(expected);
+  }
+
+  @Test
   void blockMajorQ8_0BatchRangeQuantizationMatchesWholeBatchExactlyWhenConcurrent() {
     int batchSize = 5;
     int rows = 7;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -806,6 +806,56 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q8_0BlockMajorRowAccumulatorMatchesScalarSplitRangeExactly() {
+    int batchSize = 7;
+    int batchCapacity = 9;
+    int rows = 17;
+    int cols = 96;
+    int fromRow = 3;
+    int toRow = 14;
+    Random random = new Random(0x5188_524f_5741L);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 34];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 34) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    GgufQ8_0Batch activation =
+        GgufQ8_0Batch.allocate(batchCapacity, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    activation.quantize(queries, batchSize);
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    for (int index = 0; index < expected.length; index++) {
+      expected[index] = random.nextFloat() - 0.5f;
+      actual[index] = expected[index];
+    }
+
+    new ScalarVectorUtilSupport()
+        .ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+            weightSegment, batchSize, rows, cols, fromRow, toRow, expected, activation);
+    new PanamaVectorUtilSupport()
+        .ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+            weightSegment,
+            batchSize,
+            rows,
+            cols,
+            fromRow,
+            toRow,
+            actual,
+            activation,
+            GgufQ8BlockMajorKernel.ROW_ACCUMULATED);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
   void q4_KQ8_KKernelMatchesScalarReferenceAcrossRowsAndBlocks() {
     int rows = 512;
     int cols = 2048;


### PR DESCRIPTION
## What

- add an explicit `GgufQ8BlockMajorKernel` strategy for block-major Q8_0 batched matmul
- implement a row-local accumulator that scatters each completed output row once
- preserve the existing scattered kernel as the default
- cover both strategies with exact split-range and sentinel tests
- add an isolated JMH benchmark and record the selection evidence

## Why

The existing block-major Q8_0 kernel writes each output after every quantized weight block. At prefill batch 32, that repeatedly reads and writes widely separated output cells. Retaining the partial sums for one row in a reusable batch-sized accumulator substantially reduces that memory traffic on GraalVM/EPYC Milan.

The strategy remains explicit because local Java 25 HotSpot/C2 measurements were neutral. Models can therefore select it only for validated runtime and model profiles.

## Evidence

- exact scalar/public API tests pass for full and split row ranges
- controlled EPYC Milan, GraalVM Java 25 JMH: `20.571 ms/op` to `4.335 ms/op` (`-78.9%`)
- controlled 30-trial SmolLM2 360M Q8_0 gate:
  - p50 TTFT: `898.794 ms` to `878.801 ms` (`-2.22%`)
  - p50 prefill: `175.219 tok/s` to `179.479 tok/s` (`+2.43%`)
  - p50 CPU time: `6840 ms` to `6680 ms` (`-2.34%`)
  - output token counts and output hashes remained exact in every pair
- local Java 25 HotSpot/C2 JMH was neutral (`17.713 ms/op` to `17.480 ms/op`), so no default behavior changes

## Checks

- `./gradlew :vectors-core:check :vectors-bench:jmhClasses`
