### PR TITLE
perf(core): specialize Q6_K prefill kernels

### DIFF
--- a/vectors-bench/README.md
+++ b/vectors-bench/README.md
@@ -88,6 +88,34 @@ Automatic dispatch has the same x86, 256-bit, and batch-four envelope as Q4_K. P
 between runs and was not lifecycle-aligned, so it supports no memory-capacity claim. The
 machine-readable aggregate is in `jmh-results/q5k-register-tile-20260731.json`.
 
+## Q6_K profiled register-tile gate
+
+Q6_K reconstructs signed six-bit weights from separate low- and high-bit planes. The retained x86
+kernel processes four queries per row and exposes two register shapes. `ONE_QUERY_BLOCK` limits
+live vector state and is the API default. `TWO_QUERY_BLOCK` reuses each reconstructed weight vector
+across two queries and is available for a model execution plan that has passed a full-graph gate.
+Neither shape stores Vector API accumulators in an array.
+
+On the controlled eight-vCPU AMD EPYC-Milan host with Temurin 25.0.3, the exact merged-main
+baseline and final policy artifact produced:
+
+| Batch | Established | One-query block | Two-query block |
+| ---: | ---: | ---: | ---: |
+| 4 | 0.857 ms/op | 0.484 ms/op (-43.6%) | 0.327 ms/op (-61.9%) |
+| 32 | 6.774 ms/op | 3.804 ms/op (-43.8%) | 2.601 ms/op (-61.6%) |
+
+All 99.9% baseline/candidate confidence intervals are disjoint. At batch 32, JMH measured 469,
+461, and 437 B/op respectively, with overlapping intervals and zero collections. A fixed-heap
+MiniCPM5 1B gate exposed a whole-graph tradeoff that the hot microbenchmark did not: one-query
+blocks reduced p95 TTFT by 10.1% with four young collections, while two-query blocks reduced it by
+13.0% with 19 young collections; the baseline collected 33 times. All generated outputs were
+bit-identical.
+
+The first baseline attempt accidentally resolved an older Maven Central artifact and is excluded.
+The retained baseline is the SHA-pinned merged-main JAR. Automatic tiling is restricted to x86,
+at least 256-bit vectors, and batches of four or more; ARM/SVE retains the established path until
+measured. The complete evidence is in `jmh-results/q6k-register-tile-20260731.json`.
+
 ## Q8_0 block-major row accumulation gate
 
 The original block-major Q8_0 row kernel updated `out[batch * rows + row]` after every weight

--- a/vectors-bench/jmh-results/q6k-register-tile-20260731.json
+++ b/vectors-bench/jmh-results/q6k-register-tile-20260731.json
@@ -1,0 +1,158 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-07-31",
+  "technique": "q6_k_q8_k_profiled_register_tiles",
+  "environment": {
+    "os": "Ubuntu Linux 6.8",
+    "cpu": "AMD EPYC-Milan Processor",
+    "logicalProcessors": 8,
+    "jvm": "Eclipse Temurin 25.0.3+9-LTS",
+    "vectorBits": 256,
+    "workers": 8
+  },
+  "control": {
+    "vectorsRevision": "73c882f3c90a83d59a3b5846948fd9a084088fa5",
+    "baselineCoreJarSha256": "d861ca0e49f1bf4b6fe135a809d1f9d71be5f65eb0c187e440d4b65b5cbca51d",
+    "baselineJmhJarSha256": "ddc28961c19b13f790472636b8176224f4cdb366f2f2837dcaa578b1680fe99f",
+    "rejectedControl": {
+      "reason": "The initial full-model baseline resolved the older Maven Central 0.1.4 artifact instead of the exact merged-main branch artifact.",
+      "retainedInClaims": false
+    }
+  },
+  "jmh": {
+    "benchmark": "com.integrallis.vectors.bench.GgufQ6KBatchedMatmulBenchmark",
+    "rows": 1024,
+    "cols": 2048,
+    "forks": 3,
+    "warmupIterations": 3,
+    "measurementIterations": 5,
+    "unit": "ms/op",
+    "finalCoreJarSha256": "f2671118ad1be7ff142eb68ea71647d95341f2c375415a6c1b1b10973947630f",
+    "finalJmhJarSha256": "6c03cd4d0ee7eb7e130bfec081f1482a9256e371d22622e2efb18290f9d75f1b",
+    "results": [
+      {
+        "batchSize": 4,
+        "baseline": {
+          "score": 0.8573125423,
+          "ci99_9": [0.8500759641, 0.8645491205]
+        },
+        "oneQueryBlock": {
+          "score": 0.4836016977,
+          "ci99_9": [0.4743511193, 0.4928522762],
+          "improvementFromBaselinePercent": 43.59
+        },
+        "twoQueryBlock": {
+          "score": 0.3266434035,
+          "ci99_9": [0.3245438733, 0.3287429337],
+          "improvementFromBaselinePercent": 61.90,
+          "improvementFromOneQueryPercent": 32.46
+        }
+      },
+      {
+        "batchSize": 32,
+        "baseline": {
+          "score": 6.7735450907,
+          "ci99_9": [6.7538168329, 6.7932733485]
+        },
+        "oneQueryBlock": {
+          "score": 3.8042380250,
+          "ci99_9": [3.7906677145, 3.8178083355],
+          "improvementFromBaselinePercent": 43.84
+        },
+        "twoQueryBlock": {
+          "score": 2.6006294899,
+          "ci99_9": [2.5889537591, 2.6123052206],
+          "improvementFromBaselinePercent": 61.61,
+          "improvementFromOneQueryPercent": 31.64
+        }
+      }
+    ],
+    "allocationBatch32BytesPerOperation": {
+      "baseline": {
+        "score": 469.3418,
+        "ci99_9": [429.3655, 509.3182]
+      },
+      "oneQueryBlock": {
+        "score": 461.2458,
+        "ci99_9": [421.4562, 501.0358]
+      },
+      "twoQueryBlock": {
+        "score": 436.9873,
+        "ci99_9": [412.3410, 461.6336]
+      },
+      "collectionsPerMode": 0,
+      "claim": null
+    }
+  },
+  "fullModel": {
+    "modelsRevision": "c0513b7b70d5865211c3d066a75e5b62df89bfe0",
+    "model": "MiniCPM5 1B Q4_K_M",
+    "artifactBytes": 688065920,
+    "artifactSha256": "81b64d05a23b17b34c475f42b3e72fbde62d4b92cc34541f7a8031d0752deafa",
+    "prompt": "models-bench/prompts/completion.txt",
+    "promptSha256": "2db2d875631cc7e3af3f6e4471ae4c9b2b7dfdb31ab561a41ef78182a31532e6",
+    "inputTokenRange": [149, 152],
+    "contextLength": 2048,
+    "maxOutputTokens": 1,
+    "warmupsPerProcess": 2,
+    "threads": 8,
+    "batchSize": 32,
+    "baselineCoreJarSha256": "d861ca0e49f1bf4b6fe135a809d1f9d71be5f65eb0c187e440d4b65b5cbca51d",
+    "oneQueryPrototypeCoreJarSha256": "211986ca8ce8c75c4834e01ea0e124b4c0122b3b093296a1801ca3737ea80a1f",
+    "twoQueryPrototypeCoreJarSha256": "ce851b73f1d5af02085722d50db9408d93732b98a87dcef7073a9069c221bfb3",
+    "counterbalancedTwoQueryGate": {
+      "processesPerRevision": 2,
+      "trialsPerRevision": 16,
+      "baseline": {
+        "meanProcessMedianTtftMillis": 6762.176816,
+        "meanProcessP95TtftMillis": 6844.847148,
+        "meanProcessMedianPrefillTokensPerSecond": 22.18104876
+      },
+      "twoQueryBlock": {
+        "meanProcessMedianTtftMillis": 5896.225335,
+        "meanProcessP95TtftMillis": 5954.213445,
+        "meanProcessMedianPrefillTokensPerSecond": 25.39481983
+      },
+      "claims": {
+        "medianTtftImprovementPercent": 12.81,
+        "p95TtftImprovementPercent": 13.01,
+        "medianPrefillImprovementPercent": 14.49
+      }
+    },
+    "fixedHeapGate": {
+      "heap": "1g",
+      "trialsPerMode": 8,
+      "baseline": {
+        "medianTtftMillis": 6761.051949,
+        "p95TtftMillis": 6857.196875,
+        "medianPrefillTokensPerSecond": 22.17922335,
+        "youngCollections": 33,
+        "youngCollectionMillis": 110.542
+      },
+      "oneQueryBlock": {
+        "medianTtftMillis": 6100.994450,
+        "p95TtftMillis": 6167.955353,
+        "medianPrefillTokensPerSecond": 24.56436133,
+        "youngCollections": 4,
+        "youngCollectionMillis": 28.584
+      },
+      "twoQueryBlock": {
+        "medianTtftMillis": 5915.352564,
+        "p95TtftMillis": 5962.565839,
+        "medianPrefillTokensPerSecond": 25.36473232,
+        "youngCollections": 19,
+        "youngCollectionMillis": 97.994
+      }
+    },
+    "outputSha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    "memoryCapacityClaim": null
+  },
+  "selection": {
+    "default": "ONE_QUERY_BLOCK",
+    "reason": "It retains most of the model-level gain and produced the lowest fixed-heap collection pressure on the measured Java 25 graph.",
+    "profiledAlternative": "TWO_QUERY_BLOCK",
+    "profiledAlternativeReason": "It is the highest-throughput shape and may be selected by a Models execution profile after an exact artifact and runtime gate.",
+    "automaticHardwareEnvelope": "x86 with at least 256-bit vectors and batchSize >= 4",
+    "armStatus": "Established scalar-batch path retained pending Apple Silicon or SVE evidence."
+  }
+}

--- a/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ6KBatchedMatmulBenchmark.java
+++ b/vectors-bench/src/jmh/java/com/integrallis/vectors/bench/GgufQ6KBatchedMatmulBenchmark.java
@@ -15,6 +15,7 @@
  */
 package com.integrallis.vectors.bench;
 
+import com.integrallis.vectors.core.GgufQ6BatchedKernel;
 import com.integrallis.vectors.core.VectorUtil;
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
@@ -102,7 +103,30 @@ public class GgufQ6KBatchedMatmulBenchmark {
   @Benchmark
   public void batched(Blackhole blackhole) {
     VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
-        queries, weights, batchSize, rows, cols, batchedOut, batchedQuants, batchedScales);
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQuants,
+        batchedScales,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+    blackhole.consume(batchedOut);
+  }
+
+  @Benchmark
+  public void batchedTwoQueryBlock(Blackhole blackhole) {
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        batchedOut,
+        batchedQuants,
+        batchedScales,
+        GgufQ6BatchedKernel.TWO_QUERY_BLOCK);
     blackhole.consume(batchedOut);
   }
 

--- a/vectors-core/.github/badges/mfcqi.json
+++ b/vectors-core/.github/badges/mfcqi.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "MFCQI",
-  "message": "0.74 (good)",
+  "message": "0.75 (good)",
   "color": "green",
   "cacheSeconds": 3600
 }

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ6BatchedKernel.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/GgufQ6BatchedKernel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025-2026 Integrallis Software, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.integrallis.vectors.core;
+
+/** Register-tile strategy used by GGUF Q6_K batched matrix multiplication. */
+public enum GgufQ6BatchedKernel {
+  /** Computes one query at a time to minimize live vector state and allocation pressure. */
+  ONE_QUERY_BLOCK,
+
+  /** Reuses each unpacked weight vector across two queries to maximize prefill throughput. */
+  TWO_QUERY_BLOCK
+}

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -69,6 +69,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       useQ4KFourQueryTile(System.getProperty("os.arch", ""), VECTOR_BITSIZE, 4);
   private static final boolean Q5_K_FOUR_QUERY_TILE_SUPPORTED =
       useQ5KFourQueryTile(System.getProperty("os.arch", ""), VECTOR_BITSIZE, 4);
+  private static final boolean Q6_K_FOUR_QUERY_TILE_SUPPORTED =
+      useQ6KFourQueryTile(System.getProperty("os.arch", ""), VECTOR_BITSIZE, 4);
   private static final VectorShuffle<Short> SWAP_ADJACENT_SHORTS =
       VectorShuffle.fromValues(
           ShortVector.SPECIES_256, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
@@ -147,6 +149,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   static boolean useQ5KFourQueryTile(String arch, int vectorBits, int batchSize) {
+    return useKQuantFourQueryTile(arch, vectorBits, batchSize);
+  }
+
+  static boolean useQ6KFourQueryTile(String arch, int vectorBits, int batchSize) {
     return useKQuantFourQueryTile(arch, vectorBits, batchSize);
   }
 
@@ -2293,6 +2299,44 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       byte[] q8Quants,
       float[] q8Scales,
       short[] q8Sums) {
+    ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+  }
+
+  @Override
+  public void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums,
+      GgufQ6BatchedKernel q6Kernel) {
+    Objects.requireNonNull(q6Kernel, "q6Kernel");
     if (batchSize == 1) {
       ggufQ4_KQ4_KQ6_KQ8_KTripleMatVecDot(
           queries,
@@ -2327,7 +2371,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
           cols,
           q8Quants,
           q8Scales,
-          q8Sums);
+          q8Sums,
+          q6Kernel);
       return;
     }
 
@@ -2393,7 +2438,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
                 blocks,
                 thirdOut,
                 q8Quants,
-                q8Scales);
+                q8Scales,
+                q6Kernel);
           }
         });
   }
@@ -2731,9 +2777,31 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       int blocks,
       float[] out,
       byte[] q8Quants,
-      float[] q8Scales) {
-    for (int batch = 0; batch < batchSize; batch++) {
+      float[] q8Scales,
+      GgufQ6BatchedKernel kernel) {
+    int scalarBatchStart = 0;
+    if (Q6_K_FOUR_QUERY_TILE_SUPPORTED) {
+      for (; scalarBatchStart + 4 <= batchSize; scalarBatchStart += 4) {
+        ggufQ6_KQ8_KFourQueryBatchedRow(
+            qWeight,
+            rowOffset,
+            scalarBatchStart,
+            rows,
+            row,
+            cols,
+            blocks,
+            out,
+            q8Quants,
+            q8Scales,
+            kernel);
+      }
+    }
+
+    for (int batch = scalarBatchStart; batch < batchSize; batch++) {
       out[batch * rows + row] = 0.0f;
+    }
+    if (scalarBatchStart == batchSize) {
+      return;
     }
 
     for (int block = 0; block < blocks; block++) {
@@ -2748,7 +2816,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
       int blockActivationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
 
-      for (int batch = 0; batch < batchSize; batch++) {
+      for (int batch = scalarBatchStart; batch < batchSize; batch++) {
         int quantBatchOffset = batch * cols;
         int scaleBatchOffset = batch * blocks;
         int blockSum = 0;
@@ -2784,6 +2852,391 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         out[outputOffset] = MathUtil.fma(d, blockSum, out[outputOffset]);
       }
     }
+  }
+
+  /** Multiplies one Q6_K row by four Q8_K queries while sharing block metadata and scale loads. */
+  private static void ggufQ6_KQ8_KFourQueryBatchedRow(
+      MemorySegment qWeight,
+      long rowOffset,
+      int firstBatch,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ6BatchedKernel kernel) {
+    if (kernel == GgufQ6BatchedKernel.TWO_QUERY_BLOCK) {
+      ggufQ6_KQ8_KFourQueryTwoQueryBlockRow(
+          qWeight, rowOffset, firstBatch, rows, row, cols, blocks, out, q8Quants, q8Scales);
+      return;
+    }
+    ggufQ6_KQ8_KFourQueryOneQueryBlockRow(
+        qWeight, rowOffset, firstBatch, rows, row, cols, blocks, out, q8Quants, q8Scales);
+  }
+
+  private static void ggufQ6_KQ8_KFourQueryOneQueryBlockRow(
+      MemorySegment qWeight,
+      long rowOffset,
+      int firstBatch,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int quantOffset0 = firstBatch * cols;
+    int quantOffset1 = quantOffset0 + cols;
+    int quantOffset2 = quantOffset1 + cols;
+    int quantOffset3 = quantOffset2 + cols;
+    int scaleOffset0 = firstBatch * blocks;
+    int scaleOffset1 = scaleOffset0 + blocks;
+    int scaleOffset2 = scaleOffset1 + blocks;
+    int scaleOffset3 = scaleOffset2 + blocks;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    float sum3 = 0.0f;
+
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float weightScale =
+          Float.float16ToFloat(
+              qWeight.get(
+                  GGUF_LE_SHORT,
+                  blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES));
+      int blockActivationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+      int blockSum0 =
+          q6_KQ8_KOneQueryBlockDot(
+              qWeight, blockOffset, q8Quants, quantOffset0 + blockActivationOffset);
+      int blockSum1 =
+          q6_KQ8_KOneQueryBlockDot(
+              qWeight, blockOffset, q8Quants, quantOffset1 + blockActivationOffset);
+      int blockSum2 =
+          q6_KQ8_KOneQueryBlockDot(
+              qWeight, blockOffset, q8Quants, quantOffset2 + blockActivationOffset);
+      int blockSum3 =
+          q6_KQ8_KOneQueryBlockDot(
+              qWeight, blockOffset, q8Quants, quantOffset3 + blockActivationOffset);
+
+      sum0 = MathUtil.fma(weightScale * q8Scales[scaleOffset0 + block], blockSum0, sum0);
+      sum1 = MathUtil.fma(weightScale * q8Scales[scaleOffset1 + block], blockSum1, sum1);
+      sum2 = MathUtil.fma(weightScale * q8Scales[scaleOffset2 + block], blockSum2, sum2);
+      sum3 = MathUtil.fma(weightScale * q8Scales[scaleOffset3 + block], blockSum3, sum3);
+    }
+
+    out[firstBatch * rows + row] = sum0;
+    out[(firstBatch + 1) * rows + row] = sum1;
+    out[(firstBatch + 2) * rows + row] = sum2;
+    out[(firstBatch + 3) * rows + row] = sum3;
+  }
+
+  private static void ggufQ6_KQ8_KFourQueryTwoQueryBlockRow(
+      MemorySegment qWeight,
+      long rowOffset,
+      int firstBatch,
+      int rows,
+      int row,
+      int cols,
+      int blocks,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales) {
+    int quantOffset0 = firstBatch * cols;
+    int quantOffset1 = quantOffset0 + cols;
+    int quantOffset2 = quantOffset1 + cols;
+    int quantOffset3 = quantOffset2 + cols;
+    int scaleOffset0 = firstBatch * blocks;
+    int scaleOffset1 = scaleOffset0 + blocks;
+    int scaleOffset2 = scaleOffset1 + blocks;
+    int scaleOffset3 = scaleOffset2 + blocks;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    float sum3 = 0.0f;
+
+    for (int block = 0; block < blocks; block++) {
+      long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
+      float weightScale =
+          Float.float16ToFloat(
+              qWeight.get(
+                  GGUF_LE_SHORT,
+                  blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES));
+      int blockActivationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
+      long blockSums01 =
+          q6_KQ8_KTwoQueryBlockDot(
+              qWeight,
+              blockOffset,
+              q8Quants,
+              quantOffset0 + blockActivationOffset,
+              quantOffset1 + blockActivationOffset);
+      long blockSums23 =
+          q6_KQ8_KTwoQueryBlockDot(
+              qWeight,
+              blockOffset,
+              q8Quants,
+              quantOffset2 + blockActivationOffset,
+              quantOffset3 + blockActivationOffset);
+      int blockSum0 = (int) (blockSums01 >> Integer.SIZE);
+      int blockSum1 = (int) blockSums01;
+      int blockSum2 = (int) (blockSums23 >> Integer.SIZE);
+      int blockSum3 = (int) blockSums23;
+
+      sum0 = MathUtil.fma(weightScale * q8Scales[scaleOffset0 + block], blockSum0, sum0);
+      sum1 = MathUtil.fma(weightScale * q8Scales[scaleOffset1 + block], blockSum1, sum1);
+      sum2 = MathUtil.fma(weightScale * q8Scales[scaleOffset2 + block], blockSum2, sum2);
+      sum3 = MathUtil.fma(weightScale * q8Scales[scaleOffset3 + block], blockSum3, sum3);
+    }
+
+    out[firstBatch * rows + row] = sum0;
+    out[(firstBatch + 1) * rows + row] = sum1;
+    out[(firstBatch + 2) * rows + row] = sum2;
+    out[(firstBatch + 3) * rows + row] = sum3;
+  }
+
+  private static int q6_KQ8_KOneQueryBlockDot(
+      MemorySegment qWeight, long blockOffset, byte[] q8Quants, int quantOffset) {
+    long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+    long scalesOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+    IntVector accumulator = IntVector.zero(IntVector.SPECIES_256);
+
+    for (int superBlock = 0; superBlock < 2; superBlock++) {
+      long qlBase = blockOffset + (long) superBlock * 64;
+      long qhBase = qhOffset + (long) superBlock * 32;
+      long scaleBase = scalesOffset + (long) superBlock * 8;
+      int activationBase = superBlock * 128;
+
+      for (int chunk = 0; chunk < 32; chunk += 16) {
+        int scaleIndex = chunk / 16;
+        int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+        int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+        int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+        int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+        int activationOffset = activationBase + chunk;
+
+        for (int index = 0; index < 16; index += 8) {
+          ByteVector ql1 =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_64, qWeight, qlBase + chunk + index, ByteOrder.LITTLE_ENDIAN);
+          ByteVector ql2 =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_64,
+                  qWeight,
+                  qlBase + 32L + chunk + index,
+                  ByteOrder.LITTLE_ENDIAN);
+          ByteVector qh =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_64, qWeight, qhBase + chunk + index, ByteOrder.LITTLE_ENDIAN);
+          IntVector weights =
+              ((IntVector)
+                      ql1.and((byte) 0x0F)
+                          .add(qh.and((byte) 0x03).lanewise(VectorOperators.LSHL, 4))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s1);
+          IntVector quants =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64, q8Quants, quantOffset + activationOffset + index)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator = accumulator.add(weights.mul(quants));
+
+          weights =
+              ((IntVector)
+                      ql2.and((byte) 0x0F)
+                          .add(qh.and((byte) 0x0C).lanewise(VectorOperators.LSHL, 2))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s2);
+          quants =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset + activationOffset + index + 32)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator = accumulator.add(weights.mul(quants));
+
+          weights =
+              ((IntVector)
+                      ql1.lanewise(VectorOperators.LSHR, 4)
+                          .and((byte) 0x0F)
+                          .add(qh.and((byte) 0x30))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s3);
+          quants =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset + activationOffset + index + 64)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator = accumulator.add(weights.mul(quants));
+
+          weights =
+              ((IntVector)
+                      ql2.lanewise(VectorOperators.LSHR, 4)
+                          .and((byte) 0x0F)
+                          .add(qh.and((byte) 0xC0).lanewise(VectorOperators.LSHR, 2))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s4);
+          quants =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset + activationOffset + index + 96)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator = accumulator.add(weights.mul(quants));
+        }
+      }
+    }
+
+    return accumulator.reduceLanes(VectorOperators.ADD);
+  }
+
+  private static long q6_KQ8_KTwoQueryBlockDot(
+      MemorySegment qWeight,
+      long blockOffset,
+      byte[] q8Quants,
+      int quantOffset0,
+      int quantOffset1) {
+    long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
+    long scalesOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
+    IntVector accumulator0 = IntVector.zero(IntVector.SPECIES_256);
+    IntVector accumulator1 = IntVector.zero(IntVector.SPECIES_256);
+
+    for (int superBlock = 0; superBlock < 2; superBlock++) {
+      long qlBase = blockOffset + (long) superBlock * 64;
+      long qhBase = qhOffset + (long) superBlock * 32;
+      long scaleBase = scalesOffset + (long) superBlock * 8;
+      int activationBase = superBlock * 128;
+
+      for (int chunk = 0; chunk < 32; chunk += 16) {
+        int scaleIndex = chunk / 16;
+        int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
+        int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
+        int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
+        int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
+        int activationOffset = activationBase + chunk;
+
+        for (int index = 0; index < 16; index += 8) {
+          ByteVector ql1 =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_64, qWeight, qlBase + chunk + index, ByteOrder.LITTLE_ENDIAN);
+          ByteVector ql2 =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_64,
+                  qWeight,
+                  qlBase + 32L + chunk + index,
+                  ByteOrder.LITTLE_ENDIAN);
+          ByteVector qh =
+              ByteVector.fromMemorySegment(
+                  ByteVector.SPECIES_64, qWeight, qhBase + chunk + index, ByteOrder.LITTLE_ENDIAN);
+          IntVector weights =
+              ((IntVector)
+                      ql1.and((byte) 0x0F)
+                          .add(qh.and((byte) 0x03).lanewise(VectorOperators.LSHL, 4))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s1);
+          IntVector quants0 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64, q8Quants, quantOffset0 + activationOffset + index)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          IntVector quants1 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64, q8Quants, quantOffset1 + activationOffset + index)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator0 = accumulator0.add(weights.mul(quants0));
+          accumulator1 = accumulator1.add(weights.mul(quants1));
+
+          weights =
+              ((IntVector)
+                      ql2.and((byte) 0x0F)
+                          .add(qh.and((byte) 0x0C).lanewise(VectorOperators.LSHL, 2))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s2);
+          quants0 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset0 + activationOffset + index + 32)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          quants1 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset1 + activationOffset + index + 32)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator0 = accumulator0.add(weights.mul(quants0));
+          accumulator1 = accumulator1.add(weights.mul(quants1));
+
+          weights =
+              ((IntVector)
+                      ql1.lanewise(VectorOperators.LSHR, 4)
+                          .and((byte) 0x0F)
+                          .add(qh.and((byte) 0x30))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s3);
+          quants0 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset0 + activationOffset + index + 64)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          quants1 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset1 + activationOffset + index + 64)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator0 = accumulator0.add(weights.mul(quants0));
+          accumulator1 = accumulator1.add(weights.mul(quants1));
+
+          weights =
+              ((IntVector)
+                      ql2.lanewise(VectorOperators.LSHR, 4)
+                          .and((byte) 0x0F)
+                          .add(qh.and((byte) 0xC0).lanewise(VectorOperators.LSHR, 2))
+                          .sub((byte) 32)
+                          .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0))
+                  .mul(s4);
+          quants0 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset0 + activationOffset + index + 96)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          quants1 =
+              (IntVector)
+                  ByteVector.fromArray(
+                          ByteVector.SPECIES_64,
+                          q8Quants,
+                          quantOffset1 + activationOffset + index + 96)
+                      .convertShape(VectorOperators.B2I, IntVector.SPECIES_256, 0);
+          accumulator0 = accumulator0.add(weights.mul(quants0));
+          accumulator1 = accumulator1.add(weights.mul(quants1));
+        }
+      }
+    }
+
+    int sum0 = accumulator0.reduceLanes(VectorOperators.ADD);
+    int sum1 = accumulator1.reduceLanes(VectorOperators.ADD);
+    return ((long) sum0 << Integer.SIZE) | (sum1 & 0xFFFF_FFFFL);
   }
 
   static int q4_KQ8_KIntegerDot(
@@ -3950,13 +4403,38 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+  }
+
+  /** SIMD Q6_K by a batch of Q8_K activations with an explicit register-tile strategy. */
+  @Override
+  public void ggufQ6_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ6BatchedKernel kernel) {
+    Objects.requireNonNull(kernel, "kernel");
     if (batchSize == 1) {
       ggufQ6_KQ8_KMatVecDot(queries, qWeight, rows, cols, out, q8Quants, q8Scales);
       return;
     }
     if (VECTOR_BITSIZE < 256) {
       VectorUtilSupport.super.ggufQ6_KQ8_KBatchedMatmul(
-          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+          queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, kernel);
       return;
     }
 
@@ -3971,61 +4449,19 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         qWeight,
         rows,
         cols,
-        row -> {
-          for (int batch = 0; batch < batchSize; batch++) {
-            out[batch * rows + row] = 0.0f;
-          }
-
-          long rowOffset = row * rowBytes;
-          for (int block = 0; block < blocks; block++) {
-            long blockOffset = rowOffset + (long) block * GGUF_Q6_K_BLOCK_BYTES;
-            float weightScale =
-                Float.float16ToFloat(
-                    qWeight.get(
-                        GGUF_LE_SHORT,
-                        blockOffset + GGUF_Q6_K_QL_BYTES + GGUF_Q6_K_QH_BYTES + GGUF_Q6_K_SCALES));
-            long qlOffset = blockOffset;
-            long qhOffset = blockOffset + GGUF_Q6_K_QL_BYTES;
-            long scaleOffset = qhOffset + GGUF_Q6_K_QH_BYTES;
-            int blockActivationOffset = block * GGUF_Q6_K_BLOCK_SIZE;
-
-            for (int batch = 0; batch < batchSize; batch++) {
-              int quantBatchOffset = batch * cols;
-              int scaleBatchOffset = batch * blocks;
-              int blockSum = 0;
-
-              for (int superBlock = 0; superBlock < 2; superBlock++) {
-                long qlBase = qlOffset + (long) superBlock * 64;
-                long qhBase = qhOffset + (long) superBlock * 32;
-                long scaleBase = scaleOffset + (long) superBlock * 8;
-                int quantBase = quantBatchOffset + blockActivationOffset + superBlock * 128;
-                for (int chunk = 0; chunk < 32; chunk += 16) {
-                  int scaleIndex = chunk / 16;
-                  int s1 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex);
-                  int s2 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 2L);
-                  int s3 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 4L);
-                  int s4 = qWeight.get(ValueLayout.JAVA_BYTE, scaleBase + scaleIndex + 6L);
-                  blockSum +=
-                      q6_KQ8_KIntegerDot(
-                          qWeight,
-                          qlBase + chunk,
-                          qlBase + 32L + chunk,
-                          qhBase + chunk,
-                          q8Quants,
-                          quantBase + chunk,
-                          s1,
-                          s2,
-                          s3,
-                          s4);
-                }
-              }
-
-              int outputOffset = batch * rows + row;
-              float d = weightScale * q8Scales[scaleBatchOffset + block];
-              out[outputOffset] = MathUtil.fma(d, blockSum, out[outputOffset]);
-            }
-          }
-        });
+        row ->
+            ggufQ6_KQ8_KBatchedRowDot(
+                qWeight,
+                row * rowBytes,
+                batchSize,
+                rows,
+                row,
+                cols,
+                blocks,
+                out,
+                q8Quants,
+                q8Scales,
+                kernel));
   }
 
   static int q6_KQ8_KIntegerDot(

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -1495,6 +1495,47 @@ public final class VectorUtil {
       byte[] q8Quants,
       float[] q8Scales,
       short[] q8Sums) {
+    ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+  }
+
+  /**
+   * Multiplies two Q4_K matrices and one Q6_K matrix by a batch of activations using an explicit
+   * Q6_K register-tile strategy.
+   */
+  public static void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums,
+      GgufQ6BatchedKernel q6Kernel) {
+    Objects.requireNonNull(q6Kernel, "q6Kernel");
     checkGgufQuantizedBatchedArguments(
         queries,
         firstWeight,
@@ -1541,7 +1582,8 @@ public final class VectorUtil {
         cols,
         q8Quants,
         q8Scales,
-        q8Sums);
+        q8Sums,
+        q6Kernel);
   }
 
   /** Batched row-major GEMV over GGUF Q5_K rows. */
@@ -2341,6 +2383,34 @@ public final class VectorUtil {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+  }
+
+  /**
+   * Multiplies one Q6_K matrix by batch-major activation vectors using {@code kernel}.
+   *
+   * <p>The kernel changes only the SIMD register-tile shape. Both strategies preserve the same
+   * output layout and arithmetic order for each query.
+   */
+  public static void ggufQ6_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ6BatchedKernel kernel) {
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
     }
@@ -2351,6 +2421,7 @@ public final class VectorUtil {
     Objects.requireNonNull(out, "out");
     Objects.requireNonNull(q8Quants, "q8Quants");
     Objects.requireNonNull(q8Scales, "q8Scales");
+    Objects.requireNonNull(kernel, "kernel");
     checkGgufQuantizedMatrixArguments(
         qWeight,
         rows,
@@ -2382,7 +2453,7 @@ public final class VectorUtil {
               + scaleEntries);
     }
     IMPL.ggufQ6_KQ8_KBatchedMatmul(
-        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales);
+        queries, qWeight, batchSize, rows, cols, out, q8Quants, q8Scales, kernel);
   }
 
   /**

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -1191,6 +1191,44 @@ public interface VectorUtilSupport {
       byte[] q8Quants,
       float[] q8Scales,
       short[] q8Sums) {
+    ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        firstOut,
+        secondWeight,
+        secondRows,
+        secondOut,
+        thirdWeight,
+        thirdRows,
+        thirdOut,
+        batchSize,
+        cols,
+        q8Quants,
+        q8Scales,
+        q8Sums,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+  }
+
+  /** Grouped Q4_K/Q4_K/Q6_K batched projection with an explicit Q6_K tile strategy. */
+  default void ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+      float[] queries,
+      MemorySegment firstWeight,
+      int firstRows,
+      float[] firstOut,
+      MemorySegment secondWeight,
+      int secondRows,
+      float[] secondOut,
+      MemorySegment thirdWeight,
+      int thirdRows,
+      float[] thirdOut,
+      int batchSize,
+      int cols,
+      byte[] q8Quants,
+      float[] q8Scales,
+      short[] q8Sums,
+      GgufQ6BatchedKernel q6Kernel) {
+    Objects.requireNonNull(q6Kernel, "q6Kernel");
     int blocks = cols / GGUF_Q4_K_BLOCK_SIZE;
     int sumsPerBatch = cols / GGUF_Q8_K_SUM_BLOCK_SIZE;
     for (int batch = 0; batch < batchSize; batch++) {
@@ -1677,6 +1715,30 @@ public interface VectorUtilSupport {
       float[] out,
       byte[] q8Quants,
       float[] q8Scales) {
+    ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        qWeight,
+        batchSize,
+        rows,
+        cols,
+        out,
+        q8Quants,
+        q8Scales,
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+  }
+
+  /** Q6_K batched matrix multiplication using an explicit register-tile strategy. */
+  default void ggufQ6_KQ8_KBatchedMatmul(
+      float[] queries,
+      MemorySegment qWeight,
+      int batchSize,
+      int rows,
+      int cols,
+      float[] out,
+      byte[] q8Quants,
+      float[] q8Scales,
+      GgufQ6BatchedKernel kernel) {
+    Objects.requireNonNull(kernel, "kernel");
     int blocks = cols / GGUF_Q6_K_BLOCK_SIZE;
     for (int batch = 0; batch < batchSize; batch++) {
       GgufQuantizationSupport.quantizeQ8_K(

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/GgufQuantizedDotTest.java
@@ -29,6 +29,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntUnaryOperator;
@@ -178,6 +179,45 @@ class GgufQuantizedDotTest {
         PanamaVectorUtilSupport.ggufQ6_KQ8_KLongOffsetRowDot(
             mapped, rowBytes, rowBytes, q8Quants, q8Scales)
       };
+
+      assertThat(actual).containsExactly(expected);
+    } finally {
+      Files.deleteIfExists(path);
+    }
+  }
+
+  @Test
+  void q6_KMappedBatchedMatmulMatchesDirectKernelExactly() throws IOException {
+    int batchSize = 5;
+    int rows = 2;
+    int cols = 512;
+    byte[] firstRow = repeat(q6KBlock(0.125f, i -> (i * 5 + 3) % 64 - 32, i -> i - 8), 2);
+    byte[] secondRow = repeat(q6KBlock(-0.25f, i -> 31 - (i % 64), i -> 7 - i), 2);
+    byte[] matrix = concat(firstRow, secondRow);
+    float[] queries = patternedQueries(batchSize, cols);
+    float[] expected = new float[batchSize * rows];
+    float[] actual = new float[batchSize * rows];
+    byte[] q8Quants = new byte[batchSize * cols];
+    float[] q8Scales = new float[batchSize * (cols / 256)];
+    Path path = Files.createTempFile("vectors-q6-k-batch-", ".bin");
+    Files.write(path, matrix);
+
+    try (Arena arena = Arena.ofConfined();
+        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      MemorySegment mapped = channel.map(FileChannel.MapMode.READ_ONLY, 0, matrix.length, arena);
+      assertThat(mapped.isMapped()).isTrue();
+
+      VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+          queries,
+          MemorySegment.ofArray(matrix),
+          batchSize,
+          rows,
+          cols,
+          expected,
+          q8Quants,
+          q8Scales);
+      VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+          queries, mapped, batchSize, rows, cols, actual, q8Quants, q8Scales);
 
       assertThat(actual).containsExactly(expected);
     } finally {
@@ -1983,7 +2023,7 @@ class GgufQuantizedDotTest {
 
   @Test
   void q6_KQ8_KBatchedMatmulMatchesIndependentQueriesExactly() {
-    int batchSize = 3;
+    int batchSize = 5;
     int rows = 2;
     int cols = 512;
     float[] queries = new float[batchSize * cols];
@@ -2019,6 +2059,108 @@ class GgufQuantizedDotTest {
         actual,
         new byte[batchSize * cols],
         new float[batchSize * (cols / 256)]);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void q6_KQ8_KBatchedKernelStrategiesMatchTheDefaultExactly() {
+    int batchSize = 5;
+    int rows = 2;
+    int cols = 512;
+    float[] queries = patternedQueries(batchSize, cols);
+    MemorySegment weights =
+        MemorySegment.ofArray(
+            concat(
+                repeat(q6KBlock(0.125f, i -> (i * 5 + 3) % 64 - 32, i -> i - 8), 2),
+                repeat(q6KBlock(-0.25f, i -> 31 - (i % 64), i -> 7 - i), 2)));
+    float[] expected = new float[batchSize * rows];
+    float[] oneQuery = new float[batchSize * rows];
+    float[] twoQuery = new float[batchSize * rows];
+
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        expected,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)]);
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        oneQuery,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        GgufQ6BatchedKernel.ONE_QUERY_BLOCK);
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        rows,
+        cols,
+        twoQuery,
+        new byte[batchSize * cols],
+        new float[batchSize * (cols / 256)],
+        GgufQ6BatchedKernel.TWO_QUERY_BLOCK);
+
+    assertThat(oneQuery).containsExactly(expected);
+    assertThat(twoQuery).containsExactly(expected);
+  }
+
+  @Test
+  void q6_KQ8_KBatchedMatmulRejectsMissingKernelStrategy() {
+    int cols = 256;
+    assertThatThrownBy(
+            () ->
+                VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+                    new float[cols],
+                    MemorySegment.ofArray(q6KBlock(1.0f, ignored -> 0, ignored -> 1)),
+                    1,
+                    1,
+                    cols,
+                    new float[1],
+                    new byte[cols],
+                    new float[1],
+                    null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("kernel");
+  }
+
+  @Test
+  void q6_KQ8_KFourQueryBlockAccumulatorMatchesWorstCaseSignedInputsExactly() {
+    int batchSize = 4;
+    int cols = 256;
+    float[] queries = new float[batchSize * cols];
+    Arrays.fill(queries, -1.0f);
+    MemorySegment weights = MemorySegment.ofArray(q6KBlock(1.0f, ignored -> -32, ignored -> -128));
+    float[] singleExpected = new float[1];
+    float[] expected = new float[batchSize];
+    float[] actual = new float[batchSize];
+
+    VectorUtil.ggufQ6_KQ8_KBatchDotProduct(
+        Arrays.copyOf(queries, cols),
+        weights,
+        1,
+        cols,
+        singleExpected,
+        new byte[cols],
+        new float[1]);
+    Arrays.fill(expected, singleExpected[0]);
+
+    VectorUtil.ggufQ6_KQ8_KBatchedMatmul(
+        queries,
+        weights,
+        batchSize,
+        1,
+        cols,
+        actual,
+        new byte[batchSize * cols],
+        new float[batchSize]);
 
     assertThat(actual).containsExactly(expected);
   }
@@ -2546,6 +2688,9 @@ class GgufQuantizedDotTest {
     float[] actualFirst = new float[batchSize * firstRows];
     float[] actualSecond = new float[batchSize * secondRows];
     float[] actualThird = new float[batchSize * thirdRows];
+    float[] twoQueryFirst = new float[batchSize * firstRows];
+    float[] twoQuerySecond = new float[batchSize * secondRows];
+    float[] twoQueryThird = new float[batchSize * thirdRows];
     byte[] quants = new byte[batchSize * cols];
     float[] quantScales = new float[batchSize * (cols / 256)];
     short[] quantSums = new short[batchSize * (cols / 16)];
@@ -2589,10 +2734,30 @@ class GgufQuantizedDotTest {
         quants,
         quantScales,
         quantSums);
+    VectorUtil.ggufQ4_KQ4_KQ6_KQ8_KTripleBatchedMatmul(
+        queries,
+        firstWeight,
+        firstRows,
+        twoQueryFirst,
+        secondWeight,
+        secondRows,
+        twoQuerySecond,
+        thirdWeight,
+        thirdRows,
+        twoQueryThird,
+        batchSize,
+        cols,
+        quants,
+        quantScales,
+        quantSums,
+        GgufQ6BatchedKernel.TWO_QUERY_BLOCK);
 
     assertThat(actualFirst).containsExactly(expectedFirst);
     assertThat(actualSecond).containsExactly(expectedSecond);
     assertThat(actualThird).containsExactly(expectedThird);
+    assertThat(twoQueryFirst).containsExactly(expectedFirst);
+    assertThat(twoQuerySecond).containsExactly(expectedSecond);
+    assertThat(twoQueryThird).containsExactly(expectedThird);
   }
 
   @Test

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/PanamaGgufQuantizedDotTest.java
@@ -419,6 +419,22 @@ class PanamaGgufQuantizedDotTest {
   }
 
   @Test
+  void q6_KOneQueryBlockHelperReturnsPrimitiveSum() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .filteredOn(method -> method.getName().equals("q6_KQ8_KOneQueryBlockDot"))
+        .singleElement()
+        .satisfies(method -> assertThat(method.getReturnType()).isEqualTo(int.class));
+  }
+
+  @Test
+  void q6_KTwoQueryBlockHelperPacksPrimitiveSums() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .filteredOn(method -> method.getName().equals("q6_KQ8_KTwoQueryBlockDot"))
+        .singleElement()
+        .satisfies(method -> assertThat(method.getReturnType()).isEqualTo(long.class));
+  }
+
+  @Test
   void q5_KQ8_KIntegerDotDecodesPerElementHighBits() {
     byte[] weights = new byte[64];
     byte[] q8 = new byte[32];
@@ -601,6 +617,22 @@ class PanamaGgufQuantizedDotTest {
     assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
         .extracting(Method::getName)
         .contains("ggufQ6_KQ8_KBatchedMatmul");
+  }
+
+  @Test
+  void panamaProviderOwnsQ6_KFourQueryRegisterTile() {
+    assertThat(PanamaVectorUtilSupport.class.getDeclaredMethods())
+        .extracting(Method::getName)
+        .contains("ggufQ6_KQ8_KFourQueryBatchedRow");
+  }
+
+  @Test
+  void q6_KFourQueryRegisterTileRequiresMeasuredX86VectorEnvelope() {
+    assertThat(PanamaVectorUtilSupport.useQ6KFourQueryTile("amd64", 256, 4)).isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ6KFourQueryTile("x86_64", 512, 32)).isTrue();
+    assertThat(PanamaVectorUtilSupport.useQ6KFourQueryTile("amd64", 128, 4)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ6KFourQueryTile("amd64", 256, 3)).isFalse();
+    assertThat(PanamaVectorUtilSupport.useQ6KFourQueryTile("aarch64", 256, 4)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Summary\n- add x86/256-bit Q6_K four-query register-tiled batch kernels\n- expose conservative one-query and throughput-oriented two-query block strategies\n- propagate the selected Q6_K strategy through grouped Q4_K/Q4_K/Q6_K projections\n- preserve established scalar-tail and ARM/SVE paths\n- add exact direct/mapped, strategy, grouped-projection, signed-range, and determinism coverage\n- check in controlled JMH and full-model qualification evidence\n\n## Performance qualification\nControlled 8-vCPU AMD EPYC-Milan host, Temurin 25.0.3, AVX2/256-bit:\n\n- batch 4: 0.8573 ms/op baseline; 0.4836 one-query (-43.59%); 0.3266 two-query (-61.90%)\n- batch 32: 6.7735 ms/op baseline; 3.8042 one-query (-43.84%); 2.6006 two-query (-61.61%)\n- MiniCPM5 1B Q4_K_M p95 TTFT: 6,844.8 ms -> 5,954.2 ms with two-query blocks (-13.01%)\n- MiniCPM median prefill: 22.1810 -> 25.3948 tok/s (+14.49%)\n- generated output remained bit-identical\n- allocation confidence intervals overlap; no allocation or memory-capacity claim is made\n\n## Verification\n- ./gradlew :vectors-core:check --no-daemon\n- ./gradlew check --no-daemon (361 tasks)\n- core and aggregate MFCQI gates\n- vectors-core MFCQI: 0.745\n- aggregate MFCQI: 0.773\n- LLM-backed MFCQI review plus manual integration audit\n\nRaw evidence and exact artifact hashes are recorded in vectors-bench/jmh-results/q6k-register-tile-20260731.json.