### PR TITLE
perf(core): tile Q4_K prefill across four queries

### DIFF
--- a/.github/workflows/mfcqi.yml
+++ b/.github/workflows/mfcqi.yml
@@ -44,8 +44,8 @@ jobs:
           done
           echo "MFCQI_STAGE=$STAGE" >> "$GITHUB_ENV"
 
-      - name: Generate MFCQI badges (aggregate + per-module)
-        run: ./gradlew mfcqiBadge -Pmfcqi.sourceDir="$MFCQI_STAGE" --no-daemon
+      - name: Enforce MFCQI gates and generate badges (aggregate + per-module)
+        run: ./gradlew mfcqiGate mfcqiBadge -Pmfcqi.sourceDir="$MFCQI_STAGE" --no-daemon
 
       - name: Commit badge updates
         if: github.event_name == 'push'

--- a/.mfcqi.yaml
+++ b/.mfcqi.yaml
@@ -1,0 +1,8 @@
+quality_gates:
+  overall:
+    mfcqi_score: 0.70
+  metrics:
+    security: 0.80
+    Cyclomatic Complexity: 0.70
+    Cognitive Complexity: 0.70
+    Maintainability Index: 0.70

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,8 +153,9 @@ mfcqi {
     source.set(
         layout.projectDirectory.dir(providers.gradleProperty("mfcqi.sourceDir").getOrElse("."))
     )
+    gateFile.set(layout.projectDirectory.file(".mfcqi.yaml"))
     bytecodeSecurity.set(false)
-    failOnGate.set(false)
+    failOnGate.set(true)
 }
 
 // Per-module MFCQI: every library module with production sources gets its own score + badge JSON.
@@ -162,8 +163,9 @@ configure(libraryProjects.filter { it.file("src/main/java").isDirectory }) {
     apply(plugin = "com.integrallis.mfcqi")
     configure<com.integrallis.mfcqi.gradle.MfcqiExtension> {
         source.set(layout.projectDirectory.dir("src/main/java"))
+        gateFile.set(rootProject.layout.projectDirectory.file(".mfcqi.yaml"))
         bytecodeSecurity.set(false)
-        failOnGate.set(false)
+        failOnGate.set(true)
     }
 }
 

--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -33,6 +33,32 @@ outputs. A direct dual-only versus dual-plus-triple Q/K/V gate produced only a 0
 three faster and three slower pairs, and 6.68 MB higher median RSS. Models therefore keeps Q8_0
 Q/K/V independent. The exact generic triple API remains available for other model-specific gates.
 
+## Q4_K four-query register tile gate
+
+The original Q4_K/Q8_K batched kernel reused a weight row across the activation batch but unpacked
+the same Q4 nibbles separately for every query. The x86 register-tiled path keeps each unpacked
+256-bit weight vector live while multiplying four Q8_K queries. Its four accumulators are explicit
+locals because a `FloatVector[]` accumulator array prevents JDK 25 C2 scalar replacement.
+
+On Temurin 25.0.3 and an idle eight-vCPU AMD EPYC-Milan host, the 1024x2048 projection gate used
+three forks, three one-second warmups, five one-second measurements, and eight persistent workers:
+
+| Batch | Established kernel | Four-query tile | Change |
+| ---: | ---: | ---: | ---: |
+| 4 | 0.657 ms/op | 0.488 ms/op | -25.7% |
+| 32 | 5.136 ms/op | 3.853 ms/op | -25.0% |
+
+The 99.9% confidence intervals do not overlap. Batch-32 allocation remained noise-equivalent at
+466 versus 438 B/op with zero collections. A counterbalanced MiniCPM5 1B Q4_K_M gate then combined
+16 trials per revision against the same 688,065,920-byte artifact and 100-word prompt. Median TTFT
+fell from 7958.5 to 6780.0 ms (-14.8%), p95 TTFT fell from 8080.0 to 6872.4 ms (-14.9%), and median
+prefill rose from 18.83 to 22.10 tok/s (+17.4%). All 32 outputs had the same SHA-256.
+
+Automatic dispatch is limited to x86 with at least 256-bit vectors and batches of four or more.
+ARM/SVE retains the established path pending platform evidence. The model-level RSS readings were
+not lifecycle-aligned and support no footprint or capacity claim. The machine-readable aggregate
+is in `jmh-results/q4k-register-tile-20260731.json`.
+
 ## Q8_0 block-major row accumulation gate
 
 The original block-major Q8_0 row kernel updated `out[batch * rows + row]` after every weight

--- a/vectors-bench/jmh-results/q4k-register-tile-20260731.json
+++ b/vectors-bench/jmh-results/q4k-register-tile-20260731.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-07-31",
+  "technique": "q4_k_q8_k_four_query_register_tile",
+  "environment": {
+    "os": "Ubuntu Linux 6.8",
+    "cpu": "AMD EPYC-Milan Processor",
+    "logicalProcessors": 8,
+    "jvm": "Eclipse Temurin 25.0.3+9-LTS",
+    "vectorBits": 256,
+    "workers": 8
+  },
+  "jmh": {
+    "benchmark": "com.integrallis.vectors.bench.GgufQ4KBatchedMatmulBenchmark.batched",
+    "candidateJarSha256": "019624c8f86fd217760478f591b8121bad8ca8ec11bac3542614f97bd484c2a3",
+    "rows": 1024,
+    "cols": 2048,
+    "forks": 3,
+    "warmupIterations": 3,
+    "measurementIterations": 5,
+    "unit": "ms/op",
+    "results": [
+      {
+        "batchSize": 4,
+        "baseline": {"score": 0.6566208726, "ci99_9": [0.6530602315, 0.6601815137]},
+        "candidate": {"score": 0.4875614916, "ci99_9": [0.4844367531, 0.4906862302]},
+        "improvementPercent": 25.75
+      },
+      {
+        "batchSize": 32,
+        "baseline": {"score": 5.1363045480, "ci99_9": [5.1167622505, 5.1558468455]},
+        "candidate": {"score": 3.8530789581, "ci99_9": [3.8021118341, 3.9040460820]},
+        "improvementPercent": 24.98
+      }
+    ],
+    "allocationBatch32BytesPerOperation": {
+      "baseline": 466.495,
+      "candidate": 437.585,
+      "collections": 0
+    }
+  },
+  "fullModel": {
+    "model": "MiniCPM5 1B Q4_K_M",
+    "artifactBytes": 688065920,
+    "artifactSha256": "81b64d05a23b17b34c475f42b3e72fbde62d4b92cc34541f7a8031d0752deafa",
+    "promptWords": 100,
+    "inputTokenRange": [149, 152],
+    "warmupsPerProcess": 2,
+    "trialsPerRevision": 16,
+    "baseline": {
+      "medianTtftMillis": 7958.532814,
+      "p95TtftMillis": 8080.010592,
+      "medianPrefillTokensPerSecond": 18.82807651
+    },
+    "candidate": {
+      "medianTtftMillis": 6779.9963715,
+      "p95TtftMillis": 6872.367567,
+      "medianPrefillTokensPerSecond": 22.09890218
+    },
+    "outputSha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "claims": {
+      "medianTtftImprovementPercent": 14.81,
+      "p95TtftImprovementPercent": 14.95,
+      "medianPrefillImprovementPercent": 17.37,
+      "memoryCapacity": null
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -65,6 +65,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   static final VectorSpecies<Long> LONG_SPECIES =
       PanamaConstants.preferredSpecies(LongVector.SPECIES_PREFERRED);
   static final int VECTOR_BITSIZE = FLOAT_SPECIES.vectorBitSize();
+  private static final boolean Q4_K_FOUR_QUERY_TILE_SUPPORTED =
+      useQ4KFourQueryTile(System.getProperty("os.arch", ""), VECTOR_BITSIZE, 4);
   private static final VectorShuffle<Short> SWAP_ADJACENT_SHORTS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
@@ -136,6 +138,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return Objects.requireNonNull(kernel, "kernel") == GgufQ4Kernel.UNSIGNED_PAIRWISE
         && vectorBits >= 256
         && blocks >= Q4_SHORT_PAIRWISE_MIN_BLOCKS;
+  }
+
+  static boolean useQ4KFourQueryTile(String arch, int vectorBits, int batchSize) {
+    return PanamaConstants.isX86Arch(arch) && vectorBits >= 256 && batchSize >= 4;
   }
 
   private static boolean useQ4UnsignedPairwise(GgufQ4Kernel kernel, int blocks) {
@@ -1791,58 +1797,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
-        row -> {
-          for (int batch = 0; batch < batchSize; batch++) {
-            out[batch * rows + row] = 0.0f;
-          }
-
-          long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
-            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
-            float weightMinScale =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
-            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-            int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-
-            for (int batch = 0; batch < batchSize; batch++) {
-              int quantBatchOffset = batch * cols;
-              int scaleBatchOffset = batch * blocks;
-              int sumBatchOffset = batch * sumsPerBatch;
-              float q8Scale = q8Scales[scaleBatchOffset + block];
-              float d = weightScale * q8Scale;
-              float dMin = weightMinScale * q8Scale;
-              int quantizedSum = 0;
-              int minimumSum = 0;
-
-              for (int group = 0; group < 8; group++) {
-                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-                int shift = (group & 1) * 4;
-                int groupActivationOffset = blockActivationOffset + group * 32;
-                int groupDot =
-                    q4_KQ8_KIntegerDot(
-                        qWeight,
-                        packedOffset,
-                        shift,
-                        q8Quants,
-                        quantBatchOffset + groupActivationOffset);
-                quantizedSum += scale * groupDot;
-                int activationSumOffset =
-                    sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-                minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
-              }
-
-              int outputOffset = batch * rows + row;
-              float sum = out[outputOffset];
-              sum = MathUtil.fma(d, quantizedSum, sum);
-              sum = MathUtil.fma(-dMin, minimumSum, sum);
-              out[outputOffset] = sum;
-            }
-          }
-        });
+        row ->
+            ggufQ4_KQ8_KBatchedRowDot(
+                qWeight,
+                row * rowBytes,
+                false,
+                batchSize,
+                rows,
+                row,
+                cols,
+                blocks,
+                sumsPerBatch,
+                out,
+                q8Quants,
+                q8Scales,
+                q8Sums));
   }
 
   static void ggufQ4_KQ8_KLongOffsetBatchedMatmul(
@@ -1861,60 +1830,21 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
-        row -> {
-          for (int batch = 0; batch < batchSize; batch++) {
-            out[batch * rows + row] = 0.0f;
-          }
-
-          long rowEnd = (row + 1L) * rowBytes;
-          int block = 0;
-          for (long blockOffset = row * rowBytes;
-              blockOffset < rowEnd;
-              blockOffset += GGUF_Q4_K_BLOCK_BYTES, block++) {
-            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
-            float weightMinScale =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
-            long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
-            long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
-            int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
-
-            for (int batch = 0; batch < batchSize; batch++) {
-              int quantBatchOffset = batch * cols;
-              int scaleBatchOffset = batch * blocks;
-              int sumBatchOffset = batch * sumsPerBatch;
-              float q8Scale = q8Scales[scaleBatchOffset + block];
-              float d = weightScale * q8Scale;
-              float dMin = weightMinScale * q8Scale;
-              int quantizedSum = 0;
-              int minimumSum = 0;
-
-              for (int group = 0; group < 8; group++) {
-                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-                int shift = (group & 1) * 4;
-                int groupActivationOffset = blockActivationOffset + group * 32;
-                int groupDot =
-                    q4_KQ8_KIntegerDot(
-                        qWeight,
-                        packedOffset,
-                        shift,
-                        q8Quants,
-                        quantBatchOffset + groupActivationOffset);
-                quantizedSum += scale * groupDot;
-                int activationSumOffset =
-                    sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-                minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
-              }
-
-              int outputOffset = batch * rows + row;
-              float sum = out[outputOffset];
-              sum = MathUtil.fma(d, quantizedSum, sum);
-              sum = MathUtil.fma(-dMin, minimumSum, sum);
-              out[outputOffset] = sum;
-            }
-          }
-        });
+        row ->
+            ggufQ4_KQ8_KBatchedRowDot(
+                qWeight,
+                row * rowBytes,
+                true,
+                batchSize,
+                rows,
+                row,
+                cols,
+                blocks,
+                sumsPerBatch,
+                out,
+                q8Quants,
+                q8Scales,
+                q8Sums));
   }
 
   @Override
@@ -2495,8 +2425,31 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       byte[] q8Quants,
       float[] q8Scales,
       short[] q8Sums) {
-    for (int batch = 0; batch < batchSize; batch++) {
+    int scalarBatchStart = 0;
+    if (Q4_K_FOUR_QUERY_TILE_SUPPORTED) {
+      for (; scalarBatchStart + 4 <= batchSize; scalarBatchStart += 4) {
+        ggufQ4_KQ8_KFourQueryBatchedRow(
+            qWeight,
+            rowOffset,
+            useLongOffsets,
+            scalarBatchStart,
+            rows,
+            row,
+            cols,
+            blocks,
+            sumsPerBatch,
+            out,
+            q8Quants,
+            q8Scales,
+            q8Sums);
+      }
+    }
+
+    for (int batch = scalarBatchStart; batch < batchSize; batch++) {
       out[batch * rows + row] = 0.0f;
+    }
+    if (scalarBatchStart == batchSize) {
+      return;
     }
 
     long blockOffset = rowOffset;
@@ -2511,7 +2464,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
       int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
 
-      for (int batch = 0; batch < batchSize; batch++) {
+      for (int batch = scalarBatchStart; batch < batchSize; batch++) {
         int quantBatchOffset = batch * cols;
         int scaleBatchOffset = batch * blocks;
         int sumBatchOffset = batch * sumsPerBatch;
@@ -2546,6 +2499,216 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         blockOffset += GGUF_Q4_K_BLOCK_BYTES;
       }
     }
+  }
+
+  /**
+   * Multiplies one Q4_K weight row by four Q8_K queries while each unpacked weight vector is live.
+   * The explicit locals are intentional: putting Vector API accumulators in an array prevents C2
+   * scalar replacement and regresses this kernel sharply on JDK 25.
+   */
+  private static void ggufQ4_KQ8_KFourQueryBatchedRow(
+      MemorySegment qWeight,
+      long rowOffset,
+      boolean useLongOffsets,
+      int firstBatch,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      int sumsPerBatch,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int quantOffset0 = firstBatch * cols;
+    int quantOffset1 = quantOffset0 + cols;
+    int quantOffset2 = quantOffset1 + cols;
+    int quantOffset3 = quantOffset2 + cols;
+    int scaleOffset0 = firstBatch * blocks;
+    int scaleOffset1 = scaleOffset0 + blocks;
+    int scaleOffset2 = scaleOffset1 + blocks;
+    int scaleOffset3 = scaleOffset2 + blocks;
+    int sumOffset0 = firstBatch * sumsPerBatch;
+    int sumOffset1 = sumOffset0 + sumsPerBatch;
+    int sumOffset2 = sumOffset1 + sumsPerBatch;
+    int sumOffset3 = sumOffset2 + sumsPerBatch;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    float sum3 = 0.0f;
+
+    long blockOffset = rowOffset;
+    for (int block = 0; block < blocks; block++) {
+      if (!useLongOffsets) {
+        blockOffset = rowOffset + (long) block * GGUF_Q4_K_BLOCK_BYTES;
+      }
+      float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float weightMinScale =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q4_K_SCALES_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q4_K_QUANTS_OFFSET;
+      int blockActivationOffset = block * GGUF_Q4_K_BLOCK_SIZE;
+      int quantizedSum0 = 0;
+      int quantizedSum1 = 0;
+      int quantizedSum2 = 0;
+      int quantizedSum3 = 0;
+      int minimumSum0 = 0;
+      int minimumSum1 = 0;
+      int minimumSum2 = 0;
+      int minimumSum3 = 0;
+
+      for (int groupPair = 0; groupPair < 4; groupPair++) {
+        int lowGroup = groupPair * 2;
+        int highGroup = lowGroup + 1;
+        int lowScale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, lowGroup);
+        int highScale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, highGroup);
+        int lowMin = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, lowGroup);
+        int highMin = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, highGroup);
+        long packedOffset = quantsOffset + (long) groupPair * 32;
+        int lowActivationOffset = blockActivationOffset + lowGroup * 32;
+        int highActivationOffset = lowActivationOffset + 32;
+        int lowDot0 = 0;
+        int lowDot1 = 0;
+        int lowDot2 = 0;
+        int lowDot3 = 0;
+        int highDot0 = 0;
+        int highDot1 = 0;
+        int highDot2 = 0;
+        int highDot3 = 0;
+
+        for (int index = 0; index < 32; index += 16) {
+          ByteVector packed =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_128, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+          ShortVector lowWeights =
+              (ShortVector)
+                  packed
+                      .and((byte) 0x0F)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highWeights =
+              (ShortVector)
+                  packed
+                      .lanewise(VectorOperators.LSHR, 4)
+                      .and((byte) 0x0F)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+
+          ShortVector lowQuery0 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset0 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery0 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset0 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot0 += lowWeights.mul(lowQuery0).reduceLanes(VectorOperators.ADD);
+          highDot0 += highWeights.mul(highQuery0).reduceLanes(VectorOperators.ADD);
+
+          ShortVector lowQuery1 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset1 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery1 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset1 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot1 += lowWeights.mul(lowQuery1).reduceLanes(VectorOperators.ADD);
+          highDot1 += highWeights.mul(highQuery1).reduceLanes(VectorOperators.ADD);
+
+          ShortVector lowQuery2 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset2 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery2 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset2 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot2 += lowWeights.mul(lowQuery2).reduceLanes(VectorOperators.ADD);
+          highDot2 += highWeights.mul(highQuery2).reduceLanes(VectorOperators.ADD);
+
+          ShortVector lowQuery3 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset3 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery3 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset3 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot3 += lowWeights.mul(lowQuery3).reduceLanes(VectorOperators.ADD);
+          highDot3 += highWeights.mul(highQuery3).reduceLanes(VectorOperators.ADD);
+        }
+
+        quantizedSum0 += lowScale * lowDot0;
+        quantizedSum0 += highScale * highDot0;
+        quantizedSum1 += lowScale * lowDot1;
+        quantizedSum1 += highScale * highDot1;
+        quantizedSum2 += lowScale * lowDot2;
+        quantizedSum2 += highScale * highDot2;
+        quantizedSum3 += lowScale * lowDot3;
+        quantizedSum3 += highScale * highDot3;
+
+        int lowSumIndex0 = sumOffset0 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex0 = sumOffset0 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum0 += lowMin * (q8Sums[lowSumIndex0] + q8Sums[lowSumIndex0 + 1]);
+        minimumSum0 += highMin * (q8Sums[highSumIndex0] + q8Sums[highSumIndex0 + 1]);
+        int lowSumIndex1 = sumOffset1 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex1 = sumOffset1 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum1 += lowMin * (q8Sums[lowSumIndex1] + q8Sums[lowSumIndex1 + 1]);
+        minimumSum1 += highMin * (q8Sums[highSumIndex1] + q8Sums[highSumIndex1 + 1]);
+        int lowSumIndex2 = sumOffset2 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex2 = sumOffset2 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum2 += lowMin * (q8Sums[lowSumIndex2] + q8Sums[lowSumIndex2 + 1]);
+        minimumSum2 += highMin * (q8Sums[highSumIndex2] + q8Sums[highSumIndex2 + 1]);
+        int lowSumIndex3 = sumOffset3 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex3 = sumOffset3 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum3 += lowMin * (q8Sums[lowSumIndex3] + q8Sums[lowSumIndex3 + 1]);
+        minimumSum3 += highMin * (q8Sums[highSumIndex3] + q8Sums[highSumIndex3 + 1]);
+      }
+
+      float q8Scale0 = q8Scales[scaleOffset0 + block];
+      float q8Scale1 = q8Scales[scaleOffset1 + block];
+      float q8Scale2 = q8Scales[scaleOffset2 + block];
+      float q8Scale3 = q8Scales[scaleOffset3 + block];
+      sum0 = MathUtil.fma(weightScale * q8Scale0, quantizedSum0, sum0);
+      sum0 = MathUtil.fma(-weightMinScale * q8Scale0, minimumSum0, sum0);
+      sum1 = MathUtil.fma(weightScale * q8Scale1, quantizedSum1, sum1);
+      sum1 = MathUtil.fma(-weightMinScale * q8Scale1, minimumSum1, sum1);
+      sum2 = MathUtil.fma(weightScale * q8Scale2, quantizedSum2, sum2);
+      sum2 = MathUtil.fma(-weightMinScale * q8Scale2, minimumSum2, sum2);
+      sum3 = MathUtil.fma(weightScale * q8Scale3, quantizedSum3, sum3);
+      sum3 = MathUtil.fma(-weightMinScale * q8Scale3, minimumSum3, sum3);
+      if (useLongOffsets) {
+        blockOffset += GGUF_Q4_K_BLOCK_BYTES;
+      }
+    }
+
+    out[firstBatch * rows + row] = sum0;
+    out[(firstBatch + 1) * rows + row] = sum1;
+    out[(firstBatch + 2) * rows + row] = sum2;
+    out[(firstBatch + 3) * rows + row] = sum3;
   }
 
   private static void ggufQ6_KQ8_KBatchedRowDot(

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -227,7 +227,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q4_KLongOffsetBatchedMatmulMatchesTheEstablishedKernelExactly() throws IOException {
-    int batchSize = 3;
+    int batchSize = 5;
     int rows = 2;
     int cols = 512;
     int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
@@ -2100,7 +2100,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q4_KQ8_KBatchedMatmulMatchesIndependentQueriesExactly() {
-    int batchSize = 3;
+    int batchSize = 5;
     int rows = 2;
     int cols = 512;
     float[] queries = new float[batchSize * cols];
@@ -2221,7 +2221,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q4_KQ8_KDualBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
-    int batchSize = 3;
+    int batchSize = 5;
     int cols = 512;
     int firstRows = 2;
     int secondRows = 3;
@@ -2480,7 +2480,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q4_KQ4_KQ6_KQ8_KTripleBatchedMatmulMatchesSeparateBatchedMatmulsExactly() {
-    int batchSize = 3;
+    int batchSize = 5;
     int cols = 256;
     int firstRows = 2;
     int secondRows = 3;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -544,6 +544,22 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ4_KFourQueryRegisterTile() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ4_KQ8_KFourQueryBatchedRow");
+  }
+
+  @Test
+  void q4_KFourQueryRegisterTileRequiresMeasuredX86VectorEnvelope() {
+    assertThat(PanamaVectorUtilSupport.useQ4KFourQueryTile("amd64", 256, 4)).isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ4KFourQueryTile("x86_64", 512, 32)).isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ4KFourQueryTile("amd64", 128, 4)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4KFourQueryTile("amd64", 256, 3)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ4KFourQueryTile("aarch64", 256, 4)).isFalse();
+  }
+
+  @Test
   void panamaProviderOwnsQ5_KQ8_KKernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)

--- a/vectors-hybrid/.github/badges/mfcqi.json
+++ b/vectors-hybrid/.github/badges/mfcqi.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "MFCQI",
-  "message": "0.85 (excellent)",
+  "message": "0.89 (excellent)",
   "color": "brightgreen",
   "cacheSeconds": 3600
 }

--- a/vectors-hybrid/src/main/java/com/integrallis/vectors/hybrid/MaximalMarginalRelevance.java
+++ b/vectors-hybrid/src/main/java/com/integrallis/vectors/hybrid/MaximalMarginalRelevance.java
@@ -53,12 +53,7 @@ public final class MaximalMarginalRelevance {
    */
   public static int[] select(
       float[] query, float[][] candidates, int k, float lambda, SimilarityFunction similarity) {
-    if (query == null || candidates == null || similarity == null) {
-      throw new IllegalArgumentException("query, candidates, and similarity must be non-null");
-    }
-    if (lambda < 0f || lambda > 1f) {
-      throw new IllegalArgumentException("lambda must be in [0, 1], got " + lambda);
-    }
+    validateArguments(query, candidates, lambda, similarity);
     int n = candidates.length;
     int target = Math.min(Math.max(k, 0), n);
     int[] selected = new int[target];
@@ -66,22 +61,15 @@ public final class MaximalMarginalRelevance {
       return selected;
     }
 
-    // COSINE has no fused kernel (it needs per-vector norms), so instead of paying that norm on
-    // every
-    // one of the O(k*n) scalar compares, normalize the query + candidates ONCE and score via the
-    // fused DOT_PRODUCT path — for unit vectors, dot == cosine, and (1+dot)/2 == compare(COSINE),
-    // so
-    // results are numerically identical. Other metrics score in place.
+    // COSINE has no fused kernel. Normalize once, then use the fused DOT_PRODUCT path because dot
+    // equals cosine for unit vectors and has the same score transform.
     SimilarityFunction metric = similarity;
     float[] scoreQuery = query;
     float[][] pool = candidates;
     if (similarity == SimilarityFunction.COSINE) {
       metric = SimilarityFunction.DOT_PRODUCT;
       scoreQuery = VectorUtil.l2normalize(query.clone(), false);
-      pool = new float[n][];
-      for (int i = 0; i < n; i++) {
-        pool[i] = VectorUtil.l2normalize(candidates[i].clone(), false);
-      }
+      pool = normalizedCopy(candidates);
     }
 
     // Fused-SIMD batch scoring: one kernel sweep over the whole candidate pool instead of n scalar
@@ -98,31 +86,58 @@ public final class MaximalMarginalRelevance {
     float[] simToBest = new float[n];
 
     for (int step = 0; step < target; step++) {
-      int best = -1;
-      float bestScore = Float.NEGATIVE_INFINITY;
-      for (int i = 0; i < n; i++) {
-        if (taken[i]) {
-          continue;
-        }
-        // No redundancy on the first pick (nothing selected yet).
-        float redundancy = (step == 0) ? 0f : maxSimToSelected[i];
-        float mmr = lambda * relToQuery[i] - (1f - lambda) * redundancy;
-        if (mmr > bestScore) {
-          bestScore = mmr;
-          best = i;
-        }
-      }
+      int best = bestCandidate(taken, relToQuery, maxSimToSelected, step, lambda);
       selected[step] = best;
       taken[best] = true;
       // Fold the newly selected candidate into every remaining candidate's redundancy — one fused
       // sweep of sim(selected, pool).
       FusedSimilarity.bulkCompare(metric, pool[best], pool, scratch, simToBest, n);
-      for (int i = 0; i < n; i++) {
-        if (!taken[i] && simToBest[i] > maxSimToSelected[i]) {
-          maxSimToSelected[i] = simToBest[i];
-        }
-      }
+      updateRedundancy(taken, simToBest, maxSimToSelected);
     }
     return selected;
+  }
+
+  private static void validateArguments(
+      float[] query, float[][] candidates, float lambda, SimilarityFunction similarity) {
+    if (query == null || candidates == null || similarity == null) {
+      throw new IllegalArgumentException("query, candidates, and similarity must be non-null");
+    }
+    if (lambda < 0f || lambda > 1f) {
+      throw new IllegalArgumentException("lambda must be in [0, 1], got " + lambda);
+    }
+  }
+
+  private static float[][] normalizedCopy(float[][] candidates) {
+    float[][] normalized = new float[candidates.length][];
+    for (int i = 0; i < candidates.length; i++) {
+      normalized[i] = VectorUtil.l2normalize(candidates[i].clone(), false);
+    }
+    return normalized;
+  }
+
+  private static int bestCandidate(
+      boolean[] taken, float[] relevance, float[] maxSimilarity, int step, float lambda) {
+    int best = -1;
+    float bestScore = Float.NEGATIVE_INFINITY;
+    for (int i = 0; i < taken.length; i++) {
+      if (taken[i]) {
+        continue;
+      }
+      float redundancy = step == 0 ? 0f : maxSimilarity[i];
+      float score = lambda * relevance[i] - (1f - lambda) * redundancy;
+      if (score > bestScore) {
+        bestScore = score;
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  private static void updateRedundancy(boolean[] taken, float[] similarity, float[] maxSimilarity) {
+    for (int i = 0; i < taken.length; i++) {
+      if (!taken[i] && similarity[i] > maxSimilarity[i]) {
+        maxSimilarity[i] = similarity[i];
+      }
+    }
   }
 }

--- a/vectors-spring-ai/src/main/java/com/integrallis/vectors/spring/ai/JavaVectorsVectorStore.java
+++ b/vectors-spring-ai/src/main/java/com/integrallis/vectors/spring/ai/JavaVectorsVectorStore.java
@@ -59,6 +59,8 @@ public class JavaVectorsVectorStore extends AbstractObservationVectorStore
     implements AutoCloseable {
 
   static final String DATABASE_SYSTEM = "java-vectors";
+  private static final EmbeddingOptions DEFAULT_EMBEDDING_OPTIONS =
+      DefaultEmbeddingOptions.INSTANCE;
 
   private final VectorCollection collection;
   private final String collectionName;
@@ -99,8 +101,7 @@ public class JavaVectorsVectorStore extends AbstractObservationVectorStore
     // composes with a CachingEmbeddingModel's batch de-duplication, and respects the model's token
     // limit. Embeddings are returned in request order.
     List<float[]> embeddings =
-        this.embeddingModel.embed(
-            documents, EmbeddingOptions.builder().build(), this.batchingStrategy);
+        this.embeddingModel.embed(documents, DEFAULT_EMBEDDING_OPTIONS, this.batchingStrategy);
 
     List<com.integrallis.vectors.core.Document> jvDocs = new ArrayList<>(documents.size());
     for (int i = 0; i < documents.size(); i++) {
@@ -204,6 +205,20 @@ public class JavaVectorsVectorStore extends AbstractObservationVectorStore
   @Override
   public void close() {
     collection.close();
+  }
+
+  private enum DefaultEmbeddingOptions implements EmbeddingOptions {
+    INSTANCE;
+
+    @Override
+    public String getModel() {
+      return null;
+    }
+
+    @Override
+    public Integer getDimensions() {
+      return null;
+    }
   }
 
   /** Builder for {@link JavaVectorsVectorStore}. */

--- a/vectors-spring-boot-starter/.github/badges/mfcqi.json
+++ b/vectors-spring-boot-starter/.github/badges/mfcqi.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "MFCQI",
-  "message": "0.69 (good)",
+  "message": "0.78 (good)",
   "color": "green",
   "cacheSeconds": 3600
 }

--- a/vectors-spring-boot-starter/src/main/java/com/integrallis/vectors/spring/boot/JavaVectorsProperties.java
+++ b/vectors-spring-boot-starter/src/main/java/com/integrallis/vectors/spring/boot/JavaVectorsProperties.java
@@ -141,18 +141,30 @@ public class JavaVectorsProperties {
      */
     private int efConstruction = VectorCollectionBuilder.DEFAULT_HNSW_EF_CONSTRUCTION;
 
+    /** Returns the maximum number of connections per HNSW node. */
     public int getM() {
       return m;
     }
 
+    /**
+     * Sets the maximum number of connections per HNSW node.
+     *
+     * @param m maximum connections per node
+     */
     public void setM(int m) {
       this.m = m;
     }
 
+    /** Returns the HNSW construction beam width. */
     public int getEfConstruction() {
       return efConstruction;
     }
 
+    /**
+     * Sets the HNSW construction beam width.
+     *
+     * @param efConstruction construction beam width
+     */
     public void setEfConstruction(int efConstruction) {
       this.efConstruction = efConstruction;
     }
@@ -175,26 +187,44 @@ public class JavaVectorsProperties {
     /** Pruning factor alpha. Default: {@value VectorCollectionBuilder#DEFAULT_VAMANA_ALPHA}. */
     private float alpha = VectorCollectionBuilder.DEFAULT_VAMANA_ALPHA;
 
+    /** Returns the maximum out-degree after Vamana robust pruning. */
     public int getMaxDegree() {
       return maxDegree;
     }
 
+    /**
+     * Sets the maximum out-degree after Vamana robust pruning.
+     *
+     * @param maxDegree maximum graph out-degree
+     */
     public void setMaxDegree(int maxDegree) {
       this.maxDegree = maxDegree;
     }
 
+    /** Returns the Vamana construction search-list size. */
     public int getSearchListSize() {
       return searchListSize;
     }
 
+    /**
+     * Sets the Vamana construction search-list size.
+     *
+     * @param searchListSize construction search-list size
+     */
     public void setSearchListSize(int searchListSize) {
       this.searchListSize = searchListSize;
     }
 
+    /** Returns the Vamana robust-pruning alpha factor. */
     public float getAlpha() {
       return alpha;
     }
 
+    /**
+     * Sets the Vamana robust-pruning alpha factor.
+     *
+     * @param alpha robust-pruning factor
+     */
     public void setAlpha(float alpha) {
       this.alpha = alpha;
     }
@@ -214,26 +244,44 @@ public class JavaVectorsProperties {
     /** Max KMeans iterations. Default: {@value VectorCollectionBuilder#DEFAULT_IVF_MAX_ITER}. */
     private int maxIter = VectorCollectionBuilder.DEFAULT_IVF_MAX_ITER;
 
+    /** Returns the number of IVF clusters. */
     public int getK() {
       return k;
     }
 
+    /**
+     * Sets the number of IVF clusters.
+     *
+     * @param k cluster count
+     */
     public void setK(int k) {
       this.k = k;
     }
 
+    /** Returns the number of IVF clusters probed per query. */
     public int getNprobe() {
       return nprobe;
     }
 
+    /**
+     * Sets the number of IVF clusters probed per query.
+     *
+     * @param nprobe clusters to probe
+     */
     public void setNprobe(int nprobe) {
       this.nprobe = nprobe;
     }
 
+    /** Returns the maximum number of KMeans training iterations. */
     public int getMaxIter() {
       return maxIter;
     }
 
+    /**
+     * Sets the maximum number of KMeans training iterations.
+     *
+     * @param maxIter maximum training iterations
+     */
     public void setMaxIter(int maxIter) {
       this.maxIter = maxIter;
     }
@@ -250,18 +298,30 @@ public class JavaVectorsProperties {
      */
     private int clusters = VectorCollectionBuilder.DEFAULT_PQ_CLUSTERS;
 
+    /** Returns the configured PQ subspace count, or {@code null} to use the builder default. */
     public Integer getSubspaces() {
       return subspaces;
     }
 
+    /**
+     * Sets the PQ subspace count.
+     *
+     * @param subspaces subspace count, or {@code null} to use the builder default
+     */
     public void setSubspaces(Integer subspaces) {
       this.subspaces = subspaces;
     }
 
+    /** Returns the number of clusters in each PQ subspace. */
     public int getClusters() {
       return clusters;
     }
 
+    /**
+     * Sets the number of clusters in each PQ subspace.
+     *
+     * @param clusters clusters per subspace
+     */
     public void setClusters(int clusters) {
       this.clusters = clusters;
     }
@@ -271,98 +331,172 @@ public class JavaVectorsProperties {
   // Top-level getters and setters
   // =========================================================================
 
+  /**
+   * Returns the configured vector dimension, or a non-positive value when it should be inferred.
+   */
   public int getDimension() {
     return dimension;
   }
 
+  /**
+   * Sets the vector dimension.
+   *
+   * @param dimension positive dimension, or a non-positive value to infer it from Spring AI
+   */
   public void setDimension(int dimension) {
     this.dimension = dimension;
   }
 
+  /** Returns the similarity function used by the collection. */
   public SimilarityFunction getMetric() {
     return metric;
   }
 
+  /**
+   * Sets the similarity function used by the collection.
+   *
+   * @param metric similarity function
+   */
   public void setMetric(SimilarityFunction metric) {
     this.metric = metric;
   }
 
+  /** Returns the configured index backend. */
   public IndexType getIndexType() {
     return indexType;
   }
 
+  /**
+   * Sets the index backend.
+   *
+   * @param indexType index backend
+   */
   public void setIndexType(IndexType indexType) {
     this.indexType = indexType;
   }
 
+  /** Returns the configured vector quantizer. */
   public QuantizerKind getQuantizer() {
     return quantizer;
   }
 
+  /**
+   * Sets the vector quantizer.
+   *
+   * @param quantizer quantizer kind
+   */
   public void setQuantizer(QuantizerKind quantizer) {
     this.quantizer = quantizer;
   }
 
+  /** Returns the staged-document count that triggers an automatic commit. */
   public int getAutoCommitThreshold() {
     return autoCommitThreshold;
   }
 
+  /**
+   * Sets the staged-document count that triggers an automatic commit.
+   *
+   * @param autoCommitThreshold automatic commit threshold
+   */
   public void setAutoCommitThreshold(int autoCommitThreshold) {
     this.autoCommitThreshold = autoCommitThreshold;
   }
 
+  /** Returns the persistent collection path, or {@code null} for an in-memory collection. */
   public Path getStoragePath() {
     return storagePath;
   }
 
+  /**
+   * Sets the persistent collection path.
+   *
+   * @param storagePath collection path, or {@code null} for in-memory storage
+   */
   public void setStoragePath(Path storagePath) {
     this.storagePath = storagePath;
   }
 
+  /** Returns the maximum number of cached query results. */
   public int getCacheSize() {
     return cacheSize;
   }
 
+  /**
+   * Sets the maximum number of cached query results.
+   *
+   * @param cacheSize cache capacity; zero disables the cache
+   */
   public void setCacheSize(int cacheSize) {
     this.cacheSize = cacheSize;
   }
 
+  /** Returns whether the Spring AI vector store commits after every add operation. */
   public boolean isCommitAfterAdd() {
     return commitAfterAdd;
   }
 
+  /**
+   * Sets whether the Spring AI vector store commits after every add operation.
+   *
+   * @param commitAfterAdd {@code true} to make each add immediately searchable
+   */
   public void setCommitAfterAdd(boolean commitAfterAdd) {
     this.commitAfterAdd = commitAfterAdd;
   }
 
+  /** Returns the HNSW-specific properties. */
   public HnswProperties getHnsw() {
     return hnsw;
   }
 
+  /**
+   * Sets the HNSW-specific properties.
+   *
+   * @param hnsw HNSW configuration
+   */
   public void setHnsw(HnswProperties hnsw) {
     this.hnsw = hnsw;
   }
 
+  /** Returns the Vamana-specific properties. */
   public VamanaProperties getVamana() {
     return vamana;
   }
 
+  /**
+   * Sets the Vamana-specific properties.
+   *
+   * @param vamana Vamana configuration
+   */
   public void setVamana(VamanaProperties vamana) {
     this.vamana = vamana;
   }
 
+  /** Returns the IVF-specific properties. */
   public IvfProperties getIvf() {
     return ivf;
   }
 
+  /**
+   * Sets the IVF-specific properties.
+   *
+   * @param ivf IVF configuration
+   */
   public void setIvf(IvfProperties ivf) {
     this.ivf = ivf;
   }
 
+  /** Returns the PQ-specific properties. */
   public PqProperties getPq() {
     return pq;
   }
 
+  /**
+   * Sets the PQ-specific properties.
+   *
+   * @param pq PQ configuration
+   */
   public void setPq(PqProperties pq) {
     this.pq = pq;
   }

--- a/vectors-spring-boot-starter/src/main/java/com/integrallis/vectors/spring/boot/package-info.java
+++ b/vectors-spring-boot-starter/src/main/java/com/integrallis/vectors/spring/boot/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Spring Boot configuration properties and auto-configuration for Vectors. */
+package com.integrallis.vectors.spring.boot;

--- a/vectors-vcr-serde-jackson/.github/badges/mfcqi.json
+++ b/vectors-vcr-serde-jackson/.github/badges/mfcqi.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "MFCQI",
-  "message": "0.68 (good)",
-  "color": "green",
+  "message": "0.85 (excellent)",
+  "color": "brightgreen",
   "cacheSeconds": 3600
 }

--- a/vectors-vcr-serde-jackson/src/main/java/com/integrallis/vectors/vcr/serde/jackson/JacksonCassetteSerializer.java
+++ b/vectors-vcr-serde-jackson/src/main/java/com/integrallis/vectors/vcr/serde/jackson/JacksonCassetteSerializer.java
@@ -45,6 +45,14 @@ public final class JacksonCassetteSerializer implements CassetteSerializer {
   private static final String TYPE_BATCH_EMBEDDING = "batch_embedding";
   private static final String TYPE_CHAT = "chat";
 
+  /**
+   * Serializes one embedding, batch-embedding, or chat cassette record as compact JSON.
+   *
+   * @param record cassette record to encode
+   * @return encoded JSON bytes
+   * @throws IllegalArgumentException if the record implementation is unsupported
+   * @throws UncheckedIOException if Jackson cannot write the JSON document
+   */
   @Override
   public byte[] serialize(CassetteRecord record) {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -78,6 +86,13 @@ public final class JacksonCassetteSerializer implements CassetteSerializer {
     }
   }
 
+  /**
+   * Deserializes a cassette record written by either the Jackson or Avaje serializer.
+   *
+   * @param bytes encoded cassette JSON
+   * @return the decoded cassette record
+   * @throws UncheckedIOException if the document is malformed or contains an unknown record type
+   */
   @Override
   public CassetteRecord deserialize(byte[] bytes) {
     try (JsonParser p = FACTORY.createParser(new ByteArrayInputStream(bytes))) {

--- a/vectors-vcr-serde-jackson/src/main/java/com/integrallis/vectors/vcr/serde/jackson/package-info.java
+++ b/vectors-vcr-serde-jackson/src/main/java/com/integrallis/vectors/vcr/serde/jackson/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Jackson streaming serialization for interoperable Vectors VCR cassette records. */
+package com.integrallis.vectors.vcr.serde.jackson;


### PR DESCRIPTION
## Summary

- add an exact four-query register-tiled Q4_K/Q8_K batched row kernel
- dispatch the tile only on x86 with at least 256-bit vectors and retain the established path for scalar tails and other platforms
- add direct, mapped, dual, mixed, policy, and tail correctness coverage
- enforce explicit MFCQI module watermarks in Gradle and CI, with red-to-green remediation for hybrid, Spring Boot, and Jackson VCR modules

## Performance qualification

Controlled 8-vCPU AMD EPYC-Milan VPS, Temurin 25.0.3, AVX2, 256-bit vectors, 4 GiB fixed heap. Exact benchmark JAR SHA-256: `019624c8f86fd217760478f591b8121bad8ca8ec11bac3542614f97bd484c2a3`.

| Workload | Baseline | Tiled | Change |
|---|---:|---:|---:|
| Q4_K batch 4, 1024x2048 | 0.6566 ms/op | 0.4876 ms/op | -25.75% |
| Q4_K batch 32, 1024x2048 | 5.1363 ms/op | 3.8531 ms/op | -24.98% |
| MiniCPM5 median TTFT | 7,958.5 ms | 6,780.0 ms | -14.8% |
| MiniCPM5 median prefill | 18.83 tok/s | 22.10 tok/s | +17.4% |

All 32 MiniCPM5 outputs retained the same SHA. JMH allocation declined from 466.495 to 437.585 B/op with zero collections. Raw JMH evidence is checked in under `vectors-bench/jmh-results/q4k-register-tile-20260731.json`.

## Quality

- `./gradlew check --no-daemon`: 361 tasks, BUILD SUCCESSFUL
- all 39 aggregate and per-module MFCQI gates pass
- overall gate: 0.70; security: 0.80; cyclomatic, cognitive, and maintainability: 0.70
- lowest module score: 0.733; `vectors-core`: 0.744
