### PR TITLE
Publish vectors-router to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Published to Maven Central (Apache-2.0):
 - Indexes & database: `vectors-hnsw`, `vectors-vamana`, `vectors-ivf`, `vectors-db`,
   `vectors-hybrid`
 - Frameworks: `vectors-spring-ai`, `vectors-langchain4j`, `vectors-spring-boot-starter`
+- Semantic routing: `vectors-router`
 - Caching: `vectors-cache`, `vectors-cache-jcache`, `vectors-cache-langchain4j`,
   `vectors-cache-semantic-db`, `vectors-cache-spring-ai`
 - VCR testing: `vectors-vcr-core`, `vectors-vcr-semantic-db`,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ val publishedModuleNames = setOf(
     "vectors-cache-langchain4j",
     "vectors-cache-semantic-db",
     "vectors-cache-spring-ai",
+    "vectors-router",
     "vectors-vcr-core",
     "vectors-vcr-semantic-db",
     "vectors-vcr-serde-avaje",

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -74,7 +74,7 @@ task verifyJavadocAttachments {
 				.dir('content/modules/ROOT/attachments/javadoc/aggregate/com/integrallis/vectors')
 				.asFile
 			def unpublishedPackages = [
-				'cluster', 'distributed', 'gpu', 'ingest', 'optimizer', 'router', 'server',
+				'cluster', 'distributed', 'gpu', 'ingest', 'optimizer', 'server',
 				'studio', 'text'
 			]
 		def leakedPackages = unpublishedPackages.findAll {

--- a/docs/content/modules/ROOT/pages/index.adoc
+++ b/docs/content/modules/ROOT/pages/index.adoc
@@ -130,6 +130,9 @@ NOTE: Requires JDK 25 with `--add-modules jdk.incubator.vector` at compile and r
 |`vectors-cache-spring-ai`
 |Caching decorators for Spring AI embedding and chat clients.
 
+|`vectors-router`
+|Semantic routing: classifies a query into named routes by embedding similarity.
+
 |`vectors-vcr-core`
 |Framework-neutral model-call record/replay engine and cassette storage API.
 


### PR DESCRIPTION
`vectors-router` has been in `settings.gradle.kts` but never in the publication allowlist, so `SemanticRouter` was unreachable from Central (`/com/integrallis/vectors-router/` → 404) despite the code being complete and tested.

The allowlist is deliberate:

> This is an allowlist so a new or experimental module can never become public merely by being added to `settings.gradle.kts`.

So this adds the module to it and satisfies the gates that come with being published — `verifyDocumentation` requires both the README module inventory and the Antora inventory, and it failed on each in turn until both were added.

## Verification

```
vectors-router-0.1.5.pom / .jar / -sources.jar / .module + checksums
staged under build/staging-deploy/com/integrallis/vectors-router/0.1.5/
```

`complianceCheck` passes, including `verifySbom`, `verifyLockfiles`, `verifyStagedPublications`, `verifyReproducibleBuild` and `verifyPublishingConfigured`.

## Why now

The `models` model-router builds multidimensional model selection on top of `SemanticRouter`, so this has to be consumable from Central first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)