### PR TITLE
feat(core): dequantize GGUF Q5_0 blocks

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -374,6 +374,43 @@ public final class VectorUtil {
     return IMPL.ggufQ5_0DotProduct(query, qWeight, byteOffset, dimensions);
   }
 
+  /** Dequantizes GGUF Q5_0 blocks into a caller-owned float array. */
+  public static void ggufQ5_0Dequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    Objects.requireNonNull(qWeight, "qWeight");
+    Objects.requireNonNull(out, "out");
+    if (byteOffset < 0) {
+      throw new IllegalArgumentException("byteOffset must be >= 0: " + byteOffset);
+    }
+    if (outOffset < 0 || dimensions < 0 || outOffset > out.length - dimensions) {
+      throw new IllegalArgumentException(
+          "out range is invalid: offset="
+              + outOffset
+              + ", dimensions="
+              + dimensions
+              + ", length="
+              + out.length);
+    }
+    if (dimensions % VectorUtilSupport.GGUF_Q_BLOCK_SIZE != 0) {
+      throw new IllegalArgumentException(
+          "GGUF Q5_0 dimensions must be a multiple of 32: " + dimensions);
+    }
+    long required =
+        byteOffset
+            + ggufQuantizedRowBytes(
+                dimensions,
+                VectorUtilSupport.GGUF_Q_BLOCK_SIZE,
+                VectorUtilSupport.GGUF_Q5_0_BLOCK_BYTES);
+    if (required < byteOffset || required > qWeight.byteSize()) {
+      throw new IllegalArgumentException(
+          "qWeight byteSize is too small for requested values: "
+              + qWeight.byteSize()
+              + " < "
+              + required);
+    }
+    IMPL.ggufQ5_0Dequantize(qWeight, byteOffset, out, outOffset, dimensions);
+  }
+
   /**
    * Dot product of a full-precision query with one GGUF Q8_0 quantized row.
    *

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -424,6 +424,27 @@ public interface VectorUtilSupport {
     return sum;
   }
 
+  /** Dequantizes GGUF Q5_0 blocks into a caller-owned float array. */
+  default void ggufQ5_0Dequantize(
+      MemorySegment qWeight, long byteOffset, float[] out, int outOffset, int dimensions) {
+    checkGgufBlockAligned(dimensions);
+    int blocks = dimensions / GGUF_Q_BLOCK_SIZE;
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = byteOffset + (long) block * GGUF_Q5_0_BLOCK_BYTES;
+      float scale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      int highBits = qWeight.get(GGUF_LE_INT, blockOffset + Short.BYTES);
+      long quantsOffset = blockOffset + Short.BYTES + Integer.BYTES;
+      int outputOffset = outOffset + block * GGUF_Q_BLOCK_SIZE;
+      for (int index = 0; index < 16; index++) {
+        int packed = qWeight.get(ValueLayout.JAVA_BYTE, quantsOffset + index) & 0xFF;
+        int low = (packed & 0x0F) | (((highBits >>> index) & 1) << 4);
+        int high = (packed >>> 4) | (((highBits >>> (index + 16)) & 1) << 4);
+        out[outputOffset + index] = (low - 16) * scale;
+        out[outputOffset + index + 16] = (high - 16) * scale;
+      }
+    }
+  }
+
   /**
    * Dot product of a full-precision query with one GGUF Q8_0 quantized row.
    *

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -449,6 +449,26 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_0Dequantize_matchesDecodedReferenceAtOutputOffset() {
+    byte[] block = q5Block(0.25f, index -> (index * 7) % 32 - 16);
+    float[] decoded = new float[34];
+    decoded[0] = 99.0f;
+    decoded[33] = 98.0f;
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment segment = copy(arena, block);
+
+      VectorUtil.ggufQ5_0Dequantize(segment, 0, decoded, 1, 32);
+    }
+
+    assertThat(decoded[0]).isEqualTo(99.0f);
+    assertThat(decoded[33]).isEqualTo(98.0f);
+    for (int index = 0; index < 32; index++) {
+      assertThat(decoded[index + 1]).isEqualTo(0.25f * ((index * 7) % 32 - 16));
+    }
+  }
+
+  @Test
   void q4_0BatchDotProduct_respectsRowOffsets() {
     float[] query = ones(32);
     byte[] row0 = q4Block(1.0f, query, (lo, hi) -> 0x98);


### PR DESCRIPTION
## Summary
- add validated Q5_0 dequantization to the public VectorUtil API
- implement the canonical GGUF high-bit and split-nibble layout
- cover output offsets and exact decoded values

## Verification
- ./gradlew --no-daemon spotlessApply :vectors-core:check

Required by Models for Q5_0 token-embedding tables.