### PR TITLE
chore(release): prepare vectors 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Install native BLAS (Vectors Studio)
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
       - name: Build, test, and stage artifacts
         run: >
           ./gradlew clean spotlessCheck build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to java-vectors are documented here.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-26
+
 ### Added
 
 - `com.integrallis:vectors` — a single umbrella dependency that re-exports `vectors-db` (core,

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ depending on another system.
 
 ```kotlin
 dependencies {
-    implementation("com.integrallis:vectors-db:0.1.0")
+    implementation("com.integrallis:vectors:0.1.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -666,6 +666,10 @@ tasks.register("verifyGithubWorkflows") {
             require(content.contains("jobs:")) { "$name missing 'jobs:' section" }
             println("  Workflow: $name")
         }
+        val releaseWorkflow = workflowDir.resolve("release.yml").readText()
+        require("libopenblas-dev" in releaseWorkflow) {
+            "release.yml runs the all-project build and must install OpenBLAS for Vectors Studio"
+        }
     }
 }
 

--- a/docs/content/antora.yml
+++ b/docs/content/antora.yml
@@ -1,8 +1,8 @@
 name: vectors
 title: Vectors
 version: 'current'
-display_version: '0.1.0-SNAPSHOT'
-prerelease: true
+display_version: '0.1.0'
+prerelease: false
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc
@@ -10,7 +10,7 @@ asciidoc:
   attributes:
     source-language: java
     source-highlighter: highlight.js
-    vectors-version: '0.1.0-SNAPSHOT'
+    vectors-version: '0.1.0'
     url-vectors-github: https://github.com/integrallis/java-vectors
     url-jdk-vector-api: https://docs.oracle.com/en/java/javase/25/docs/api/jdk.incubator.vector/jdk/incubator/vector/package-summary.html
     url-ffm-api: https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/foreign/package-summary.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.1.0-SNAPSHOT
+version = 0.1.0
 
 # Build performance.
 # parallel: build independent modules concurrently. With 49 modules and a 32-core host the


### PR DESCRIPTION
## Summary

- promote the project version from 0.1.0-SNAPSHOT to 0.1.0
- finalize the 0.1.0 changelog and Antora release metadata
- make the com.integrallis:vectors umbrella artifact the README quick-start dependency

## Verification

- ./gradlew --no-daemon clean spotlessCheck build :vectors-bench:recallGate complianceCheck publish -x :docs:build --stacktrace
- ./gradlew --no-daemon spotlessCheck complianceCheck -x :docs:build

The first command completed 656 actionable tasks successfully and validated all 17 staged Maven publications. This PR does not publish to Maven Central; deployment remains a separate manual workflow action.