### PR TITLE
docs: use dynamic README dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ depending on another system.
 ## Quick start
 
 ```kotlin
+val vectorsVersion = providers.gradleProperty("vectorsVersion").get()
+
 dependencies {
-    implementation("com.integrallis:vectors:0.1.4")
+    implementation("com.integrallis:vectors:$vectorsVersion")
 }
 ```
 
@@ -85,7 +87,7 @@ is configured.
 
 ### Spring AI
 
-Add `com.integrallis:vectors-spring-ai:0.1.4` alongside the Spring AI BOM:
+Add `com.integrallis:vectors-spring-ai:$vectorsVersion` alongside the Spring AI BOM:
 
 ```java
 VectorCollection collection = VectorCollection.builder()
@@ -100,7 +102,7 @@ VectorStore store =
 
 ### LangChain4j
 
-Add `com.integrallis:vectors-langchain4j:0.1.4` alongside LangChain4j:
+Add `com.integrallis:vectors-langchain4j:$vectorsVersion` alongside LangChain4j:
 
 ```java
 VectorCollection collection = VectorCollection.builder()
@@ -121,8 +123,8 @@ that integration:
 
 ```kotlin
 dependencies {
-    implementation("com.integrallis:vectors-storage-s3:0.1.4")
-    implementation("com.integrallis:vectors-db-arrow:0.1.4")
+    implementation("com.integrallis:vectors-storage-s3:$vectorsVersion")
+    implementation("com.integrallis:vectors-db-arrow:$vectorsVersion")
 }
 ```
 
@@ -160,7 +162,7 @@ warnings:
 --enable-native-access=ALL-UNNAMED
 ```
 
-Every published 0.1.4 artifact is a Java-only JAR with no JNI or bundled native
+Every published artifact is a Java-only JAR with no JNI or bundled native
 library. The storage module uses the standard JDK FFM API for an optional
 `posix_madvise` optimization. The optional Arrow IPC exporter/ingester
 additionally needs the module opens required by Arrow's allocator:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -971,6 +971,17 @@ tasks.register("verifyDocumentation") {
         }
 
         val readme = readmeFile.readText()
+        val hardcodedReadmeCoordinate =
+            Regex(
+                """com\.integrallis:vectors(?:-[A-Za-z0-9.-]+)?:\d+\.\d+\.\d+""" +
+                    """(?:[-+][A-Za-z0-9._-]+)?"""
+            )
+        require(!hardcodedReadmeCoordinate.containsMatchIn(readme)) {
+            "README must use the vectorsVersion property in dependency snippets, not hardcoded versions"
+        }
+        require("\$vectorsVersion" in readme) {
+            "README dependency snippets must pull the Vectors version from vectorsVersion"
+        }
         publishedModuleNames.forEach { module ->
             require("`$module`" in readme) {
                 "README module inventory is missing $module"


### PR DESCRIPTION
## What changed

- Replaced hardcoded Vectors dependency versions in README snippets with a Gradle `vectorsVersion` property.
- Added README verification that rejects hardcoded `com.integrallis:vectors:*` artifact versions in the main README.

## Why

README dependency examples had drifted behind the release version. The examples now follow the project version property instead of accumulating manual version updates.

## Validation

- `./gradlew --no-configuration-cache verifyDocumentation`
