### PR TITLE
feat(core): expose prepared activation compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,65 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Verify Maven Central publication
+        if: ${{ github.event_name == 'push' || (!inputs.dry_run && !inputs.skip_deploy) }}
+        env:
+          MAVENCENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          MAVENCENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          deployment_id="$(sed -n 's/^deployMavenCentralSonatypeDeploymentId=//p' \
+            out/jreleaser/output.properties)"
+          if [[ ! "$deployment_id" =~ ^[0-9a-f-]{36}$ ]]; then
+            echo "::error::JReleaser did not record a valid Maven Central deployment ID"
+            exit 1
+          fi
+
+          auth="$(printf '%s:%s' "$MAVENCENTRAL_USERNAME" "$MAVENCENTRAL_PASSWORD" \
+            | base64 | tr -d '\n')"
+          published=false
+          for attempt in $(seq 1 120); do
+            response="$(curl --fail --silent --show-error --request POST \
+              --header "Authorization: Bearer $auth" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=$deployment_id")"
+            state="$(jq -er '.deploymentState' <<<"$response")"
+            echo "Maven Central deployment $deployment_id: $state ($attempt/120)"
+            case "$state" in
+              PUBLISHED)
+                published=true
+                break
+                ;;
+              FAILED)
+                jq -c '.errors // []' <<<"$response"
+                echo "::error::Maven Central deployment $deployment_id failed"
+                exit 1
+                ;;
+              PENDING|VALIDATING|VALIDATED|PUBLISHING)
+                sleep 30
+                ;;
+              *)
+                echo "::error::Unknown Maven Central deployment state: $state"
+                exit 1
+                ;;
+            esac
+          done
+          if [[ "$published" != true ]]; then
+            echo "::error::Maven Central deployment $deployment_id did not reach PUBLISHED"
+            exit 1
+          fi
+
+          artifact_url="https://repo1.maven.org/maven2/com/integrallis/vectors-core/$VERSION/vectors-core-$VERSION.pom"
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --show-error \
+              "$artifact_url?release=$GITHUB_RUN_ID-$attempt" --output /dev/null; then
+              echo "Verified published artifact: $artifact_url"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Published deployment did not synchronize to $artifact_url"
+          exit 1
+
       - name: Publish GitHub release
         if: ${{ github.event_name == 'push' || !inputs.dry_run }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to java-vectors are documented here.
 
 ## [Unreleased]
 
+## [0.1.13] - 2026-08-27
+
+### Added
+
+- `RotatedCodebookMatrix.accepts(...)` lets Java inference runtimes safely reuse one
+  prepared activation across compatible compact matrices without relying on exceptions.
+
 ## [0.1.12] - 2026-08-25
 
 ### Added

--- a/docs/content/antora.yml
+++ b/docs/content/antora.yml
@@ -1,7 +1,7 @@
 name: vectors
 title: Vectors
 version: 'current'
-display_version: '0.1.12'
+display_version: '0.1.13'
 prerelease: false
 start_page: ROOT:index.adoc
 nav:
@@ -10,7 +10,7 @@ asciidoc:
   attributes:
     source-language: java
     source-highlighter: highlight.js
-    vectors-version: '0.1.12'
+    vectors-version: '0.1.13'
     url-vectors-github: https://github.com/integrallis/vectors
     url-jdk-vector-api: https://docs.oracle.com/en/java/javase/25/docs/api/jdk.incubator.vector/jdk/incubator/vector/package-summary.html
     url-ffm-api: https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/foreign/package-summary.html

--- a/docs/landing/assets/js/landing.js
+++ b/docs/landing/assets/js/landing.js
@@ -77,20 +77,20 @@ document.addEventListener('DOMContentLoaded', () => {
   // ---- Dependency coordinates (build-system tabs) ----------------------
   const COORDS = {
     'gradle-kts': {
-      copy: 'implementation("com.integrallis:vectors:0.1.12")',
-      show: 'implementation("com.integrallis:vectors:0.1.12")',
+      copy: 'implementation("com.integrallis:vectors:0.1.13")',
+      show: 'implementation("com.integrallis:vectors:0.1.13")',
     },
     'gradle-groovy': {
-      copy: "implementation 'com.integrallis:vectors:0.1.12'",
-      show: "implementation 'com.integrallis:vectors:0.1.12'",
+      copy: "implementation 'com.integrallis:vectors:0.1.13'",
+      show: "implementation 'com.integrallis:vectors:0.1.13'",
     },
     maven: {
-      copy: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.12</version>\n</dependency>',
-      show: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.12</version>\n</dependency>',
+      copy: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.13</version>\n</dependency>',
+      show: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.13</version>\n</dependency>',
     },
     sbt: {
-      copy: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.12"',
-      show: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.12"',
+      copy: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.13"',
+      show: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.13"',
     },
   };
   // Build-system tabs are the .install-tab buttons that carry a data-target.

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -31,7 +31,7 @@
                 <a href="https://integrallis.com" class="brand-mark" aria-label="Integrallis"><img class="ilogo" src="assets/images/integrallis-logo.png" alt="Integrallis"></a>
                 <span class="sep">/</span>
                 <a href="#top" class="product">vectors</a>
-                <a href="https://github.com/integrallis/vectors/releases" class="version-pill" title="Release notes">v0.1.12</a>
+                <a href="https://github.com/integrallis/vectors/releases" class="version-pill" title="Release notes">v0.1.13</a>
             </div>
             <div class="nav-right">
                 <div class="nav-links">
@@ -124,7 +124,7 @@ var matches = store.search(EmbeddingSearchRequest.builder()
                     <button class="install-tab" data-target="sbt">sbt</button>
                 </div>
                 <div class="install-cmd">
-                    <code><span class="prompt" id="install-prompt" style="display:none">$ </span><span id="install-text">implementation("com.integrallis:vectors:0.1.12")</span></code>
+                    <code><span class="prompt" id="install-prompt" style="display:none">$ </span><span id="install-text">implementation("com.integrallis:vectors:0.1.13")</span></code>
                     <button class="install-copy" id="install-copy" aria-label="Copy dependency" title="Copy">
                         <svg class="clip" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
                         <svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.1.12
+version = 0.1.13
 
 # Build performance.
 # parallel: build independent modules concurrently. With 49 modules and a 32-core host the

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/RotatedCodebookMatrix.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/RotatedCodebookMatrix.java
@@ -204,7 +204,7 @@ public final class RotatedCodebookMatrix {
   public void multiply(PreparedActivation activation, float[] output) {
     Objects.requireNonNull(activation, "activation");
     Objects.requireNonNull(output, "output");
-    if (!activation.compatible(columns, groupSize, rowBytes, encoding, codebook)) {
+    if (!accepts(activation)) {
       throw new IllegalArgumentException("prepared activation is incompatible with this matrix");
     }
     if (output.length < rows) {
@@ -217,6 +217,12 @@ public final class RotatedCodebookMatrix {
     } else {
       multiplyDirect(activation, output);
     }
+  }
+
+  /** Returns whether a prepared activation can be reused by this matrix. */
+  public boolean accepts(PreparedActivation activation) {
+    return activation != null
+        && activation.compatible(columns, groupSize, rowBytes, encoding, codebook);
   }
 
   /**

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/RotatedCodebookMatrixTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/RotatedCodebookMatrixTest.java
@@ -80,6 +80,8 @@ class RotatedCodebookMatrixTest {
     second.multiply(activation, secondOutput);
 
     assertThat(secondOutput).containsExactly(firstOutput);
+    assertThat(first.accepts(activation)).isTrue();
+    assertThat(second.accepts(activation)).isTrue();
   }
 
   @ParameterizedTest(name = "decode {0}")
@@ -215,6 +217,7 @@ class RotatedCodebookMatrixTest {
     Fixture cq4 = readFixture("needle-cq4-v7bd8a63.b64");
     RotatedCodebookMatrix cq2Matrix = cq2.matrix();
     RotatedCodebookMatrix cq4Matrix = cq4.matrix();
+    RotatedCodebookMatrix.PreparedActivation cq2Activation = cq2Matrix.prepare(cq2.input());
 
     assertThatThrownBy(() -> cq2Matrix.prepare(new float[cq2.columns() - 1]))
         .isInstanceOf(IllegalArgumentException.class)
@@ -223,10 +226,10 @@ class RotatedCodebookMatrixTest {
             () -> cq2Matrix.multiply(cq2Matrix.prepare(cq2.input()), new float[cq2.rows() - 1]))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("output");
-    assertThatThrownBy(
-            () -> cq4Matrix.multiply(cq2Matrix.prepare(cq2.input()), new float[cq4.rows()]))
+    assertThatThrownBy(() -> cq4Matrix.multiply(cq2Activation, new float[cq4.rows()]))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("incompatible");
+    assertThat(cq4Matrix.accepts(cq2Activation)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- expose compatibility checks for prepared rotated-codebook activations
- release Vectors 0.1.13 metadata
- require Maven Central to reach PUBLISHED and the CDN artifact to resolve before release CI can turn green

## Verification
- ./gradlew spotlessCheck test :docs:build complianceCheck
- release build, tests, notebooks, and staging completed for v0.1.13
- Maven Central deployment is tracked as pending until the published artifact resolves