### PR TITLE
release: vectors 0.1.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.1.4
+version = 0.1.5
 
 # Build performance.
 # parallel: build independent modules concurrently. With 49 modules and a 32-core host the


### PR DESCRIPTION
## Summary\n- bump Vectors from 0.1.4 to 0.1.5\n- release the qualified Q4_K, Q5_K, and Q6_K batched prefill kernels now merged on main\n- make the Q6_K execution-policy API available to Models\n\n## Local release verification\n- full source check passed before the release bump (361 tasks)\n- verifyStagedPublications passed for all 27 Maven Central artifacts\n- facade runtime footprint passed at 930,866 bytes across nine runtime JARs\n- all source, Javadoc, POM metadata, and internal dependencies validated\n\nAfter merge, the release workflow will run first with dry_run=true, then publish only after the signed JReleaser bundle validates.