### PR TITLE
perf(core): add fused Qwen 3.5 vector kernels

### DIFF
--- a/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/PanamaVectorUtilSupport.java
@@ -6231,6 +6231,137 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void swiGlu(
+      float[] out,
+      int outOffset,
+      float[] gate,
+      int gateOffset,
+      float[] up,
+      int upOffset,
+      int length) {
+    int index = 0;
+    int limit = FLOAT_SPECIES.loopBound(length);
+    FloatVector one = FloatVector.broadcast(FLOAT_SPECIES, 1.0f);
+    for (; index < limit; index += FLOAT_SPECIES.length()) {
+      FloatVector value = FloatVector.fromArray(FLOAT_SPECIES, gate, gateOffset + index);
+      FloatVector multiplier = FloatVector.fromArray(FLOAT_SPECIES, up, upOffset + index);
+      value
+          .div(one.add(value.neg().lanewise(VectorOperators.EXP)))
+          .mul(multiplier)
+          .intoArray(out, outOffset + index);
+    }
+    for (; index < length; index++) {
+      float value = gate[gateOffset + index];
+      out[outOffset + index] = value / (1.0f + (float) Math.exp(-value)) * up[upOffset + index];
+    }
+  }
+
+  @Override
+  public void sigmoidAndScaledSoftplus(
+      float[] sigmoidValues,
+      int sigmoidOffset,
+      float[] softplusValues,
+      int softplusOffset,
+      float[] bias,
+      int biasOffset,
+      float[] scale,
+      int scaleOffset,
+      float[] scaledSoftplus,
+      int scaledSoftplusOffset,
+      int length) {
+    int index = 0;
+    int limit = FLOAT_SPECIES.loopBound(length);
+    FloatVector one = FloatVector.broadcast(FLOAT_SPECIES, 1.0f);
+    FloatVector threshold = FloatVector.broadcast(FLOAT_SPECIES, 20.0f);
+    for (; index < limit; index += FLOAT_SPECIES.length()) {
+      FloatVector sigmoid =
+          FloatVector.fromArray(FLOAT_SPECIES, sigmoidValues, sigmoidOffset + index);
+      one.div(one.add(sigmoid.neg().lanewise(VectorOperators.EXP)))
+          .intoArray(sigmoidValues, sigmoidOffset + index);
+      FloatVector value =
+          FloatVector.fromArray(FLOAT_SPECIES, softplusValues, softplusOffset + index)
+              .add(FloatVector.fromArray(FLOAT_SPECIES, bias, biasOffset + index));
+      FloatVector softplus =
+          one.add(value.lanewise(VectorOperators.EXP)).lanewise(VectorOperators.LOG);
+      softplus = softplus.blend(value, value.compare(VectorOperators.GT, threshold));
+      softplus
+          .mul(FloatVector.fromArray(FLOAT_SPECIES, scale, scaleOffset + index))
+          .intoArray(scaledSoftplus, scaledSoftplusOffset + index);
+    }
+    for (; index < length; index++) {
+      int sigmoidIndex = sigmoidOffset + index;
+      float sigmoidValue = sigmoidValues[sigmoidIndex];
+      sigmoidValues[sigmoidIndex] = 1.0f / (1.0f + (float) Math.exp(-sigmoidValue));
+      float softplusValue = softplusValues[softplusOffset + index] + bias[biasOffset + index];
+      float softplus =
+          softplusValue > 20.0f
+              ? softplusValue
+              : softplusValue < -20.0f
+                  ? (float) Math.exp(softplusValue)
+                  : (float) Math.log1p(Math.exp(softplusValue));
+      scaledSoftplus[scaledSoftplusOffset + index] = scale[scaleOffset + index] * softplus;
+    }
+  }
+
+  @Override
+  public void causalDepthwiseConv1dSilu(
+      float[] values,
+      int valuesOffset,
+      float[] history,
+      int historyOffset,
+      float[] weights,
+      int weightsOffset,
+      int channels,
+      int kernelSize) {
+    int historyLength = kernelSize - 1;
+    int channel = 0;
+    int limit = FLOAT_SPECIES.loopBound(channels);
+    FloatVector one = FloatVector.broadcast(FLOAT_SPECIES, 1.0f);
+    for (; channel < limit; channel += FLOAT_SPECIES.length()) {
+      FloatVector input = FloatVector.fromArray(FLOAT_SPECIES, values, valuesOffset + channel);
+      FloatVector convolved =
+          input.mul(
+              FloatVector.fromArray(
+                  FLOAT_SPECIES, weights, weightsOffset + historyLength * channels + channel));
+      FloatVector previous = FloatVector.fromArray(FLOAT_SPECIES, history, historyOffset + channel);
+      convolved =
+          fma(
+              previous,
+              FloatVector.fromArray(FLOAT_SPECIES, weights, weightsOffset + channel),
+              convolved);
+      for (int tap = 1; tap < historyLength; tap++) {
+        int historyIndex = historyOffset + tap * channels + channel;
+        FloatVector current = FloatVector.fromArray(FLOAT_SPECIES, history, historyIndex);
+        convolved =
+            fma(
+                current,
+                FloatVector.fromArray(
+                    FLOAT_SPECIES, weights, weightsOffset + tap * channels + channel),
+                convolved);
+        current.intoArray(history, historyIndex - channels);
+      }
+      input.intoArray(history, historyOffset + (historyLength - 1) * channels + channel);
+      convolved
+          .div(one.add(convolved.neg().lanewise(VectorOperators.EXP)))
+          .intoArray(values, valuesOffset + channel);
+    }
+    for (; channel < channels; channel++) {
+      float input = values[valuesOffset + channel];
+      float convolved = input * weights[weightsOffset + historyLength * channels + channel];
+      float previous = history[historyOffset + channel];
+      convolved += previous * weights[weightsOffset + channel];
+      for (int tap = 1; tap < historyLength; tap++) {
+        int historyIndex = historyOffset + tap * channels + channel;
+        float current = history[historyIndex];
+        convolved += current * weights[weightsOffset + tap * channels + channel];
+        history[historyIndex - channels] = current;
+      }
+      history[historyOffset + (historyLength - 1) * channels + channel] = input;
+      values[valuesOffset + channel] = convolved / (1.0f + (float) Math.exp(-convolved));
+    }
+  }
+
+  @Override
   public void addWeightedRowsInPlace(
       float[] out,
       int outOffset,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/ScalarVectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/ScalarVectorUtilSupport.java
@@ -263,6 +263,76 @@ final class ScalarVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void swiGlu(
+      float[] out,
+      int outOffset,
+      float[] gate,
+      int gateOffset,
+      float[] up,
+      int upOffset,
+      int length) {
+    for (int index = 0; index < length; index++) {
+      float value = gate[gateOffset + index];
+      out[outOffset + index] = value / (1.0f + (float) Math.exp(-value)) * up[upOffset + index];
+    }
+  }
+
+  @Override
+  public void sigmoidAndScaledSoftplus(
+      float[] sigmoidValues,
+      int sigmoidOffset,
+      float[] softplusValues,
+      int softplusOffset,
+      float[] bias,
+      int biasOffset,
+      float[] scale,
+      int scaleOffset,
+      float[] scaledSoftplus,
+      int scaledSoftplusOffset,
+      int length) {
+    for (int index = 0; index < length; index++) {
+      int sigmoidIndex = sigmoidOffset + index;
+      float sigmoidValue = sigmoidValues[sigmoidIndex];
+      sigmoidValues[sigmoidIndex] = 1.0f / (1.0f + (float) Math.exp(-sigmoidValue));
+      float softplusValue = softplusValues[softplusOffset + index] + bias[biasOffset + index];
+      float softplus =
+          softplusValue > 20.0f
+              ? softplusValue
+              : softplusValue < -20.0f
+                  ? (float) Math.exp(softplusValue)
+                  : (float) Math.log1p(Math.exp(softplusValue));
+      scaledSoftplus[scaledSoftplusOffset + index] = scale[scaleOffset + index] * softplus;
+    }
+  }
+
+  @Override
+  public void causalDepthwiseConv1dSilu(
+      float[] values,
+      int valuesOffset,
+      float[] history,
+      int historyOffset,
+      float[] weights,
+      int weightsOffset,
+      int channels,
+      int kernelSize) {
+    int historyLength = kernelSize - 1;
+    for (int channel = 0; channel < channels; channel++) {
+      float input = values[valuesOffset + channel];
+      float convolved = input * weights[weightsOffset + historyLength * channels + channel];
+      float previous = history[historyOffset + channel];
+      convolved += previous * weights[weightsOffset + channel];
+      for (int tap = 1; tap < historyLength; tap++) {
+        int historyIndex = historyOffset + tap * channels + channel;
+        float current = history[historyIndex];
+        convolved += current * weights[weightsOffset + tap * channels + channel];
+        history[historyIndex - channels] = current;
+      }
+      history[historyOffset + (historyLength - 1) * channels + channel] = input;
+      values[valuesOffset + channel] = convolved / (1.0f + (float) Math.exp(-convolved));
+    }
+  }
+
+  @Override
   public void addWeightedRowsInPlace(
       float[] out,
       int outOffset,

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtil.java
@@ -147,6 +147,83 @@ public final class VectorUtil {
     IMPL.addScaledInPlace(out, outOffset, vector, vectorOffset, length, scale);
   }
 
+  /** Applies {@code silu(gate) * up} over the requested sub-vector range. */
+  public static void swiGlu(
+      float[] out,
+      int outOffset,
+      float[] gate,
+      int gateOffset,
+      float[] up,
+      int upOffset,
+      int length) {
+    checkSubVectorArguments(out, outOffset, gate, gateOffset, length);
+    checkSubVectorArguments(out, outOffset, up, upOffset, length);
+    IMPL.swiGlu(out, outOffset, gate, gateOffset, up, upOffset, length);
+  }
+
+  /** Applies sigmoid in place and writes {@code scale * softplus(value + bias)}. */
+  public static void sigmoidAndScaledSoftplus(
+      float[] sigmoidValues,
+      int sigmoidOffset,
+      float[] softplusValues,
+      int softplusOffset,
+      float[] bias,
+      int biasOffset,
+      float[] scale,
+      int scaleOffset,
+      float[] scaledSoftplus,
+      int scaledSoftplusOffset,
+      int length) {
+    checkSubVectorArguments(sigmoidValues, sigmoidOffset, softplusValues, softplusOffset, length);
+    checkSubVectorArguments(sigmoidValues, sigmoidOffset, bias, biasOffset, length);
+    checkSubVectorArguments(sigmoidValues, sigmoidOffset, scale, scaleOffset, length);
+    checkSubVectorArguments(
+        sigmoidValues, sigmoidOffset, scaledSoftplus, scaledSoftplusOffset, length);
+    IMPL.sigmoidAndScaledSoftplus(
+        sigmoidValues,
+        sigmoidOffset,
+        softplusValues,
+        softplusOffset,
+        bias,
+        biasOffset,
+        scale,
+        scaleOffset,
+        scaledSoftplus,
+        scaledSoftplusOffset,
+        length);
+  }
+
+  /** Applies a tap-major causal depthwise convolution and SiLU, updating history in place. */
+  public static void causalDepthwiseConv1dSilu(
+      float[] values,
+      int valuesOffset,
+      float[] history,
+      int historyOffset,
+      float[] weights,
+      int weightsOffset,
+      int channels,
+      int kernelSize) {
+    Objects.requireNonNull(values, "values");
+    Objects.requireNonNull(history, "history");
+    Objects.requireNonNull(weights, "weights");
+    if (channels < 1
+        || kernelSize < 2
+        || valuesOffset < 0
+        || historyOffset < 0
+        || weightsOffset < 0) {
+      throw new IllegalArgumentException("invalid causal depthwise convolution shape or offset");
+    }
+    long historyElements = (long) (kernelSize - 1) * channels;
+    long weightElements = (long) kernelSize * channels;
+    if ((long) valuesOffset + channels > values.length
+        || (long) historyOffset + historyElements > history.length
+        || (long) weightsOffset + weightElements > weights.length) {
+      throw new IllegalArgumentException("causal depthwise convolution buffer is too small");
+    }
+    IMPL.causalDepthwiseConv1dSilu(
+        values, valuesOffset, history, historyOffset, weights, weightsOffset, channels, kernelSize);
+  }
+
   /**
    * Adds a weighted sum of flat, strided matrix rows to {@code out} in ascending row order. Inputs
    * must not alias {@code out}.

--- a/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
+++ b/vectors-core/src/main/java/com/integrallis/vectors/core/VectorUtilSupport.java
@@ -115,6 +115,41 @@ public interface VectorUtilSupport {
     }
   }
 
+  /** Applies the fused SwiGLU activation over the requested sub-vector range. */
+  void swiGlu(
+      float[] out,
+      int outOffset,
+      float[] gate,
+      int gateOffset,
+      float[] up,
+      int upOffset,
+      int length);
+
+  /** Applies sigmoid in place and writes {@code scale * softplus(value + bias)}. */
+  void sigmoidAndScaledSoftplus(
+      float[] sigmoidValues,
+      int sigmoidOffset,
+      float[] softplusValues,
+      int softplusOffset,
+      float[] bias,
+      int biasOffset,
+      float[] scale,
+      int scaleOffset,
+      float[] scaledSoftplus,
+      int scaledSoftplusOffset,
+      int length);
+
+  /** Applies a tap-major causal depthwise convolution and SiLU, updating history in place. */
+  void causalDepthwiseConv1dSilu(
+      float[] values,
+      int valuesOffset,
+      float[] history,
+      int historyOffset,
+      float[] weights,
+      int weightsOffset,
+      int channels,
+      int kernelSize);
+
   /**
    * Adds a weighted sum of flat, strided matrix rows to {@code out} in ascending row order.
    * Implementations must preserve that row order for each output element.

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilSupportTest.java
@@ -633,6 +633,104 @@ class VectorUtilSupportTest {
 
     @ParameterizedTest(name = "dim={0}")
     @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
+    void swiGluPanamaMatchesScalar(int dim) {
+      Random rng = new Random(SEED);
+      float[] gate = randomFloats(dim + 4, rng);
+      float[] up = randomFloats(dim + 4, rng);
+      float[] expected = randomFloats(dim + 2, rng);
+      float[] actual = expected.clone();
+      for (int index = 0; index < gate.length; index++) {
+        gate[index] *= 10.0f;
+      }
+
+      scalar.swiGlu(expected, 1, gate, 2, up, 2, dim);
+      panama.swiGlu(actual, 1, gate, 2, up, 2, dim);
+
+      for (int index = 0; index < expected.length; index++) {
+        assertThat(actual[index])
+            .as("element %d", index)
+            .isCloseTo(expected[index], within(2.0e-6f));
+      }
+    }
+
+    @ParameterizedTest(name = "dim={0}")
+    @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
+    void swiGluPanamaMatchesScalarWhenOutputAliasesUpInput(int dim) {
+      Random rng = new Random(SEED);
+      float[] gate = randomFloats(dim + 4, rng);
+      float[] expected = randomFloats(dim + 4, rng);
+      float[] actual = expected.clone();
+      for (int index = 0; index < gate.length; index++) {
+        gate[index] *= 10.0f;
+      }
+
+      scalar.swiGlu(expected, 2, gate, 2, expected, 2, dim);
+      panama.swiGlu(actual, 2, gate, 2, actual, 2, dim);
+
+      for (int index = 0; index < expected.length; index++) {
+        assertThat(actual[index])
+            .as("element %d", index)
+            .isCloseTo(expected[index], within(2.0e-6f));
+      }
+    }
+
+    @ParameterizedTest(name = "dim={0}")
+    @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
+    void sigmoidAndScaledSoftplusPanamaMatchesScalar(int dim) {
+      Random rng = new Random(SEED);
+      float[] expectedSigmoid = randomFloats(dim + 4, rng);
+      float[] actualSigmoid = expectedSigmoid.clone();
+      float[] softplus = randomFloats(dim + 4, rng);
+      float[] bias = randomFloats(dim + 4, rng);
+      float[] scale = randomFloats(dim + 4, rng);
+      float[] expectedSoftplus = randomFloats(dim + 4, rng);
+      float[] actualSoftplus = expectedSoftplus.clone();
+      for (int index = 0; index < dim; index++) {
+        expectedSigmoid[2 + index] *= 10.0f;
+        actualSigmoid[2 + index] *= 10.0f;
+        softplus[2 + index] *= 10.0f;
+      }
+
+      scalar.sigmoidAndScaledSoftplus(
+          expectedSigmoid, 2, softplus, 2, bias, 2, scale, 2, expectedSoftplus, 2, dim);
+      panama.sigmoidAndScaledSoftplus(
+          actualSigmoid, 2, softplus, 2, bias, 2, scale, 2, actualSoftplus, 2, dim);
+
+      for (int index = 0; index < expectedSigmoid.length; index++) {
+        assertThat(actualSigmoid[index])
+            .as("sigmoid element %d", index)
+            .isCloseTo(expectedSigmoid[index], within(2.0e-6f));
+        assertThat(actualSoftplus[index])
+            .as("softplus element %d", index)
+            .isCloseTo(expectedSoftplus[index], within(2.0e-5f));
+      }
+    }
+
+    @ParameterizedTest(name = "dim={0}")
+    @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
+    void causalDepthwiseConv1dSiluPanamaMatchesScalar(int dim) {
+      Random rng = new Random(SEED);
+      int kernelSize = 4;
+      float[] expected = randomFloats(dim + 2, rng);
+      float[] actual = expected.clone();
+      float[] expectedHistory = randomFloats((kernelSize - 1) * dim, rng);
+      float[] actualHistory = expectedHistory.clone();
+      float[] weights = randomFloats(kernelSize * dim, rng);
+
+      scalar.causalDepthwiseConv1dSilu(
+          expected, 1, expectedHistory, 0, weights, 0, dim, kernelSize);
+      panama.causalDepthwiseConv1dSilu(actual, 1, actualHistory, 0, weights, 0, dim, kernelSize);
+
+      for (int index = 0; index < expected.length; index++) {
+        assertThat(actual[index])
+            .as("value element %d", index)
+            .isCloseTo(expected[index], within(2.0e-6f));
+      }
+      assertThat(actualHistory).containsExactly(expectedHistory);
+    }
+
+    @ParameterizedTest(name = "dim={0}")
+    @MethodSource("com.integrallis.vectors.core.VectorUtilSupportTest#dimensionProvider")
     void addWeightedRowsInPlacePanamaMatchesScalarExactly(int dim) {
       Random rng = new Random(SEED);
       int rows = 7;

--- a/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilTest.java
+++ b/vectors-core/src/test/java/com/integrallis/vectors/core/VectorUtilTest.java
@@ -119,6 +119,96 @@ class VectorUtilTest {
   }
 
   @Test
+  void swiGlu_withOffsets() {
+    float[] out = {99.0f, Float.NaN, Float.NaN, Float.NaN, 98.0f};
+    float[] gate = {97.0f, 0.0f, 1.0f, -1.0f, 96.0f};
+    float[] up = {95.0f, 5.0f, 2.0f, 3.0f, 94.0f};
+
+    VectorUtil.swiGlu(out, 1, gate, 1, up, 1, 3);
+
+    assertThat(out[0]).isEqualTo(99.0f);
+    assertThat(out[1]).isZero();
+    assertThat(out[2]).isCloseTo(1.4621172f, within(1.0e-6f));
+    assertThat(out[3]).isCloseTo(-0.8068243f, within(1.0e-6f));
+    assertThat(out[4]).isEqualTo(98.0f);
+  }
+
+  @Test
+  void swiGlu_supportsOutputAliasingUpInput() {
+    float[] gate = {97.0f, 0.0f, 1.0f, -1.0f, 96.0f};
+    float[] upAndOutput = {95.0f, 5.0f, 2.0f, 3.0f, 94.0f};
+
+    VectorUtil.swiGlu(upAndOutput, 1, gate, 1, upAndOutput, 1, 3);
+
+    assertThat(upAndOutput[0]).isEqualTo(95.0f);
+    assertThat(upAndOutput[1]).isZero();
+    assertThat(upAndOutput[2]).isCloseTo(1.4621172f, within(1.0e-6f));
+    assertThat(upAndOutput[3]).isCloseTo(-0.8068243f, within(1.0e-6f));
+    assertThat(upAndOutput[4]).isEqualTo(94.0f);
+  }
+
+  @Test
+  void sigmoidAndScaledSoftplus_withOffsets() {
+    float[] sigmoidValues = {99.0f, -1.0f, 0.0f, 2.0f, 98.0f};
+    float[] softplusValues = {97.0f, -2.0f, 0.5f, 3.0f, 96.0f};
+    float[] bias = {95.0f, 0.25f, -0.5f, 1.0f, 94.0f};
+    float[] scale = {93.0f, -0.5f, -1.0f, -2.0f, 92.0f};
+    float[] scaledSoftplus = {91.0f, Float.NaN, Float.NaN, Float.NaN, 90.0f};
+
+    VectorUtil.sigmoidAndScaledSoftplus(
+        sigmoidValues, 1, softplusValues, 1, bias, 1, scale, 1, scaledSoftplus, 1, 3);
+
+    assertThat(sigmoidValues[0]).isEqualTo(99.0f);
+    assertThat(sigmoidValues[1]).isCloseTo(0.26894143f, within(1.0e-6f));
+    assertThat(sigmoidValues[2]).isCloseTo(0.5f, within(1.0e-6f));
+    assertThat(sigmoidValues[3]).isCloseTo(0.8807971f, within(1.0e-6f));
+    assertThat(sigmoidValues[4]).isEqualTo(98.0f);
+    assertThat(scaledSoftplus[0]).isEqualTo(91.0f);
+    assertThat(scaledSoftplus[1]).isCloseTo(-0.08011287f, within(1.0e-6f));
+    assertThat(scaledSoftplus[2]).isCloseTo(-0.6931472f, within(1.0e-6f));
+    assertThat(scaledSoftplus[3]).isCloseTo(-8.0363f, within(1.0e-4f));
+    assertThat(scaledSoftplus[4]).isEqualTo(90.0f);
+  }
+
+  @Test
+  void sigmoidAndScaledSoftplus_remainsFiniteForLargePositiveInputs() {
+    float[] sigmoidValues = {0.0f};
+    float[] softplusValues = {100.0f};
+    float[] bias = {25.0f};
+    float[] scale = {-2.0f};
+    float[] scaledSoftplus = {Float.NaN};
+
+    VectorUtil.sigmoidAndScaledSoftplus(
+        sigmoidValues, 0, softplusValues, 0, bias, 0, scale, 0, scaledSoftplus, 0, 1);
+
+    assertThat(scaledSoftplus[0]).isEqualTo(-250.0f);
+  }
+
+  @Test
+  void causalDepthwiseConv1dSilu_updatesTapMajorHistoryAndSupportsInPlaceValues() {
+    float[] values = {99.0f, 0.5f, -1.0f, 2.0f, 98.0f};
+    float[] history = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    float[] weights = {0.1f, 0.2f, 0.3f, -0.4f, 0.5f, -0.6f, 0.7f, -0.8f, 0.9f};
+    float[] expected = new float[3];
+    for (int channel = 0; channel < 3; channel++) {
+      float convolved =
+          history[channel] * weights[channel]
+              + history[3 + channel] * weights[3 + channel]
+              + values[1 + channel] * weights[6 + channel];
+      expected[channel] = convolved / (1.0f + (float) Math.exp(-convolved));
+    }
+
+    VectorUtil.causalDepthwiseConv1dSilu(values, 1, history, 0, weights, 0, 3, 3);
+
+    assertThat(values[0]).isEqualTo(99.0f);
+    for (int channel = 0; channel < 3; channel++) {
+      assertThat(values[1 + channel]).isCloseTo(expected[channel], within(1.0e-6f));
+    }
+    assertThat(values[4]).isEqualTo(98.0f);
+    assertThat(history).containsExactly(4.0f, 5.0f, 6.0f, 0.5f, -1.0f, 2.0f);
+  }
+
+  @Test
   void addWeightedRowsInPlace_withOffsetsAndStride() {
     float[] out = {99.0f, 1.0f, 2.0f, 98.0f};
     float[] matrix = {


### PR DESCRIPTION
## Summary
- add SIMD SwiGLU and gate/softplus primitives
- add fused causal depthwise-convolution + SiLU with tap-major state
- cover scalar/Panama parity, aliasing, offsets, tails, and numerical stability

## Verification
- `./gradlew --no-daemon spotlessCheck test`
- Qwen3.5-0.8B controlled benchmark: 27/27 correct, 80.61 tok/s median decode, 1.649 s p95 end-to-end