### PR TITLE
perf(core): retain Q8 float lanes across blocks

### DIFF
--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ8BatchedMatmulBenchmark.java
@@ -153,4 +153,19 @@ public class GgufQ8BatchedMatmulBenchmark {
         GgufQ8BlockMajorKernel.ROW_ACCUMULATED);
     blackhole.consume(batchedOut);
   }
+
+  @Benchmark
+  public void blockMajorFloatLaneAccumulatedPrequantizedRows(Blackhole blackhole) {
+    VectorUtil.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weights,
+        batchSize,
+        rows,
+        cols,
+        0,
+        rows,
+        batchedOut,
+        blockMajorPrequantized,
+        GgufQ8BlockMajorKernel.FLOAT_LANE_ACCUMULATED);
+    blackhole.consume(batchedOut);
+  }
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8BlockMajorKernel.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ8BlockMajorKernel.java
@@ -21,5 +21,12 @@ public enum GgufQ8BlockMajorKernel {
   SCATTERED,
 
   /** Accumulates one output row contiguously and scatters it once after all weight blocks. */
-  ROW_ACCUMULATED
+  ROW_ACCUMULATED,
+
+  /**
+   * Retains eight strided floating lanes across weight blocks and reduces once per batch output.
+   * This non-associative order is deterministic but need not be bit-identical to scalar block
+   * accumulation.
+   */
+  FLOAT_LANE_ACCUMULATED
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -46,6 +46,8 @@ import jdk.incubator.vector.VectorSpecies;
 final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   private static final int Q4_SHORT_PAIRWISE_MIN_BLOCKS = 32;
+  private static final ThreadLocal<float[]> Q8_FLOAT_LANE_SCRATCH =
+      ThreadLocal.withInitial(() -> new float[0]);
 
   // Species are capped to PanamaConstants.MAX_BITS (default 256) to avoid AVX-512 frequency
   // downclock; opt into wider with -Dvectors.maxBits=512. The cap only ever narrows below the
@@ -3849,6 +3851,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
       return;
     }
+    if (kernel == GgufQ8BlockMajorKernel.FLOAT_LANE_ACCUMULATED && VECTOR_BITSIZE == 256) {
+      ggufQ8_0Q8_0BlockMajorBatchedMatmulRowsWithFloatLaneAccumulator(
+          qWeight, batchSize, rows, cols, fromRow, toRow, out, activation);
+      return;
+    }
 
     int blocks = cols / GGUF_Q_BLOCK_SIZE;
     byte[] blockMajorQuants = activation.blockMajorQuants();
@@ -3927,6 +3934,125 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       for (int batch = 0; batch < batchSize; batch++) {
         out[batch * rows + row] = rowAccumulator[batch];
       }
+    }
+  }
+
+  private static void ggufQ8_0Q8_0BlockMajorBatchedMatmulRowsWithFloatLaneAccumulator(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      int fromRow,
+      int toRow,
+      float[] out,
+      GgufQ8_0Batch activation) {
+    int blocks = cols / GGUF_Q_BLOCK_SIZE;
+    int laneCount = FloatVector.SPECIES_256.length();
+    float[] laneAccumulator = q8FloatLaneScratch(Math.multiplyExact(batchSize, laneCount));
+    for (int row = fromRow; row < toRow; row++) {
+      ggufQ8_0Q8_0BlockMajorFloatLaneRow(
+          qWeight, batchSize, rows, blocks, row, out, activation, laneAccumulator);
+    }
+  }
+
+  static float[] q8FloatLaneScratch(int minimumLength) {
+    if (minimumLength < 0) {
+      throw new IllegalArgumentException("minimumLength must be non-negative: " + minimumLength);
+    }
+    float[] scratch = Q8_FLOAT_LANE_SCRATCH.get();
+    if (scratch.length < minimumLength) {
+      scratch = new float[minimumLength];
+      Q8_FLOAT_LANE_SCRATCH.set(scratch);
+    }
+    return scratch;
+  }
+
+  private static void ggufQ8_0Q8_0BlockMajorFloatLaneRow(
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int blocks,
+      int row,
+      float[] out,
+      GgufQ8_0Batch activation,
+      float[] laneAccumulator) {
+    byte[] blockMajorQuants = activation.blockMajorQuants();
+    float[] q8Scales = activation.scales();
+    int laneCount = FloatVector.SPECIES_256.length();
+    int activeLanes = batchSize * laneCount;
+    for (int lane = 0; lane < activeLanes; lane++) {
+      laneAccumulator[lane] = 0.0f;
+    }
+
+    long rowOffset = (long) row * blocks * GGUF_Q8_0_BLOCK_BYTES;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q8_0_BLOCK_BYTES;
+      float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      long weightOffset = blockOffset + Short.BYTES;
+      IntVector weight0 =
+          (IntVector)
+              ByteVector.fromMemorySegment(
+                      ByteVector.SPECIES_64, qWeight, weightOffset, ByteOrder.LITTLE_ENDIAN)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector weight1 =
+          (IntVector)
+              ByteVector.fromMemorySegment(
+                      ByteVector.SPECIES_64, qWeight, weightOffset + 8, ByteOrder.LITTLE_ENDIAN)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector weight2 =
+          (IntVector)
+              ByteVector.fromMemorySegment(
+                      ByteVector.SPECIES_64, qWeight, weightOffset + 16, ByteOrder.LITTLE_ENDIAN)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      IntVector weight3 =
+          (IntVector)
+              ByteVector.fromMemorySegment(
+                      ByteVector.SPECIES_64, qWeight, weightOffset + 24, ByteOrder.LITTLE_ENDIAN)
+                  .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+      int blockActivationOffset = block * activation.batchCapacity() * GGUF_Q_BLOCK_SIZE;
+      for (int batch = 0; batch < batchSize; batch++) {
+        int quantOffset = blockActivationOffset + batch * GGUF_Q_BLOCK_SIZE;
+        IntVector quant0 =
+            (IntVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, blockMajorQuants, quantOffset)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        IntVector quant1 =
+            (IntVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, blockMajorQuants, quantOffset + 8)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        IntVector quant2 =
+            (IntVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, blockMajorQuants, quantOffset + 16)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        IntVector quant3 =
+            (IntVector)
+                ByteVector.fromArray(ByteVector.SPECIES_64, blockMajorQuants, quantOffset + 24)
+                    .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+        IntVector integerLanes =
+            weight0
+                .mul(quant0)
+                .add(weight1.mul(quant1))
+                .add(weight2.mul(quant2))
+                .add(weight3.mul(quant3));
+        FloatVector products =
+            (FloatVector)
+                integerLanes.convertShape(VectorOperators.I2F, FloatVector.SPECIES_256, 0);
+        int laneOffset = batch * laneCount;
+        FloatVector accumulator =
+            FloatVector.fromArray(FloatVector.SPECIES_256, laneAccumulator, laneOffset);
+        fma(
+                products,
+                FloatVector.broadcast(
+                    FloatVector.SPECIES_256, weightScale * q8Scales[batch * blocks + block]),
+                accumulator)
+            .intoArray(laneAccumulator, laneOffset);
+      }
+    }
+
+    for (int batch = 0; batch < batchSize; batch++) {
+      out[batch * rows + row] =
+          reduceAdd(
+              FloatVector.fromArray(FloatVector.SPECIES_256, laneAccumulator, batch * laneCount));
     }
   }
 

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
@@ -853,6 +854,107 @@ class PanamaGgufQuantizedDotTest {
             GgufQ8BlockMajorKernel.ROW_ACCUMULATED);
 
     assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q8FloatLaneScratchReusesCapacityPerThread() throws InterruptedException {
+    float[] initial = PanamaVectorUtilSupport.q8FloatLaneScratch(8);
+    assertThat(PanamaVectorUtilSupport.q8FloatLaneScratch(8)).isSameAs(initial);
+
+    float[] grown = PanamaVectorUtilSupport.q8FloatLaneScratch(initial.length + 1);
+    assertThat(grown).hasSize(initial.length + 1).isNotSameAs(initial);
+    assertThat(PanamaVectorUtilSupport.q8FloatLaneScratch(grown.length)).isSameAs(grown);
+
+    AtomicReference<float[]> otherThreadScratch = new AtomicReference<>();
+    Thread thread =
+        new Thread(() -> otherThreadScratch.set(PanamaVectorUtilSupport.q8FloatLaneScratch(32)));
+    thread.start();
+    thread.join();
+
+    assertThat(otherThreadScratch.get()).isNotSameAs(grown);
+  }
+
+  @Test
+  void q8_0BlockMajorFloatLaneAccumulatorIsDeterministicAndBoundedAcrossModelSizedInputs() {
+    int[][] shapes = {{1, 2048}, {2, 32}, {7, 96}, {7, 2048}, {32, 2048}, {7, 8192}};
+    for (int[] shape : shapes) {
+      assertFloatLaneAccumulatorIsDeterministicAndBounded(shape[0], shape[1]);
+    }
+  }
+
+  private static void assertFloatLaneAccumulatorIsDeterministicAndBounded(int batchSize, int cols) {
+    int batchCapacity = batchSize + 2;
+    int rows = 17;
+    int fromRow = 3;
+    int toRow = 14;
+    Random random = new Random(0x5188_4c41_4e45L ^ ((long) batchSize << 32) ^ cols);
+    float[] queries = new float[batchSize * cols];
+    for (int index = 0; index < queries.length; index++) {
+      queries[index] = random.nextFloat() * 4.0f - 2.0f;
+    }
+
+    byte[] weights = new byte[rows * (cols / 32) * 34];
+    random.nextBytes(weights);
+    ByteBuffer buffer = ByteBuffer.wrap(weights).order(ByteOrder.LITTLE_ENDIAN);
+    for (int offset = 0; offset < weights.length; offset += 34) {
+      buffer.putShort(offset, Float.floatToFloat16(random.nextFloat() * 0.05f + 0.001f));
+    }
+
+    GgufQ8_0Batch activation =
+        GgufQ8_0Batch.allocate(batchCapacity, cols, GgufQ8ActivationLayout.BLOCK_MAJOR_BYTES);
+    activation.quantize(queries, batchSize);
+    MemorySegment weightSegment = MemorySegment.ofArray(weights);
+    float[] expected = new float[batchSize * rows];
+    float[] first = new float[batchSize * rows];
+    float[] second = new float[batchSize * rows];
+    for (int index = 0; index < expected.length; index++) {
+      expected[index] = random.nextFloat() - 0.5f;
+      first[index] = expected[index];
+      second[index] = expected[index];
+    }
+
+    new ScalarVectorUtilSupport()
+        .ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+            weightSegment, batchSize, rows, cols, fromRow, toRow, expected, activation);
+    PanamaVectorUtilSupport support = new PanamaVectorUtilSupport();
+    support.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weightSegment,
+        batchSize,
+        rows,
+        cols,
+        fromRow,
+        toRow,
+        first,
+        activation,
+        GgufQ8BlockMajorKernel.FLOAT_LANE_ACCUMULATED);
+    support.ggufQ8_0Q8_0BlockMajorBatchedMatmulRows(
+        weightSegment,
+        batchSize,
+        rows,
+        cols,
+        fromRow,
+        toRow,
+        second,
+        activation,
+        GgufQ8BlockMajorKernel.FLOAT_LANE_ACCUMULATED);
+
+    assertThat(second).containsExactly(first);
+    for (int batch = 0; batch < batchSize; batch++) {
+      for (int row = 0; row < rows; row++) {
+        int index = batch * rows + row;
+        if (row >= fromRow && row < toRow) {
+          float absoluteError = Math.abs(first[index] - expected[index]);
+          float tolerance = Math.max(1.0e-3f, Math.abs(expected[index]) * 2.0e-6f);
+          assertThat(absoluteError)
+              .as(
+                  "batchSize=%s, cols=%s, batch=%s, row=%s, expected=%s, actual=%s",
+                  batchSize, cols, batch, row, expected[index], first[index])
+              .isLessThanOrEqualTo(tolerance);
+        } else {
+          assertThat(first[index]).isEqualTo(expected[index]);
+        }
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add an opt-in Q8_0 block-major kernel that retains eight float lanes across all weight blocks
- reuse per-thread lane scratch instead of allocating for each matrix multiplication
- cover deterministic bounded accuracy, row ranges, model-sized shapes, and scratch isolation
- add the kernel to the controlled JMH benchmark

## Why

The row-accumulated kernel still performed a horizontal reduction for every 32-element block. Keeping the eight strided lanes live until the output is complete removes those repeated reductions on measured 256-bit GraalVM runtimes.

On the controlled EPYC-Milan/GraalVM Java 25 host, the 1,024x2,048 batch-32 benchmark improved from `4.320 +/- 0.012 ms/op` to `2.829 +/- 0.019 ms/op` (-34.5%). Normalized candidate allocation was `19.613 +/- 0.137 B/op` after scratch reuse.

The floating-point order is deterministic but non-associative relative to scalar block accumulation, so this kernel remains an explicit profile-selected strategy.

## Validation

- `./gradlew :vectors-core:check :vectors-bench:check spotlessCheck`
- controlled JMH and generated-assembly inspection on GraalVM Java 25
- controlled SmolLM2 360M Q8_0 full-model gate in the dependent Models branch
