### PR TITLE
perf(core): tile Q5_K prefill across four queries

### DIFF
--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -59,6 +59,35 @@ ARM/SVE retains the established path pending platform evidence. The model-level 
 not lifecycle-aligned and support no footprint or capacity claim. The machine-readable aggregate
 is in `jmh-results/q4k-register-tile-20260731.json`.
 
+## Q5_K four-query register tile gate
+
+Q5_K adds a separate fifth-bit plane to the packed four-bit values. The established batched kernel
+reloaded and reconstructed both planes for every query. The retained x86 path reconstructs each
+weight vector once and consumes four Q8_K queries while it is live, using explicit scalar locals so
+JDK 25 can keep the vectors and accumulators out of arrays.
+
+The controlled 1024x2048 JMH gate used the same eight-vCPU AMD EPYC-Milan host, Temurin 25.0.3,
+three forks, three one-second warmups, five one-second measurements, and eight persistent workers:
+
+| Batch | Established kernel | Four-query tile | Change |
+| ---: | ---: | ---: | ---: |
+| 4 | 1.105 ms/op | 0.541 ms/op | -51.0% |
+| 32 | 8.704 ms/op | 4.286 ms/op | -50.8% |
+
+Both 99.9% confidence-interval pairs are non-overlapping. At batch 32, allocation measured 499.5
+B/op for the baseline and 538.1 B/op for the candidate, with overlapping confidence intervals and
+zero collections; the data establishes no allocation change.
+
+The ABBA full-model gate used SQLCoder-7B-2 Q5_K_M, its exact 4,783,256,288-byte artifact, the
+committed SQL prompt, two warmups per process, and 16 one-token prefill trials per revision. Median
+TTFT fell from 44,780.7 to 26,585.8 ms (-40.6%), p95 TTFT fell from 45,721.4 to 28,019.7 ms
+(-38.7%), and median prefill rose from 1.326 to 2.236 tok/s (+68.6%). Corresponding input-token
+series and all 32 output hashes were identical.
+
+Automatic dispatch has the same x86, 256-bit, and batch-four envelope as Q4_K. Process RSS differed
+between runs and was not lifecycle-aligned, so it supports no memory-capacity claim. The
+machine-readable aggregate is in `jmh-results/q5k-register-tile-20260731.json`.
+
 ## Q8_0 block-major row accumulation gate
 
 The original block-major Q8_0 row kernel updated `out[batch * rows + row]` after every weight

--- a/vectors-bench/jmh-results/q5k-register-tile-20260731.json
+++ b/vectors-bench/jmh-results/q5k-register-tile-20260731.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-07-31",
+  "technique": "q5_k_q8_k_four_query_register_tile",
+  "environment": {
+    "os": "Ubuntu Linux 6.8",
+    "cpu": "AMD EPYC-Milan Processor",
+    "logicalProcessors": 8,
+    "jvm": "Eclipse Temurin 25.0.3+9-LTS",
+    "vectorBits": 256,
+    "workers": 8
+  },
+  "jmh": {
+    "benchmark": "com.integrallis.vectors.bench.GgufQ5KBatchedMatmulBenchmark.batched",
+    "baselineJarSha256": "019624c8f86fd217760478f591b8121bad8ca8ec11bac3542614f97bd484c2a3",
+    "candidateJarSha256": "0f9712eb96cdd847eec94364292a7d1531a7645582cd9342207c6b36d4d8a165",
+    "rows": 1024,
+    "cols": 2048,
+    "forks": 3,
+    "warmupIterations": 3,
+    "measurementIterations": 5,
+    "unit": "ms/op",
+    "results": [
+      {
+        "batchSize": 4,
+        "baseline": {"score": 1.1052129052, "ci99_9": [1.1001104191, 1.1103153912]},
+        "candidate": {"score": 0.5413606587, "ci99_9": [0.5291319558, 0.5535893615]},
+        "improvementPercent": 51.02
+      },
+      {
+        "batchSize": 32,
+        "baseline": {"score": 8.7042851869, "ci99_9": [8.6756095350, 8.7329608388]},
+        "candidate": {"score": 4.2860953985, "ci99_9": [4.2364221917, 4.3357686054]},
+        "improvementPercent": 50.76
+      }
+    ],
+    "allocationBatch32BytesPerOperation": {
+      "baseline": {"score": 499.4534, "ci99_9": [437.5415, 561.3653]},
+      "candidate": {"score": 538.1148, "ci99_9": [410.1987, 666.0309]},
+      "collections": 0,
+      "claim": null
+    }
+  },
+  "fullModel": {
+    "modelsRevision": "c0513b7b70d5865211c3d066a75e5b62df89bfe0",
+    "model": "SQLCoder-7B-2 Q5_K_M",
+    "artifactBytes": 4783256288,
+    "artifactSha256": "0068f25d1fc37cb25aa6be85064432eeeb1a0754d97139c0d2eb3529fc8fc32b",
+    "prompt": "models-bench/prompts/sqlcoder.txt",
+    "promptSha256": "30f6a0295f161a7ead0a95049f492a711aea3921908b8ae9bf27589c41abe8c7",
+    "inputTokenRange": [57, 61],
+    "contextLength": 128,
+    "maxOutputTokens": 1,
+    "warmupsPerProcess": 2,
+    "processesPerRevision": 2,
+    "trialsPerRevision": 16,
+    "baselineVectorsJarSha256": "194335b24e0f9a535af07f14aa08112641f0a57c096424d09ac7588058b8c61c",
+    "candidateVectorsJarSha256": "d861ca0e49f1bf4b6fe135a809d1f9d71be5f65eb0c187e440d4b65b5cbca51d",
+    "baseline": {
+      "medianTtftMillis": 44780.685381,
+      "p95TtftMillis": 45721.394181,
+      "medianPrefillTokensPerSecond": 1.3264517509,
+      "observedPeakRssBytes": 5167296512
+    },
+    "candidate": {
+      "medianTtftMillis": 26585.761660,
+      "p95TtftMillis": 28019.745619,
+      "medianPrefillTokensPerSecond": 2.2361297185,
+      "observedPeakRssBytes": 5950337024
+    },
+    "outputSha256": "71d94190e40b85351e9312a4d1e72ab121fc539d0dbfd8ff4ec800511984f639",
+    "claims": {
+      "medianTtftImprovementPercent": 40.63,
+      "p95TtftImprovementPercent": 38.72,
+      "medianPrefillImprovementPercent": 68.58,
+      "memoryCapacity": null
+    }
+  }
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -67,6 +67,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   static final int VECTOR_BITSIZE = FLOAT_SPECIES.vectorBitSize();
   private static final boolean Q4_K_FOUR_QUERY_TILE_SUPPORTED =
       useQ4KFourQueryTile(System.getProperty("os.arch", ""), VECTOR_BITSIZE, 4);
+  private static final boolean Q5_K_FOUR_QUERY_TILE_SUPPORTED =
+      useQ5KFourQueryTile(System.getProperty("os.arch", ""), VECTOR_BITSIZE, 4);
   private static final VectorShuffle<Short> SWAP_ADJACENT_SHORTS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
@@ -141,6 +143,14 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   static boolean useQ4KFourQueryTile(String arch, int vectorBits, int batchSize) {
+    return useKQuantFourQueryTile(arch, vectorBits, batchSize);
+  }
+
+  static boolean useQ5KFourQueryTile(String arch, int vectorBits, int batchSize) {
+    return useKQuantFourQueryTile(arch, vectorBits, batchSize);
+  }
+
+  private static boolean useKQuantFourQueryTile(String arch, int vectorBits, int batchSize) {
     return PanamaConstants.isX86Arch(arch) && vectorBits >= 256 && batchSize >= 4;
   }
 
@@ -2941,80 +2951,352 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     int blocks = cols / GGUF_Q5_K_BLOCK_SIZE;
     int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
-    for (int batch = 0; batch < batchSize; batch++) {
-      GgufQuantizationSupport.quantizeQ8_K(
-          queries,
-          batch * cols,
-          cols,
-          q8Quants,
-          batch * cols,
-          q8Scales,
-          batch * blocks,
-          q8Sums,
-          batch * sumsPerBatch);
-    }
+    quantizeQ8_KBatch(queries, batchSize, cols, blocks, sumsPerBatch, q8Quants, q8Scales, q8Sums);
 
     long rowBytes = (long) blocks * GGUF_Q5_K_BLOCK_BYTES;
+    boolean useLongOffsets = qWeight.isMapped() && PanamaConstants.USE_MAPPED_Q5_K_LONG_OFFSETS;
     GgufParallelSupport.forEachRow(
         qWeight,
         rows,
         cols,
-        row -> {
-          for (int batch = 0; batch < batchSize; batch++) {
-            out[batch * rows + row] = 0.0f;
-          }
+        row ->
+            ggufQ5_KQ8_KBatchedRowDot(
+                qWeight,
+                row * rowBytes,
+                useLongOffsets,
+                batchSize,
+                rows,
+                row,
+                cols,
+                blocks,
+                sumsPerBatch,
+                out,
+                q8Quants,
+                q8Scales,
+                q8Sums));
+  }
 
-          long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
-            float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
-            float weightMinScale =
-                Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
-            long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
-            long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
-            long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
-            int blockActivationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+  private static void ggufQ5_KQ8_KBatchedRowDot(
+      MemorySegment qWeight,
+      long rowOffset,
+      boolean useLongOffsets,
+      int batchSize,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      int sumsPerBatch,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int scalarBatchStart = 0;
+    if (Q5_K_FOUR_QUERY_TILE_SUPPORTED) {
+      for (; scalarBatchStart + 4 <= batchSize; scalarBatchStart += 4) {
+        ggufQ5_KQ8_KFourQueryBatchedRow(
+            qWeight,
+            rowOffset,
+            useLongOffsets,
+            scalarBatchStart,
+            rows,
+            row,
+            cols,
+            blocks,
+            sumsPerBatch,
+            out,
+            q8Quants,
+            q8Scales,
+            q8Sums);
+      }
+    }
 
-            for (int batch = 0; batch < batchSize; batch++) {
-              int quantBatchOffset = batch * cols;
-              int scaleBatchOffset = batch * blocks;
-              int sumBatchOffset = batch * sumsPerBatch;
-              float q8Scale = q8Scales[scaleBatchOffset + block];
-              float d = weightScale * q8Scale;
-              float dMin = weightMinScale * q8Scale;
-              int quantizedSum = 0;
-              int minimumSum = 0;
+    for (int batch = scalarBatchStart; batch < batchSize; batch++) {
+      out[batch * rows + row] = 0.0f;
+    }
+    if (scalarBatchStart == batchSize) {
+      return;
+    }
 
-              for (int group = 0; group < 8; group++) {
-                int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
-                int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
-                long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
-                int shift = (group & 1) * 4;
-                int highBit = 1 << group;
-                int groupActivationOffset = blockActivationOffset + group * 32;
-                int groupDot =
-                    q5_KQ8_KIntegerDot(
-                        qWeight,
-                        packedOffset,
-                        shift,
-                        highBitsOffset,
-                        highBit,
-                        q8Quants,
-                        quantBatchOffset + groupActivationOffset);
-                quantizedSum += scale * groupDot;
-                int activationSumOffset =
-                    sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
-                minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
-              }
+    long blockOffset = rowOffset;
+    for (int block = 0; block < blocks; block++) {
+      if (!useLongOffsets) {
+        blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      }
+      float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float weightMinScale =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int blockActivationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
 
-              int outputOffset = batch * rows + row;
-              float sum = out[outputOffset];
-              sum = MathUtil.fma(d, quantizedSum, sum);
-              sum = MathUtil.fma(-dMin, minimumSum, sum);
-              out[outputOffset] = sum;
-            }
-          }
-        });
+      for (int batch = scalarBatchStart; batch < batchSize; batch++) {
+        int quantBatchOffset = batch * cols;
+        int scaleBatchOffset = batch * blocks;
+        int sumBatchOffset = batch * sumsPerBatch;
+        float q8Scale = q8Scales[scaleBatchOffset + block];
+        float d = weightScale * q8Scale;
+        float dMin = weightMinScale * q8Scale;
+        int quantizedSum = 0;
+        int minimumSum = 0;
+
+        for (int group = 0; group < 8; group++) {
+          int scale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, group);
+          int min = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, group);
+          long packedOffset = quantsOffset + (long) (group >>> 1) * 32;
+          int shift = (group & 1) * 4;
+          int highBit = 1 << group;
+          int groupActivationOffset = blockActivationOffset + group * 32;
+          int groupDot =
+              q5_KQ8_KIntegerDot(
+                  qWeight,
+                  packedOffset,
+                  shift,
+                  highBitsOffset,
+                  highBit,
+                  q8Quants,
+                  quantBatchOffset + groupActivationOffset);
+          quantizedSum += scale * groupDot;
+          int activationSumOffset =
+              sumBatchOffset + groupActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+          minimumSum += min * (q8Sums[activationSumOffset] + q8Sums[activationSumOffset + 1]);
+        }
+
+        int outputOffset = batch * rows + row;
+        float sum = out[outputOffset];
+        sum = MathUtil.fma(d, quantizedSum, sum);
+        sum = MathUtil.fma(-dMin, minimumSum, sum);
+        out[outputOffset] = sum;
+      }
+      if (useLongOffsets) {
+        blockOffset += GGUF_Q5_K_BLOCK_BYTES;
+      }
+    }
+  }
+
+  /**
+   * Multiplies one Q5_K weight row by four Q8_K queries while each reconstructed weight vector is
+   * live. Explicit locals keep the Vector API values scalar-replaceable on JDK 25.
+   */
+  private static void ggufQ5_KQ8_KFourQueryBatchedRow(
+      MemorySegment qWeight,
+      long rowOffset,
+      boolean useLongOffsets,
+      int firstBatch,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      int sumsPerBatch,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums) {
+    int quantOffset0 = firstBatch * cols;
+    int quantOffset1 = quantOffset0 + cols;
+    int quantOffset2 = quantOffset1 + cols;
+    int quantOffset3 = quantOffset2 + cols;
+    int scaleOffset0 = firstBatch * blocks;
+    int scaleOffset1 = scaleOffset0 + blocks;
+    int scaleOffset2 = scaleOffset1 + blocks;
+    int scaleOffset3 = scaleOffset2 + blocks;
+    int sumOffset0 = firstBatch * sumsPerBatch;
+    int sumOffset1 = sumOffset0 + sumsPerBatch;
+    int sumOffset2 = sumOffset1 + sumsPerBatch;
+    int sumOffset3 = sumOffset2 + sumsPerBatch;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    float sum3 = 0.0f;
+
+    long blockOffset = rowOffset;
+    for (int block = 0; block < blocks; block++) {
+      if (!useLongOffsets) {
+        blockOffset = rowOffset + (long) block * GGUF_Q5_K_BLOCK_BYTES;
+      }
+      float weightScale = Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset));
+      float weightMinScale =
+          Float.float16ToFloat(qWeight.get(GGUF_LE_SHORT, blockOffset + Short.BYTES));
+      long scalesOffset = blockOffset + GGUF_Q5_K_SCALES_OFFSET;
+      long highBitsOffset = blockOffset + GGUF_Q5_K_HIGH_BITS_OFFSET;
+      long quantsOffset = blockOffset + GGUF_Q5_K_QUANTS_OFFSET;
+      int blockActivationOffset = block * GGUF_Q5_K_BLOCK_SIZE;
+      int quantizedSum0 = 0;
+      int quantizedSum1 = 0;
+      int quantizedSum2 = 0;
+      int quantizedSum3 = 0;
+      int minimumSum0 = 0;
+      int minimumSum1 = 0;
+      int minimumSum2 = 0;
+      int minimumSum3 = 0;
+
+      for (int groupPair = 0; groupPair < 4; groupPair++) {
+        int lowGroup = groupPair * 2;
+        int highGroup = lowGroup + 1;
+        int lowScale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, lowGroup);
+        int highScale = GgufQuantizationSupport.qKScale(qWeight, scalesOffset, highGroup);
+        int lowMin = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, lowGroup);
+        int highMin = GgufQuantizationSupport.qKMin(qWeight, scalesOffset, highGroup);
+        long packedOffset = quantsOffset + (long) groupPair * 32;
+        int lowActivationOffset = blockActivationOffset + lowGroup * 32;
+        int highActivationOffset = lowActivationOffset + 32;
+        int lowDot0 = 0;
+        int lowDot1 = 0;
+        int lowDot2 = 0;
+        int lowDot3 = 0;
+        int highDot0 = 0;
+        int highDot1 = 0;
+        int highDot2 = 0;
+        int highDot3 = 0;
+
+        for (int index = 0; index < 32; index += 16) {
+          ByteVector packed =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_128, qWeight, packedOffset + index, ByteOrder.LITTLE_ENDIAN);
+          ByteVector highBits =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_128, qWeight, highBitsOffset + index, ByteOrder.LITTLE_ENDIAN);
+          ByteVector lowFifthBit =
+              highBits
+                  .lanewise(VectorOperators.LSHR, lowGroup)
+                  .and((byte) 1)
+                  .lanewise(VectorOperators.LSHL, 4);
+          ByteVector highFifthBit =
+              highBits
+                  .lanewise(VectorOperators.LSHR, highGroup)
+                  .and((byte) 1)
+                  .lanewise(VectorOperators.LSHL, 4);
+          ShortVector lowWeights =
+              (ShortVector)
+                  packed
+                      .and((byte) 0x0F)
+                      .add(lowFifthBit)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highWeights =
+              (ShortVector)
+                  packed
+                      .lanewise(VectorOperators.LSHR, 4)
+                      .and((byte) 0x0F)
+                      .add(highFifthBit)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+
+          ShortVector lowQuery0 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset0 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery0 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset0 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot0 += lowWeights.mul(lowQuery0).reduceLanes(VectorOperators.ADD);
+          highDot0 += highWeights.mul(highQuery0).reduceLanes(VectorOperators.ADD);
+
+          ShortVector lowQuery1 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset1 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery1 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset1 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot1 += lowWeights.mul(lowQuery1).reduceLanes(VectorOperators.ADD);
+          highDot1 += highWeights.mul(highQuery1).reduceLanes(VectorOperators.ADD);
+
+          ShortVector lowQuery2 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset2 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery2 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset2 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot2 += lowWeights.mul(lowQuery2).reduceLanes(VectorOperators.ADD);
+          highDot2 += highWeights.mul(highQuery2).reduceLanes(VectorOperators.ADD);
+
+          ShortVector lowQuery3 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset3 + lowActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          ShortVector highQuery3 =
+              (ShortVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_128,
+                          q8Quants,
+                          quantOffset3 + highActivationOffset + index)
+                      .convertShape(VectorOperators.B2S, ShortVector.SPECIES_256, 0);
+          lowDot3 += lowWeights.mul(lowQuery3).reduceLanes(VectorOperators.ADD);
+          highDot3 += highWeights.mul(highQuery3).reduceLanes(VectorOperators.ADD);
+        }
+
+        quantizedSum0 += lowScale * lowDot0;
+        quantizedSum0 += highScale * highDot0;
+        quantizedSum1 += lowScale * lowDot1;
+        quantizedSum1 += highScale * highDot1;
+        quantizedSum2 += lowScale * lowDot2;
+        quantizedSum2 += highScale * highDot2;
+        quantizedSum3 += lowScale * lowDot3;
+        quantizedSum3 += highScale * highDot3;
+
+        int lowSumIndex0 = sumOffset0 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex0 = sumOffset0 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum0 += lowMin * (q8Sums[lowSumIndex0] + q8Sums[lowSumIndex0 + 1]);
+        minimumSum0 += highMin * (q8Sums[highSumIndex0] + q8Sums[highSumIndex0 + 1]);
+        int lowSumIndex1 = sumOffset1 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex1 = sumOffset1 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum1 += lowMin * (q8Sums[lowSumIndex1] + q8Sums[lowSumIndex1 + 1]);
+        minimumSum1 += highMin * (q8Sums[highSumIndex1] + q8Sums[highSumIndex1 + 1]);
+        int lowSumIndex2 = sumOffset2 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex2 = sumOffset2 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum2 += lowMin * (q8Sums[lowSumIndex2] + q8Sums[lowSumIndex2 + 1]);
+        minimumSum2 += highMin * (q8Sums[highSumIndex2] + q8Sums[highSumIndex2 + 1]);
+        int lowSumIndex3 = sumOffset3 + lowActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        int highSumIndex3 = sumOffset3 + highActivationOffset / GGUF_Q8_K_SUM_BLOCK_SIZE;
+        minimumSum3 += lowMin * (q8Sums[lowSumIndex3] + q8Sums[lowSumIndex3 + 1]);
+        minimumSum3 += highMin * (q8Sums[highSumIndex3] + q8Sums[highSumIndex3 + 1]);
+      }
+
+      float q8Scale0 = q8Scales[scaleOffset0 + block];
+      float q8Scale1 = q8Scales[scaleOffset1 + block];
+      float q8Scale2 = q8Scales[scaleOffset2 + block];
+      float q8Scale3 = q8Scales[scaleOffset3 + block];
+      sum0 = MathUtil.fma(weightScale * q8Scale0, quantizedSum0, sum0);
+      sum0 = MathUtil.fma(-weightMinScale * q8Scale0, minimumSum0, sum0);
+      sum1 = MathUtil.fma(weightScale * q8Scale1, quantizedSum1, sum1);
+      sum1 = MathUtil.fma(-weightMinScale * q8Scale1, minimumSum1, sum1);
+      sum2 = MathUtil.fma(weightScale * q8Scale2, quantizedSum2, sum2);
+      sum2 = MathUtil.fma(-weightMinScale * q8Scale2, minimumSum2, sum2);
+      sum3 = MathUtil.fma(weightScale * q8Scale3, quantizedSum3, sum3);
+      sum3 = MathUtil.fma(-weightMinScale * q8Scale3, minimumSum3, sum3);
+      if (useLongOffsets) {
+        blockOffset += GGUF_Q5_K_BLOCK_BYTES;
+      }
+    }
+
+    out[firstBatch * rows + row] = sum0;
+    out[(firstBatch + 1) * rows + row] = sum1;
+    out[(firstBatch + 2) * rows + row] = sum2;
+    out[(firstBatch + 3) * rows + row] = sum3;
   }
 
   @Override

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -312,6 +312,49 @@ class GgufQuantizedDotTest {
   }
 
   @Test
+  void q5_KMappedBatchedMatmulMatchesDirectKernelExactly() throws IOException {
+    int batchSize = 5;
+    int rows = 2;
+    int cols = 512;
+    int[] scales = {5, 12, 30, 60, 7, 15, 31, 63};
+    int[] mins = {3, 8, 20, 45, 1, 10, 25, 50};
+    byte[] firstRow = repeat(q5KBlock(0.125f, 0.0625f, i -> (i * 7 + 3) & 0x1F, scales, mins), 2);
+    byte[] secondRow = repeat(q5KBlock(-0.25f, 0.03125f, i -> 31 - (i & 0x1F), scales, mins), 2);
+    byte[] matrix = concat(firstRow, secondRow);
+    float[] queries = patternedQueries(batchSize, cols);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    byte[] q8Quants = new byte[batchSize * cols];
+    float[] q8Scales = new float[batchSize * (cols / 256)];
+    short[] q8Sums = new short[batchSize * (cols / 16)];
+    Path path = Files.createTempFile("vectors-q5-k-batch-", ".bin");
+    Files.write(path, matrix);
+
+    try (Arena arena = Arena.ofConfined();
+        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      MemorySegment mapped = channel.map(FileChannel.MapMode.READ_ONLY, 0, matrix.length, arena);
+      assertThat(mapped.isMapped()).isTrue();
+
+      VectorUtil.ggufQ5_KQ8_KBatchedMatmul(
+          queries,
+          MemorySegment.ofArray(matrix),
+          batchSize,
+          rows,
+          cols,
+          expected,
+          q8Quants,
+          q8Scales,
+          q8Sums);
+      VectorUtil.ggufQ5_KQ8_KBatchedMatmul(
+          queries, mapped, batchSize, rows, cols, actual, q8Quants, q8Scales, q8Sums);
+
+      assertThat(actual).containsExactly(expected);
+    } finally {
+      Files.deleteIfExists(path);
+    }
+  }
+
+  @Test
   void q6_KDequantize_matchesDecodedReferenceAtOutputOffset() {
     byte[] block = q6KBlock(0.125f, i -> (i % 64) - 32, i -> (i % 7) - 3);
     float[] decoded = new float[258];
@@ -2683,7 +2726,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q5_KQ8_KBatchedMatmulMatchesIndependentQueriesExactly() {
-    int batchSize = 3;
+    int batchSize = 5;
     int rows = 2;
     int cols = 512;
     float[] queries = new float[batchSize * cols];
@@ -2735,7 +2778,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q5_KQ8_KBatchedMatmulMatchesGemvAtProjectionScaleAfterWarmup() {
-    int batchSize = 4;
+    int batchSize = 5;
     int rows = 512;
     int cols = 2_048;
     int blocks = cols / 256;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -574,6 +574,22 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void panamaProviderOwnsQ5_KFourQueryRegisterTile() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ5_KQ8_KFourQueryBatchedRow");
+  }
+
+  @Test
+  void q5_KFourQueryRegisterTileRequiresMeasuredX86VectorEnvelope() {
+    assertThat(PanamaVectorUtilSupport.useQ5KFourQueryTile("amd64", 256, 4)).isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ5KFourQueryTile("x86_64", 512, 32)).isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ5KFourQueryTile("amd64", 128, 4)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ5KFourQueryTile("amd64", 256, 3)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ5KFourQueryTile("aarch64", 256, 4)).isFalse();
+  }
+
+  @Test
   void panamaProviderOwnsQ6_KQ8_KKernel() {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)


### PR DESCRIPTION
## Summary
- add an x86/256-bit Q5_K four-query register-tiled batch path
- preserve the established scalar path for 1-3 query tails and ARM/SVE
- add exact direct/mapped parity, tail, projection, and cold/hot determinism coverage
- check in controlled JMH and full-model qualification evidence

## Performance qualification
Controlled 8-vCPU AMD EPYC-Milan host, Temurin 25.0.3, AVX2/256-bit:

- batch 4 kernel: 1.1052 ms/op -> 0.5414 ms/op (51.02% reduction)
- batch 32 kernel: 8.7043 ms/op -> 4.2861 ms/op (50.76% reduction)
- SQLCoder-7B-2 Q5_K_M median TTFT: 44,780.7 ms -> 26,585.8 ms (40.63% reduction)
- SQLCoder median prefill: 1.3265 -> 2.2361 tok/s (68.58% increase)
- 32/32 full-model runs succeeded with identical output SHA-256
- allocation confidence intervals overlap; no allocation or capacity claim is made

## Verification
- `./gradlew :vectors-core:check --no-daemon`
- `./gradlew check --no-daemon` (361 tasks)
- aggregate `mfcqiGate` (39 module gates)
- vectors-core MFCQI: 0.7444
- LLM-backed MFCQI review found no Q5_K-specific refactor recommendation

Raw evidence and exact environment identifiers are recorded in `vectors-bench/jmh-results/q5k-register-tile-20260731.json`.