### PR TITLE
chore(release): prepare Vectors 0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to java-vectors are documented here.
 
-## Unreleased
+## [0.1.19] - 2026-09-02
 
 ### Added
 

--- a/docs/content/antora.yml
+++ b/docs/content/antora.yml
@@ -1,7 +1,7 @@
 name: vectors
 title: Vectors
 version: 'current'
-display_version: '0.1.18'
+display_version: '0.1.19'
 prerelease: false
 start_page: ROOT:index.adoc
 nav:
@@ -10,7 +10,7 @@ asciidoc:
   attributes:
     source-language: java
     source-highlighter: highlight.js
-    vectors-version: '0.1.18'
+    vectors-version: '0.1.19'
     url-vectors-github: https://github.com/integrallis/vectors
     url-jdk-vector-api: https://docs.oracle.com/en/java/javase/25/docs/api/jdk.incubator.vector/jdk/incubator/vector/package-summary.html
     url-ffm-api: https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/foreign/package-summary.html

--- a/docs/landing/assets/js/landing.js
+++ b/docs/landing/assets/js/landing.js
@@ -77,20 +77,20 @@ document.addEventListener('DOMContentLoaded', () => {
   // ---- Dependency coordinates (build-system tabs) ----------------------
   const COORDS = {
     'gradle-kts': {
-      copy: 'implementation("com.integrallis:vectors:0.1.18")',
-      show: 'implementation("com.integrallis:vectors:0.1.18")',
+      copy: 'implementation("com.integrallis:vectors:0.1.19")',
+      show: 'implementation("com.integrallis:vectors:0.1.19")',
     },
     'gradle-groovy': {
-      copy: "implementation 'com.integrallis:vectors:0.1.18'",
-      show: "implementation 'com.integrallis:vectors:0.1.18'",
+      copy: "implementation 'com.integrallis:vectors:0.1.19'",
+      show: "implementation 'com.integrallis:vectors:0.1.19'",
     },
     maven: {
-      copy: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.18</version>\n</dependency>',
-      show: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.18</version>\n</dependency>',
+      copy: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.19</version>\n</dependency>',
+      show: '<dependency>\n  <groupId>com.integrallis</groupId>\n  <artifactId>vectors</artifactId>\n  <version>0.1.19</version>\n</dependency>',
     },
     sbt: {
-      copy: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.18"',
-      show: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.18"',
+      copy: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.19"',
+      show: 'libraryDependencies += "com.integrallis" % "vectors" % "0.1.19"',
     },
   };
   // Build-system tabs are the .install-tab buttons that carry a data-target.

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -31,7 +31,7 @@
                 <a href="https://integrallis.com" class="brand-mark" aria-label="Integrallis"><img class="ilogo" src="assets/images/integrallis-logo.png" alt="Integrallis"></a>
                 <span class="sep">/</span>
                 <a href="#top" class="product">vectors</a>
-                <a href="https://github.com/integrallis/vectors/releases" class="version-pill" title="Release notes">v0.1.18</a>
+                <a href="https://github.com/integrallis/vectors/releases" class="version-pill" title="Release notes">v0.1.19</a>
             </div>
             <div class="nav-right">
                 <div class="nav-links">
@@ -124,7 +124,7 @@ var matches = store.search(EmbeddingSearchRequest.builder()
                     <button class="install-tab" data-target="sbt">sbt</button>
                 </div>
                 <div class="install-cmd">
-                    <code><span class="prompt" id="install-prompt" style="display:none">$ </span><span id="install-text">implementation("com.integrallis:vectors:0.1.18")</span></code>
+                    <code><span class="prompt" id="install-prompt" style="display:none">$ </span><span id="install-text">implementation("com.integrallis:vectors:0.1.19")</span></code>
                     <button class="install-copy" id="install-copy" aria-label="Copy dependency" title="Copy">
                         <svg class="clip" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
                         <svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.1.18
+version = 0.1.19
 
 # Build performance.
 # parallel: build independent modules concurrently. With 49 modules and a 32-core host the


### PR DESCRIPTION
## Summary
- prepare Vectors 0.1.19
- publish signed packed INT4 kernels used by pure-Java MobileMoE inference
- update versioned documentation and install snippets

## Verification
- MobileMoE feature PR #66 passed the full CI and framework matrices
- local SpotBugs JMH gate and vectors-core tests pass
- release workflow will independently rebuild, stage, and resolve published artifacts